### PR TITLE
Fix/refactor minRelevance

### DIFF
--- a/dotnet/ClientLib/IKernelMemory.cs
+++ b/dotnet/ClientLib/IKernelMemory.cs
@@ -168,8 +168,9 @@ public interface IKernelMemory
     /// <param name="index">Optional index name</param>
     /// <param name="filter">Filter to match</param>
     /// <param name="filters">Filters to match (using inclusive OR logic). If 'filter' is provided too, the value is merged into this list.</param>
-    /// <param name="cancellationToken">Async task cancellation token</param>
     /// <param name="limit">Max number of results to return</param>
+    /// <param name="minRelevanceScore">Minimum Cosine Similarity required</param>
+    /// <param name="cancellationToken">Async task cancellation token</param>
     /// <returns>Answer to the query, if possible</returns>
     public Task<SearchResult> SearchAsync(
         string query,
@@ -177,6 +178,7 @@ public interface IKernelMemory
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
         int limit = -1,
+        double minRelevanceScore = 0,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -186,6 +188,7 @@ public interface IKernelMemory
     /// <param name="index">Optional index name</param>
     /// <param name="filter">Filter to match</param>
     /// <param name="filters">Filters to match (using inclusive OR logic). If 'filter' is provided too, the value is merged into this list.</param>
+    /// <param name="minRelevanceScore">Minimum Cosine Similarity required</param>
     /// <param name="cancellationToken">Async task cancellation token</param>
     /// <returns>Answer to the query, if possible</returns>
     public Task<MemoryAnswer> AskAsync(
@@ -193,5 +196,6 @@ public interface IKernelMemory
         string? index = null,
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
+        double minRelevanceScore = 0,
         CancellationToken cancellationToken = default);
 }

--- a/dotnet/ClientLib/IKernelMemory.cs
+++ b/dotnet/ClientLib/IKernelMemory.cs
@@ -168,8 +168,8 @@ public interface IKernelMemory
     /// <param name="index">Optional index name</param>
     /// <param name="filter">Filter to match</param>
     /// <param name="filters">Filters to match (using inclusive OR logic). If 'filter' is provided too, the value is merged into this list.</param>
+    /// <param name="minRelevance">Minimum Cosine Similarity required</param>
     /// <param name="limit">Max number of results to return</param>
-    /// <param name="minRelevanceScore">Minimum Cosine Similarity required</param>
     /// <param name="cancellationToken">Async task cancellation token</param>
     /// <returns>Answer to the query, if possible</returns>
     public Task<SearchResult> SearchAsync(
@@ -177,8 +177,8 @@ public interface IKernelMemory
         string? index = null,
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
+        double minRelevance = 0,
         int limit = -1,
-        double minRelevanceScore = 0,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -188,7 +188,7 @@ public interface IKernelMemory
     /// <param name="index">Optional index name</param>
     /// <param name="filter">Filter to match</param>
     /// <param name="filters">Filters to match (using inclusive OR logic). If 'filter' is provided too, the value is merged into this list.</param>
-    /// <param name="minRelevanceScore">Minimum Cosine Similarity required</param>
+    /// <param name="minRelevance">Minimum Cosine Similarity required</param>
     /// <param name="cancellationToken">Async task cancellation token</param>
     /// <returns>Answer to the query, if possible</returns>
     public Task<MemoryAnswer> AskAsync(
@@ -196,6 +196,6 @@ public interface IKernelMemory
         string? index = null,
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
-        double minRelevanceScore = 0,
+        double minRelevance = 0,
         CancellationToken cancellationToken = default);
 }

--- a/dotnet/ClientLib/MemoryWebClient.cs
+++ b/dotnet/ClientLib/MemoryWebClient.cs
@@ -237,6 +237,7 @@ public class MemoryWebClient : IKernelMemory
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
         int limit = -1,
+        double minRelevanceScore = 0,
         CancellationToken cancellationToken = default)
     {
         if (filter != null)
@@ -247,7 +248,14 @@ public class MemoryWebClient : IKernelMemory
         }
 
         index = IndexExtensions.CleanName(index);
