### PR TITLE
Add support for listing memory contents (issue 69)

### DIFF
--- a/dotnet/CoreLib/Memory.cs
+++ b/dotnet/CoreLib/Memory.cs
@@ -204,4 +204,21 @@ public class Memory : ISemanticMemoryClient
         index = IndexExtensions.CleanName(index);
         return this._searchClient.AskAsync(index: index, question: question, filters: filters, cancellationToken: cancellationToken);
     }
+
+    public Task<SearchResult> ListAsync(
+        string? index = null,
+        MemoryFilter? filter = null,
+        ICollection<MemoryFilter>? filters = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (filter != null)
+        {
+            if (filters == null) { filters = new List<MemoryFilter>(); }
+
+            filters.Add(filter);
+        }
+
+        index = IndexExtensions.CleanName(index);
+        return this._searchClient.ListAsync(index: index, filters: filters, cancellationToken: cancellationToken);
+    }
 }

--- a/examples/001-dotnet-Serverless/Program.cs
+++ b/examples/001-dotnet-Serverless/Program.cs
@@ -23,6 +23,7 @@ bool ingestion = true;
 bool useImages = false; // Enable Azure Form Recognizer OCR to use this
 bool retrieval = true;
 bool purge = true;
+bool listContents = true;
 
 // =======================
 // === INGESTION =========
@@ -187,6 +188,25 @@ if (retrieval)
 
     answer = await memory.AskAsync(question, filter: MemoryFilters.ByTag("type", "news"));
     Console.WriteLine($"\nNews: {answer.Result}");
+}
+
+// =======================
+// === LIST CONTENTS =====
+// =======================
+if (listContents)
+{
+    Console.WriteLine("\n====================================\n");
+    Console.WriteLine("Listing contents of memory");
+
+    var results = await memory.ListAsync();
+    foreach (var result in results.Results)
+    {
+        Console.WriteLine($"  - {result.SourceName}  - {result.Link}");
+        foreach (var partition in result.Partitions)
+        {
+            Console.WriteLine($"    - {partition.Text.Substring(0, 30)}... [{result.Partitions.First().LastUpdate:D}]");
+        }
+    }
 }
 
 // =======================


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

Related to issue https://github.com/microsoft/semantic-memory/issues/69.

**Goal:** we want to be able to inspect the contents of the memory store

Opening as a draft PR as I haven't discussed this change with the maintainers. I expect there are many problems with it, but thought it would be good to open to start a conversation.

## High level description (Approach, Design)

I'm exposing the internal `ListAsync` function that already exists in the db.