-        SearchQuery request = new() { Index = index, Query = query, Filters = (filters is { Count: > 0 }) ? filters.ToList() : new(), Limit = limit };
+        SearchQuery request = new()
+        {
+            Index = index,
+            Query = query,
+            Filters = (filters is { Count: > 0 }) ? filters.ToList() : new(),
+            Limit = limit,
+            MinRelevanceScore = minRelevanceScore
+        };
         using StringContent content = new(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
 
         HttpResponseMessage? response = await this._client.PostAsync(Constants.HttpSearchEndpoint, content, cancellationToken).ConfigureAwait(false);
@@ -263,6 +271,7 @@ public class MemoryWebClient : IKernelMemory
         string? index = null,
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
+        double minRelevanceScore = 0,
         CancellationToken cancellationToken = default)
     {
         if (filter != null)
@@ -273,7 +282,13 @@ public class MemoryWebClient : IKernelMemory
         }
 
         index = IndexExtensions.CleanName(index);
-        MemoryQuery request = new() { Index = index, Question = question, Filters = (filters is { Count: > 0 }) ? filters.ToList() : new() };
+        MemoryQuery request = new()
+        {
+            Index = index,
+            Question = question,
+            Filters = (filters is { Count: > 0 }) ? filters.ToList() : new(),
+            MinRelevanceScore = minRelevanceScore
+        };
         using StringContent content = new(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
 
         HttpResponseMessage? response = await this._client.PostAsync(Constants.HttpAskEndpoint, content, cancellationToken).ConfigureAwait(false);

--- a/dotnet/ClientLib/MemoryWebClient.cs
+++ b/dotnet/ClientLib/MemoryWebClient.cs
@@ -236,8 +236,8 @@ public class MemoryWebClient : IKernelMemory
         string? index = null,
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
+        double minRelevance = 0,
         int limit = -1,
-        double minRelevanceScore = 0,
         CancellationToken cancellationToken = default)
     {
         if (filter != null)
@@ -254,7 +254,7 @@ public class MemoryWebClient : IKernelMemory
             Query = query,
             Filters = (filters is { Count: > 0 }) ? filters.ToList() : new(),
             Limit = limit,
-            MinRelevanceScore = minRelevanceScore
+            MinRelevance = minRelevance
         };
         using StringContent content = new(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
 
@@ -271,7 +271,7 @@ public class MemoryWebClient : IKernelMemory
         string? index = null,
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
-        double minRelevanceScore = 0,
+        double minRelevance = 0,
         CancellationToken cancellationToken = default)
     {
         if (filter != null)
@@ -287,7 +287,7 @@ public class MemoryWebClient : IKernelMemory
             Index = index,
             Question = question,
             Filters = (filters is { Count: > 0 }) ? filters.ToList() : new(),
-            MinRelevanceScore = minRelevanceScore
+            MinRelevance = minRelevance
         };
         using StringContent content = new(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
 

--- a/dotnet/ClientLib/MemoryWebClient.cs
+++ b/dotnet/ClientLib/MemoryWebClient.cs
@@ -253,8 +253,8 @@ public class MemoryWebClient : IKernelMemory
             Index = index,
             Query = query,
             Filters = (filters is { Count: > 0 }) ? filters.ToList() : new(),
+            MinRelevance = minRelevance,
             Limit = limit,
-            MinRelevance = minRelevance
         };
         using StringContent content = new(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
 

--- a/dotnet/ClientLib/Models/MemoryFilter.cs
+++ b/dotnet/ClientLib/Models/MemoryFilter.cs
@@ -8,8 +8,6 @@ namespace Microsoft.KernelMemory;
 
 public class MemoryFilter : TagCollection
 {
-    public float MinRelevance { get; set; } = 0.5f;
-
     public bool IsEmpty()
     {
         return this.Count == 0;

--- a/dotnet/ClientLib/Models/MemoryQuery.cs
+++ b/dotnet/ClientLib/Models/MemoryQuery.cs
@@ -18,6 +18,6 @@ public class MemoryQuery
     [JsonPropertyName("filters")]
     public List<MemoryFilter> Filters { get; set; } = new();
 
-    [JsonPropertyName("minRelevanceScore")]
-    public double MinRelevanceScore { get; set; } = 0;
+    [JsonPropertyName("minRelevance")]
+    public double MinRelevance { get; set; } = 0;
 }

--- a/dotnet/ClientLib/Models/MemoryQuery.cs
+++ b/dotnet/ClientLib/Models/MemoryQuery.cs
@@ -17,4 +17,7 @@ public class MemoryQuery
 
     [JsonPropertyName("filters")]
     public List<MemoryFilter> Filters { get; set; } = new();
+
+    [JsonPropertyName("minRelevanceScore")]
+    public double MinRelevanceScore { get; set; } = 0;
 }

--- a/dotnet/ClientLib/Models/MemoryQuery.cs
+++ b/dotnet/ClientLib/Models/MemoryQuery.cs
@@ -10,14 +10,18 @@ namespace Microsoft.KernelMemory;
 public class MemoryQuery
 {
     [JsonPropertyName("index")]
+    [JsonPropertyOrder(0)]
     public string Index { get; set; } = string.Empty;
 
     [JsonPropertyName("question")]
+    [JsonPropertyOrder(1)]
     public string Question { get; set; } = string.Empty;
 
     [JsonPropertyName("filters")]
+    [JsonPropertyOrder(10)]
     public List<MemoryFilter> Filters { get; set; } = new();
 
     [JsonPropertyName("minRelevance")]
+    [JsonPropertyOrder(2)]
     public double MinRelevance { get; set; } = 0;
 }

--- a/dotnet/ClientLib/Models/SearchQuery.cs
+++ b/dotnet/ClientLib/Models/SearchQuery.cs
@@ -21,6 +21,6 @@ public class SearchQuery
     [JsonPropertyName("limit")]
     public int Limit { get; set; } = -1;
 
-    [JsonPropertyName("minRelevanceScore")]
-    public double MinRelevanceScore { get; set; } = 0;
+    [JsonPropertyName("minRelevance")]
+    public double MinRelevance { get; set; } = 0;
 }

--- a/dotnet/ClientLib/Models/SearchQuery.cs
+++ b/dotnet/ClientLib/Models/SearchQuery.cs
@@ -20,4 +20,7 @@ public class SearchQuery
 
     [JsonPropertyName("limit")]
     public int Limit { get; set; } = -1;
+
+    [JsonPropertyName("minRelevanceScore")]
+    public double MinRelevanceScore { get; set; } = 0;
 }

--- a/dotnet/ClientLib/Models/SearchQuery.cs
+++ b/dotnet/ClientLib/Models/SearchQuery.cs
@@ -10,17 +10,22 @@ namespace Microsoft.KernelMemory;
 public class SearchQuery
 {
     [JsonPropertyName("index")]
+    [JsonPropertyOrder(0)]
     public string Index { get; set; } = string.Empty;
 
     [JsonPropertyName("query")]
+    [JsonPropertyOrder(1)]
     public string Query { get; set; } = string.Empty;
 
     [JsonPropertyName("filters")]
+    [JsonPropertyOrder(10)]
     public List<MemoryFilter> Filters { get; set; } = new();
 
-    [JsonPropertyName("limit")]
-    public int Limit { get; set; } = -1;
-
     [JsonPropertyName("minRelevance")]
+    [JsonPropertyOrder(2)]
     public double MinRelevance { get; set; } = 0;
+
+    [JsonPropertyName("limit")]
+    [JsonPropertyOrder(3)]
+    public int Limit { get; set; } = -1;
 }

--- a/dotnet/CoreLib/Handlers/DeleteDocumentHandler.cs
+++ b/dotnet/CoreLib/Handlers/DeleteDocumentHandler.cs
@@ -43,14 +43,14 @@ public class DeleteDocumentHandler : IPipelineStepHandler
         foreach (IVectorDb db in this._vectorDbs)
         {
             IAsyncEnumerable<MemoryRecord> records = db.GetListAsync(
-                indexName: pipeline.Index,
+                index: pipeline.Index,
                 limit: -1,
                 filters: new List<MemoryFilter> { MemoryFilters.ByDocument(pipeline.DocumentId) },
                 cancellationToken: cancellationToken);
 
             await foreach (var record in records.WithCancellation(cancellationToken))
             {
-                await db.DeleteAsync(indexName: pipeline.Index, record, cancellationToken: cancellationToken).ConfigureAwait(false);
+                await db.DeleteAsync(index: pipeline.Index, record, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/dotnet/CoreLib/Handlers/DeleteIndexHandler.cs
+++ b/dotnet/CoreLib/Handlers/DeleteIndexHandler.cs
@@ -42,7 +42,7 @@ public class DeleteIndexHandler : IPipelineStepHandler
         // Delete index from vector storage
         foreach (IVectorDb db in this._vectorDbs)
         {
-            await db.DeleteIndexAsync(indexName: pipeline.Index, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await db.DeleteIndexAsync(index: pipeline.Index, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         // Delete index from file storage

--- a/dotnet/CoreLib/Memory.cs
+++ b/dotnet/CoreLib/Memory.cs
@@ -180,8 +180,8 @@ public class Memory : IKernelMemory
         string? index = null,
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
+        double minRelevance = 0,
         int limit = -1,
-        double minRelevanceScore = 0,
         CancellationToken cancellationToken = default)
     {
         if (filter != null)
@@ -195,8 +195,8 @@ public class Memory : IKernelMemory
         return this._searchClient.SearchAsync(
             index: index,
             query: query,
-            minRelevanceScore: minRelevanceScore,
             filters: filters,
+            minRelevance: minRelevance,
             limit: limit,
             cancellationToken: cancellationToken);
     }
@@ -207,7 +207,7 @@ public class Memory : IKernelMemory
         string? index = null,
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
-        double minRelevanceScore = 0,
+        double minRelevance = 0,
         CancellationToken cancellationToken = default)
     {
         if (filter != null)
@@ -221,7 +221,7 @@ public class Memory : IKernelMemory
         return this._searchClient.AskAsync(
             index: index,
             question: question,
-            minRelevanceScore: minRelevanceScore,
+            minRelevance: minRelevance,
             filters: filters,
             cancellationToken: cancellationToken);
     }

--- a/dotnet/CoreLib/Memory.cs
+++ b/dotnet/CoreLib/Memory.cs
@@ -181,6 +181,7 @@ public class Memory : IKernelMemory
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
         int limit = -1,
+        double minRelevanceScore = 0,
         CancellationToken cancellationToken = default)
     {
         if (filter != null)
@@ -191,7 +192,13 @@ public class Memory : IKernelMemory
         }
 
         index = IndexExtensions.CleanName(index);
-        return this._searchClient.SearchAsync(index, query: query, filters: filters, limit: limit, cancellationToken: cancellationToken);
+        return this._searchClient.SearchAsync(
+            index: index,
+            query: query,
+            minRelevanceScore: minRelevanceScore,
+            filters: filters,
+            limit: limit,
+            cancellationToken: cancellationToken);
     }
 
     /// <inheritdoc />
@@ -200,6 +207,7 @@ public class Memory : IKernelMemory
         string? index = null,
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
+        double minRelevanceScore = 0,
         CancellationToken cancellationToken = default)
     {
         if (filter != null)
@@ -210,6 +218,11 @@ public class Memory : IKernelMemory
         }
 
         index = IndexExtensions.CleanName(index);
-        return this._searchClient.AskAsync(index: index, question: question, filters: filters, cancellationToken: cancellationToken);
+        return this._searchClient.AskAsync(
+            index: index,
+            question: question,
+            minRelevanceScore: minRelevanceScore,
+            filters: filters,
+            cancellationToken: cancellationToken);
     }
 }

--- a/dotnet/CoreLib/Memory.cs
+++ b/dotnet/CoreLib/Memory.cs
@@ -221,8 +221,8 @@ public class Memory : IKernelMemory
         return this._searchClient.AskAsync(
             index: index,
             question: question,
-            minRelevance: minRelevance,
             filters: filters,
+            minRelevance: minRelevance,
             cancellationToken: cancellationToken);
     }
 }

--- a/dotnet/CoreLib/MemoryService.cs
+++ b/dotnet/CoreLib/MemoryService.cs
@@ -163,8 +163,8 @@ public class MemoryService : IKernelMemory
         string? index = null,
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
+        double minRelevance = 0,
         int limit = -1,
-        double minRelevanceScore = 0,
         CancellationToken cancellationToken = default)
     {
         if (filter != null)
@@ -179,8 +179,8 @@ public class MemoryService : IKernelMemory
             index: index,
             query: query,
             filters: filters,
+            minRelevance: minRelevance,
             limit: limit,
-            minRelevanceScore: minRelevanceScore,
             cancellationToken: cancellationToken);
     }
 
@@ -190,7 +190,7 @@ public class MemoryService : IKernelMemory
         string? index = null,
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
-        double minRelevanceScore = 0,
+        double minRelevance = 0,
         CancellationToken cancellationToken = default)
     {
         if (filter != null)
@@ -204,7 +204,7 @@ public class MemoryService : IKernelMemory
         return this._searchClient.AskAsync(
             index: index,
             question: question,
-            minRelevanceScore: minRelevanceScore,
+            minRelevance: minRelevance,
             filters: filters,
             cancellationToken: cancellationToken);
     }

--- a/dotnet/CoreLib/MemoryService.cs
+++ b/dotnet/CoreLib/MemoryService.cs
@@ -204,8 +204,8 @@ public class MemoryService : IKernelMemory
         return this._searchClient.AskAsync(
             index: index,
             question: question,
-            minRelevance: minRelevance,
             filters: filters,
+            minRelevance: minRelevance,
             cancellationToken: cancellationToken);
     }
 }

--- a/dotnet/CoreLib/MemoryService.cs
+++ b/dotnet/CoreLib/MemoryService.cs
@@ -164,6 +164,7 @@ public class MemoryService : IKernelMemory
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
         int limit = -1,
+        double minRelevanceScore = 0,
         CancellationToken cancellationToken = default)
     {
         if (filter != null)
@@ -174,7 +175,13 @@ public class MemoryService : IKernelMemory
         }
 
         index = IndexExtensions.CleanName(index);
-        return this._searchClient.SearchAsync(index, query: query, filters: filters, limit: limit, cancellationToken: cancellationToken);
+        return this._searchClient.SearchAsync(
+            index: index,
+            query: query,
+            filters: filters,
+            limit: limit,
+            minRelevanceScore: minRelevanceScore,
+            cancellationToken: cancellationToken);
     }
 
     /// <inheritdoc />
@@ -183,6 +190,7 @@ public class MemoryService : IKernelMemory
         string? index = null,
         MemoryFilter? filter = null,
         ICollection<MemoryFilter>? filters = null,
+        double minRelevanceScore = 0,
         CancellationToken cancellationToken = default)
     {
         if (filter != null)
@@ -193,6 +201,11 @@ public class MemoryService : IKernelMemory
         }
 
         index = IndexExtensions.CleanName(index);
-        return this._searchClient.AskAsync(index: index, question: question, filters: filters, cancellationToken: cancellationToken);
+        return this._searchClient.AskAsync(
+            index: index,
+            question: question,
+            minRelevanceScore: minRelevanceScore,
+            filters: filters,
+            cancellationToken: cancellationToken);
     }
 }

--- a/dotnet/CoreLib/MemoryStorage/IVectorDb.cs
+++ b/dotnet/CoreLib/MemoryStorage/IVectorDb.cs
@@ -11,11 +11,11 @@ public interface IVectorDb
     /// <summary>
     /// Create an index/collection
     /// </summary>
-    /// <param name="indexName">Index/Collection name</param>
+    /// <param name="index">Index/Collection name</param>
     /// <param name="vectorSize">Index/Collection vector size</param>
     /// <param name="cancellationToken">Task cancellation token</param>
     Task CreateIndexAsync(
-        string indexName,
+        string index,
         int vectorSize,
         CancellationToken cancellationToken = default);
 
@@ -29,41 +29,41 @@ public interface IVectorDb
     /// <summary>
     /// Delete an index/collection
     /// </summary>
-    /// <param name="indexName">Index/Collection name</param>
+    /// <param name="index">Index/Collection name</param>
     /// <param name="cancellationToken">Task cancellation token</param>
     Task DeleteIndexAsync(
-        string indexName,
+        string index,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Insert/Update a vector + payload
     /// </summary>
-    /// <param name="indexName">Index/Collection name</param>
+    /// <param name="index">Index/Collection name</param>
     /// <param name="record">Vector + payload to save</param>
     /// <param name="cancellationToken">Task cancellation token</param>
     /// <returns>Record ID</returns>
     Task<string> UpsertAsync(
-        string indexName,
+        string index,
         MemoryRecord record,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get list of similar vectors (+payload)
     /// </summary>
-    /// <param name="indexName">Index/Collection name</param>
+    /// <param name="index">Index/Collection name</param>
     /// <param name="embedding">Target vector to compare to</param>
     /// <param name="limit">Max number of results</param>
-    /// <param name="minRelevanceScore">Minimum Cosine Similarity required</param>
+    /// <param name="minRelevance">Minimum Cosine Similarity required</param>
     /// <param name="filters">Values to match in the field used for tagging records (the field must be a list of strings)</param>
     /// <param name="withEmbeddings">Whether to include vector in the result</param>
     /// <param name="cancellationToken">Task cancellation token</param>
     /// <returns>List of similar vectors, starting from the most similar</returns>
     IAsyncEnumerable<(MemoryRecord, double)> GetSimilarListAsync(
-        string indexName,
+        string index,
         Embedding embedding,
-        int limit,
-        double minRelevanceScore = 0,
         ICollection<MemoryFilter>? filters = null,
+        double minRelevance = 0,
+        int limit = 1,
         bool withEmbeddings = false,
         CancellationToken cancellationToken = default);
 
@@ -71,14 +71,14 @@ public interface IVectorDb
     /// Get list of records having a field matching a given value.
     /// E.g. searching vectors by tag, for deletions.
     /// </summary>
-    /// <param name="indexName">Index/Collection name</param>
+    /// <param name="index">Index/Collection name</param>
     /// <param name="filters">Values to match in the field used for tagging records (the field must be a list of strings)</param>
     /// <param name="limit">Max number of records to return</param>
     /// <param name="withEmbeddings">Whether to include vector in the result</param>
     /// <param name="cancellationToken">Task cancellation token</param>
     /// <returns>List of records</returns>
     IAsyncEnumerable<MemoryRecord> GetListAsync(
-        string indexName,
+        string index,
         ICollection<MemoryFilter>? filters = null,
         int limit = 1,
         bool withEmbeddings = false,
@@ -87,11 +87,11 @@ public interface IVectorDb
     /// <summary>
     /// Delete a record
     /// </summary>
-    /// <param name="indexName">Index/Collection name</param>
+    /// <param name="index">Index/Collection name</param>
     /// <param name="record">Record to delete. Most Vector DB requires only the record ID to be set.</param>
     /// <param name="cancellationToken">Task cancellation token</param>
     Task DeleteAsync(
-        string indexName,
+        string index,
         MemoryRecord record,
         CancellationToken cancellationToken = default);
 }

--- a/dotnet/CoreLib/MemoryStorage/Qdrant/Client/Http/SearchVectorsRequest.cs
+++ b/dotnet/CoreLib/MemoryStorage/Qdrant/Client/Http/SearchVectorsRequest.cs
@@ -103,9 +103,9 @@ internal sealed class SearchVectorsRequest
         return this;
     }
 
-    public SearchVectorsRequest WithScoreThreshold(double threshold)
+    public SearchVectorsRequest WithScoreThreshold(double scoreThreshold)
     {
-        this.ScoreThreshold = threshold;
+        this.ScoreThreshold = scoreThreshold;
         return this;
     }
 

--- a/dotnet/CoreLib/MemoryStorage/Qdrant/Client/QdrantClient.cs
+++ b/dotnet/CoreLib/MemoryStorage/Qdrant/Client/QdrantClient.cs
@@ -304,7 +304,7 @@ internal sealed class QdrantClient<T> where T : DefaultQdrantPayload, new()
     /// </summary>
     /// <param name="collectionName">Collection name</param>
     /// <param name="target">Vector to compare to</param>
-    /// <param name="minSimilarityScore">Minimum similarity required to be included in the results</param>
+    /// <param name="scoreThreshold">Minimum similarity required to be included in the results</param>
     /// <param name="limit">Max number of vectors to return</param>
     /// <param name="withVectors">Whether to include vectors</param>
     /// <param name="requiredTags">Optional filtering rules</param>
@@ -313,7 +313,7 @@ internal sealed class QdrantClient<T> where T : DefaultQdrantPayload, new()
     public async Task<List<(QdrantPoint<T>, double)>> GetSimilarListAsync(
         string collectionName,
         Embedding target,
-        double minSimilarityScore,
+        double scoreThreshold,
         int limit = 1,
         bool withVectors = false,
         IEnumerable<IEnumerable<string>?>? requiredTags = null,
@@ -327,7 +327,7 @@ internal sealed class QdrantClient<T> where T : DefaultQdrantPayload, new()
             .Create(collectionName)
             .SimilarTo(target)
             .HavingSomeTags(requiredTags)
-            .WithScoreThreshold(minSimilarityScore)
+            .WithScoreThreshold(scoreThreshold)
             .IncludePayLoad()
             .IncludeVectorData(withVectors)
             .Take(limit)

--- a/dotnet/CoreLib/Search/SearchClient.cs
+++ b/dotnet/CoreLib/Search/SearchClient.cs
@@ -53,8 +53,8 @@ public class SearchClient
     public async Task<SearchResult> SearchAsync(
         string index,
         string query,
-        double minRelevanceScore = 0,
         ICollection<MemoryFilter>? filters = null,
+        double minRelevance = 0,
         int limit = -1,
         CancellationToken cancellationToken = default)
     {
@@ -76,7 +76,13 @@ public class SearchClient
 
         this._log.LogTrace("Fetching relevant memories");
         IAsyncEnumerable<(MemoryRecord, double)> matches = this._vectorDb.GetSimilarListAsync(
-            indexName: index, embedding, limit, minRelevanceScore, filters, false, cancellationToken: cancellationToken);
+            index: index,
+            embedding: embedding,
+            filters: filters,
+            minRelevance: minRelevance,
+            limit: limit,
+            withEmbeddings: false,
+            cancellationToken: cancellationToken);
 
         // Memories are sorted by relevance, starting from the most relevant
         await foreach ((MemoryRecord memory, double relevance) in matches.WithCancellation(cancellationToken))
@@ -154,8 +160,8 @@ public class SearchClient
     public async Task<MemoryAnswer> AskAsync(
         string index,
         string question,
-        double minRelevanceScore = 0,
         ICollection<MemoryFilter>? filters = null,
+        double minRelevance = 0,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(question))
@@ -187,7 +193,13 @@ public class SearchClient
 
         this._log.LogTrace("Fetching relevant memories");
         IAsyncEnumerable<(MemoryRecord, double)> matches = this._vectorDb.GetSimilarListAsync(
-            indexName: index, embedding, MaxMatchesCount, minRelevanceScore, filters, false, cancellationToken: cancellationToken);
+            index: index,
+            embedding: embedding,
+            filters: filters,
+            minRelevance: minRelevance,
+            limit: MaxMatchesCount,
+            withEmbeddings: false,
+            cancellationToken: cancellationToken);
 
         // Memories are sorted by relevance, starting from the most relevant
         await foreach ((MemoryRecord memory, double relevance) in matches.WithCancellation(cancellationToken))

--- a/dotnet/Service/Program.cs
+++ b/dotnet/Service/Program.cs
@@ -192,7 +192,12 @@ if (config.Service.RunWebService)
                 CancellationToken cancellationToken) =>
             {
                 log.LogTrace("New search request");
-                MemoryAnswer answer = await service.AskAsync(question: query.Question, index: query.Index, filters: query.Filters, cancellationToken: cancellationToken)
+                MemoryAnswer answer = await service.AskAsync(
+                        question: query.Question,
+                        index: query.Index,
+                        filters: query.Filters,
+                        minRelevance: query.MinRelevance,
+                        cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
                 return Results.Ok(answer);
             })
@@ -207,7 +212,13 @@ if (config.Service.RunWebService)
                 CancellationToken cancellationToken) =>
             {
                 log.LogTrace("New search HTTP request");
-                SearchResult answer = await service.SearchAsync(query: query.Query, index: query.Index, filters: query.Filters, limit: query.Limit, cancellationToken: cancellationToken)
+                SearchResult answer = await service.SearchAsync(
+                        query: query.Query,
+                        index: query.Index,
+                        filters: query.Filters,
+                        minRelevance: query.MinRelevance,
+                        limit: query.Limit,
+                        cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
                 return Results.Ok(answer);
             })

--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -1,7 +1,7 @@
 ﻿<Project>
     <PropertyGroup>
         <!-- Central version prefix - applies to all nuget packages. -->
-        <Version>0.7.0</Version>
+        <Version>0.8.0</Version>
 
         <!-- Default description and tags. Packages can override. -->
         <Authors>Microsoft</Authors>

--- a/tests/FunctionalTests/TestHelpers/RedirectConsole.cs
+++ b/tests/FunctionalTests/TestHelpers/RedirectConsole.cs
@@ -301,7 +301,7 @@ internal sealed class RedirectConsole : TextWriter
         {
             this._output.WriteLine(s);
         }
-        catch (InvalidOperationException e) when (e.Message.Contains("no currently active test"))
+        catch (InvalidOperationException e) when (e.Message.Contains("no currently active test", StringComparison.OrdinalIgnoreCase))
         {
             // NOOP: Xunit thread out of scope
         }
@@ -313,7 +313,7 @@ internal sealed class RedirectConsole : TextWriter
         {
             this._output.WriteLine(s);
         }
-        catch (InvalidOperationException e) when (e.Message.Contains("no currently active test"))
+        catch (InvalidOperationException e) when (e.Message.Contains("no currently active test", StringComparison.OrdinalIgnoreCase))
         {
             // NOOP: Xunit thread out of scope
         }

--- a/tests/FunctionalTests/VectorDbComparison/TestCosineSimilarity.cs
+++ b/tests/FunctionalTests/VectorDbComparison/TestCosineSimilarity.cs
@@ -69,9 +69,9 @@ public class TestCosineSimilarity
 
         await Task.Delay(TimeSpan.FromSeconds(2));
         var target = new[] { 0.01f, 0.5f, 0.41f };
-        IAsyncEnumerable<(MemoryRecord, double)> acsList = acs.GetSimilarListAsync(indexName, target, 10, withEmbeddings: true);
-        IAsyncEnumerable<(MemoryRecord, double)> qdrantList = qdrant.GetSimilarListAsync(indexName, target, 10, withEmbeddings: true);
-        IAsyncEnumerable<(MemoryRecord, double)> simpleVecDbList = simpleVecDb.GetSimilarListAsync(indexName, target, 10, withEmbeddings: true);
+        IAsyncEnumerable<(MemoryRecord, double)> acsList = acs.GetSimilarListAsync(indexName, target, limit: 10, withEmbeddings: true);
+        IAsyncEnumerable<(MemoryRecord, double)> qdrantList = qdrant.GetSimilarListAsync(indexName, target, limit: 10, withEmbeddings: true);
+        IAsyncEnumerable<(MemoryRecord, double)> simpleVecDbList = simpleVecDb.GetSimilarListAsync(indexName, target, limit: 10, withEmbeddings: true);
 
         var acsResults = await acsList.ToListAsync();
         var qdrantResults = await qdrantList.ToListAsync();


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)
Refactor `minRelevance` logic:

- Remove `MemoryFilter.MinRelevance`
- Add optional argument `minRelevance` to `SearchAsync` and `AskAsync` and forward as necessary

Fixes #109.

## High level description (Approach, Design)
Remove the unused `MemoryFilter.MinRelevance` property and instead follow the optional argument pattern.

BREAKING change.