### PR TITLE
Various improvements to input string validation

### DIFF
--- a/KernelMemory.sln.DotSettings
+++ b/KernelMemory.sln.DotSettings
@@ -202,6 +202,7 @@ public void It$SOMENAME$()
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=DEC4D140B393B04F8A18C0913BDE0592/Shortcut/@EntryValue">copy</s:String>
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=DEC4D140B393B04F8A18C0913BDE0592/Text/@EntryValue">// Copyright (c) Microsoft. All rights reserved.
 </s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=abcdefghijklmnopqrstuvwxyz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AOAI/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AZUREBLOBS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AZUREIDENTITY/@EntryIndexedValue">True</s:Boolean>

--- a/dotnet/ClientLib/Constants.cs
+++ b/dotnet/ClientLib/Constants.cs
@@ -22,9 +22,11 @@ public static class Constants
     // Index name used when none is specified
     public const string DefaultIndex = "default";
 
-    // Tags reserved for internal logic
-    public const char ReservedEqualsSymbol = ':';
+    // Tags settings
+    public const char ReservedEqualsChar = ':';
     public const string ReservedTagsPrefix = "__";
+
+    // Tags reserved for internal logic
     public const string ReservedDocumentIdTag = $"{ReservedTagsPrefix}document_id";
     public const string ReservedFileIdTag = $"{ReservedTagsPrefix}file_id";
     public const string ReservedFilePartitionTag = $"{ReservedTagsPrefix}file_part";

--- a/dotnet/ClientLib/Models/FileCollection.cs
+++ b/dotnet/ClientLib/Models/FileCollection.cs
@@ -68,20 +68,19 @@ public class FileCollection
             throw new KernelMemoryException("The content stream is NULL");
         }
 
-        fileName = Document.ValidateId(fileName);
         if (string.IsNullOrWhiteSpace(fileName))
         {
             fileName = "content.txt";
         }
 
         var count = 0;
-        while (this._fileNames.Contains(fileName))
+        while (this._fileNames.Contains(fileName!))
         {
             fileName = $"stream{count++}_{fileName}";
         }
 
-        this._streams.Add(fileName, content);
-        this._fileNames.Add(fileName);
+        this._streams.Add(fileName!, content);
+        this._fileNames.Add(fileName!);
     }
 
     public IEnumerable<(string name, Stream content)> GetStreams()

--- a/dotnet/ClientLib/Models/TagCollection.cs
+++ b/dotnet/ClientLib/Models/TagCollection.cs
@@ -147,9 +147,15 @@ public class TagCollection : IDictionary<string, List<string?>>
 
     private static void ValidateKey(string key)
     {
-        if (key.Contains("="))
+        if (key.Contains(Constants.ReservedEqualsChar))
         {
-            throw new KernelMemoryException("A tag name cannot contain the '=' symbol");
+            throw new KernelMemoryException($"A tag name cannot contain the '{Constants.ReservedEqualsChar}' char");
+        }
+
+        // '=' is reserved for backward/forward compatibility and to reduce URLs query params encoding complexity
+        if (key.Contains('='))
+        {
+            throw new KernelMemoryException("A tag name cannot contain the '=' char");
         }
     }
 }

--- a/dotnet/CoreLib/FileSystem/DevTools/DiskFileSystem.cs
+++ b/dotnet/CoreLib/FileSystem/DevTools/DiskFileSystem.cs
@@ -19,7 +19,7 @@ namespace Microsoft.KernelMemory.FileSystem.DevTools;
 internal sealed class DiskFileSystem : IFileSystem
 {
     private const string DefaultVolumeName = "__default__";
-    private static readonly Regex s_invalidSymbolsRegex = new(@"[\s|\||\\|/|\0|'|\`|""|:|;|,|~|!|?|*|+|=|^|@|#|$|%|&]");
+    private static readonly Regex s_invalidCharsRegex = new(@"[\s|\||\\|/|\0|'|\`|""|:|;|,|~|!|?|*|+|=|^|@|#|$|%|&]");
 
     private readonly ILogger _log;
     private readonly string _dataPath;
@@ -222,9 +222,9 @@ internal sealed class DiskFileSystem : IFileSystem
             return DefaultVolumeName;
         }
 
-        if (s_invalidSymbolsRegex.Match(volume).Success)
+        if (s_invalidCharsRegex.Match(volume).Success)
         {
-            throw new ArgumentException("The volume name contains some invalid symbols or empty spaces");
+            throw new ArgumentException("The volume name contains some invalid chars or empty spaces");
         }
 
         return volume;
@@ -232,9 +232,15 @@ internal sealed class DiskFileSystem : IFileSystem
 
     private static string ValidatePath(string path)
     {
-        if (path.Contains('\\', StringComparison.Ordinal) || path.Contains(':', StringComparison.Ordinal))
+        // Check invalid chars one at a time for better error messages
+        if (path.Contains('\\', StringComparison.Ordinal))
         {
-            throw new ArgumentException("The path contains some invalid symbols");
+            throw new ArgumentException("The path contains some invalid chars: backslash '\\' chars are not allowed");
+        }
+
+        if (path.Contains(':', StringComparison.Ordinal))
+        {
+            throw new ArgumentException("The path contains some invalid chars: colon ':' chars are not allowed");
         }
 
         return path;
@@ -242,9 +248,20 @@ internal sealed class DiskFileSystem : IFileSystem
 
     private static string ValidateFileName(string fileName)
     {
-        if (fileName.Contains('/', StringComparison.Ordinal) || fileName.Contains('\\', StringComparison.Ordinal) || fileName.Contains(':', StringComparison.Ordinal))
+        // Check invalid chars one at a time for better error messages
+        if (fileName.Contains('/', StringComparison.Ordinal))
         {
-            throw new ArgumentException("The file name contains some invalid symbols");
+            throw new ArgumentException($"The file name {fileName} contains some invalid chars: slash '/' chars are not allowed");
+        }
+
+        if (fileName.Contains('\\', StringComparison.Ordinal))
+        {
+            throw new ArgumentException($"The file name {fileName} contains some invalid chars: backslash '\\' chars are not allowed");
+        }
+
+        if (fileName.Contains(':', StringComparison.Ordinal))
+        {
+            throw new ArgumentException($"The file name {fileName} contains some invalid chars: colon ':' chars are not allowed");
         }
 
         return fileName;

--- a/dotnet/CoreLib/FileSystem/DevTools/VolatileFileSystem.cs
+++ b/dotnet/CoreLib/FileSystem/DevTools/VolatileFileSystem.cs
@@ -20,7 +20,7 @@ internal sealed class VolatileFileSystem : IFileSystem
 {
     private const string DefaultVolumeName = "__default__";
     private const char DirSeparator = '/';
-    private static readonly Regex s_invalidSymbolsRegex = new(@"[\s|\||\\|/|\0|'|\`|""|:|;|,|~|!|?|*|+|=|^|@|#|$|%|&]");
+    private static readonly Regex s_invalidCharsRegex = new(@"[\s|\||\\|/|\0|'|\`|""|:|;|,|~|!|?|*|+|=|^|@|#|$|%|&]");
     private static VolatileFileSystem? s_singleton;
 
     private readonly ILogger _log;
@@ -287,9 +287,9 @@ internal sealed class VolatileFileSystem : IFileSystem
             return DefaultVolumeName;
         }
 
-        if (s_invalidSymbolsRegex.Match(volume).Success)
+        if (s_invalidCharsRegex.Match(volume).Success)
         {
-            throw new ArgumentException("The volume name contains some invalid symbols or empty spaces");
+            throw new ArgumentException("The volume name contains some invalid chars or empty spaces");
         }
 
         return volume;
@@ -297,9 +297,15 @@ internal sealed class VolatileFileSystem : IFileSystem
 
     private static string ValidatePath(string path)
     {
-        if (path.Contains('\\', StringComparison.Ordinal) || path.Contains(':', StringComparison.Ordinal))
+        // Check invalid chars one at a time for better error messages
+        if (path.Contains('\\', StringComparison.Ordinal))
         {
-            throw new ArgumentException("The path contains some invalid symbols");
+            throw new ArgumentException("The path contains some invalid chars: backslash '\\' chars are not allowed");
+        }
+
+        if (path.Contains(':', StringComparison.Ordinal))
+        {
+            throw new ArgumentException("The path contains some invalid chars: colon ':' chars are not allowed");
         }
 
         return path;
@@ -307,9 +313,20 @@ internal sealed class VolatileFileSystem : IFileSystem
 
     private static string ValidateFileName(string fileName)
     {
-        if (fileName.Contains('/', StringComparison.Ordinal) || fileName.Contains('\\', StringComparison.Ordinal) || fileName.Contains(':', StringComparison.Ordinal))
+        // Check invalid chars one at a time for better error messages
+        if (fileName.Contains('/', StringComparison.Ordinal))
         {
-            throw new ArgumentException($"The file name contains some invalid symbols: {fileName}");
+            throw new ArgumentException($"The file name {fileName} contains some invalid chars: slash '/' chars are not allowed");
+        }
+
+        if (fileName.Contains('\\', StringComparison.Ordinal))
+        {
+            throw new ArgumentException($"The file name {fileName} contains some invalid chars: backslash '\\' chars are not allowed");
+        }
+
+        if (fileName.Contains(':', StringComparison.Ordinal))
+        {
+            throw new ArgumentException($"The file name {fileName} contains some invalid chars: colon ':' chars are not allowed");
         }
 
         return fileName;

--- a/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/AzureCognitiveSearchMemory.cs
+++ b/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/AzureCognitiveSearchMemory.cs
@@ -322,7 +322,7 @@ public class AzureCognitiveSearchMemory : IVectorDb
     /// - replacing chars introduces a small chance of conflicts, e.g. "the-user" and "the_user".
     /// - we should consider whether making this optional and leave it to the developer to handle.
     /// </summary>
-    private static readonly Regex s_replaceIndexNameSymbolsRegex = new(@"[\s|\\|/|.|_|:]");
+    private static readonly Regex s_replaceIndexNameCharsRegex = new(@"[\s|\\|/|.|_|:]");
 
     private readonly ConcurrentDictionary<string, SearchClient> _clientsByIndex = new();
 
@@ -408,7 +408,7 @@ public class AzureCognitiveSearchMemory : IVectorDb
 
         indexName = indexName.ToLowerInvariant();
 
-        indexName = s_replaceIndexNameSymbolsRegex.Replace(indexName.Trim(), "-");
+        indexName = s_replaceIndexNameCharsRegex.Replace(indexName.Trim(), "-");
 
         // Name cannot start with a dash
         if (indexName.StartsWith('-')) { indexName = $"z{indexName}"; }
@@ -583,7 +583,7 @@ public class AzureCognitiveSearchMemory : IVectorDb
                 .Select(keyValue =>
                 {
                     var fieldValue = keyValue.Value?.Replace("'", "''", StringComparison.Ordinal);
-                    return $"tags/any(s: s eq '{keyValue.Key}{Constants.ReservedEqualsSymbol}{fieldValue}')";
+                    return $"tags/any(s: s eq '{keyValue.Key}{Constants.ReservedEqualsChar}{fieldValue}')";
                 })
                 .ToList();
 

--- a/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/AzureCognitiveSearchMemoryRecord.cs
+++ b/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/AzureCognitiveSearchMemoryRecord.cs
@@ -69,7 +69,7 @@ public sealed class AzureCognitiveSearchMemoryRecord
             result.Vector = this.Vector;
         }
 
-        foreach (string[] keyValue in this.Tags.Select(tag => tag.Split(Constants.ReservedEqualsSymbol, 2)))
+        foreach (string[] keyValue in this.Tags.Select(tag => tag.Split(Constants.ReservedEqualsChar, 2)))
         {
             string key = keyValue[0];
             string? value = keyValue.Length == 1 ? null : keyValue[1];
@@ -90,7 +90,7 @@ public sealed class AzureCognitiveSearchMemoryRecord
 
         foreach (var tag in record.Tags.Pairs)
         {
-            result.Tags.Add($"{tag.Key}{Constants.ReservedEqualsSymbol}{tag.Value}");
+            result.Tags.Add($"{tag.Key}{Constants.ReservedEqualsChar}{tag.Value}");
         }
 
         return result;

--- a/dotnet/CoreLib/MemoryStorage/Qdrant/Client/QdrantPoint.cs
+++ b/dotnet/CoreLib/MemoryStorage/Qdrant/Client/QdrantPoint.cs
@@ -37,7 +37,7 @@ internal class QdrantPoint<T> where T : DefaultQdrantPayload, new()
             result.Vector = this.Vector;
         }
 
-        foreach (string[] keyValue in this.Payload.Tags.Select(tag => tag.Split(Constants.ReservedEqualsSymbol, 2)))
+        foreach (string[] keyValue in this.Payload.Tags.Select(tag => tag.Split(Constants.ReservedEqualsChar, 2)))
         {
             string key = keyValue[0];
             string? value = keyValue.Length == 1 ? null : keyValue[1];
@@ -55,7 +55,7 @@ internal class QdrantPoint<T> where T : DefaultQdrantPayload, new()
             Payload = new T
             {
                 Id = record.Id,
-                Tags = record.Tags.Pairs.Select(tag => $"{tag.Key}{Constants.ReservedEqualsSymbol}{tag.Value}").ToList(),
+                Tags = record.Tags.Pairs.Select(tag => $"{tag.Key}{Constants.ReservedEqualsChar}{tag.Value}").ToList(),
                 Payload = JsonSerializer.Serialize(record.Payload, QdrantConfig.JSONOptions),
             }
         };

--- a/dotnet/CoreLib/MemoryStorage/Qdrant/QdrantMemory.cs
+++ b/dotnet/CoreLib/MemoryStorage/Qdrant/QdrantMemory.cs
@@ -108,7 +108,7 @@ public class QdrantMemory : IVectorDb
         var requiredTags = new List<IEnumerable<string>>();
         if (filters is { Count: > 0 })
         {
-            requiredTags.AddRange(filters.Select(filter => filter.GetFilters().Select(x => $"{x.Key}{Constants.ReservedEqualsSymbol}{x.Value}")));
+            requiredTags.AddRange(filters.Select(filter => filter.GetFilters().Select(x => $"{x.Key}{Constants.ReservedEqualsChar}{x.Value}")));
         }
 
         List<(QdrantPoint<DefaultQdrantPayload>, double)> results = await this._qdrantClient.GetSimilarListAsync(
@@ -143,7 +143,7 @@ public class QdrantMemory : IVectorDb
         var requiredTags = new List<IEnumerable<string>>();
         if (filters is { Count: > 0 })
         {
-            requiredTags.AddRange(filters.Select(filter => filter.GetFilters().Select(x => $"{x.Key}{Constants.ReservedEqualsSymbol}{x.Value}")));
+            requiredTags.AddRange(filters.Select(filter => filter.GetFilters().Select(x => $"{x.Key}{Constants.ReservedEqualsChar}{x.Value}")));
         }
 
         List<QdrantPoint<DefaultQdrantPayload>> results = await this._qdrantClient.GetListAsync(

--- a/dotnet/CoreLib/WebService/HttpDocumentUploadRequest.cs
+++ b/dotnet/CoreLib/WebService/HttpDocumentUploadRequest.cs
@@ -105,7 +105,7 @@ public class HttpDocumentUploadRequest
     {
         if (key.Contains('=', StringComparison.Ordinal))
         {
-            throw new KernelMemoryException("A tag name cannot contain the '=' symbol");
+            throw new KernelMemoryException("A tag name cannot contain the '=' char");
         }
 
         if (key is

--- a/tests/FunctionalTests/ServerLess/ImportFilesTest.cs
+++ b/tests/FunctionalTests/ServerLess/ImportFilesTest.cs
@@ -61,6 +61,26 @@ public class ImportFilesTest : BaseTestCase
             steps: new[] { "extract", "partition" });
     }
 
+    [Fact]
+    public async Task ItImportsStreams()
+    {
+        // Arrange
+        var fileName = "Doc1.txt";
+        var filePath = Path.Join(this._fixturesPath, fileName);
+        using MemoryStream memoryStream = new();
+        using Stream fileStream = File.OpenRead(filePath);
+        await fileStream.CopyToAsync(memoryStream);
+        memoryStream.Seek(0, SeekOrigin.Begin);
+
+        // Act - Assert no exception occurs
+        await this._memory.ImportDocumentAsync(
+            content: memoryStream,
+            documentId: "487BC53B60CFBD42167A0488A78347929E0FE811FC705A94253E419CA5911360",
+            fileName: fileName,
+            steps: new[] { "extract", "partition" },
+            tags: new() { { "user", "user1" } });
+    }
+
     // Find the "Fixtures" directory (inside the project)
     private static string? FindFixturesDir()
     {

--- a/tests/UnitTests/Models/DocumentTest.cs
+++ b/tests/UnitTests/Models/DocumentTest.cs
@@ -12,6 +12,14 @@ public class DocumentTest
         // Assert - No exception occurs
         Assert.Equal("a-b.txt", Document.ValidateId("a-b.txt"));
         Assert.Equal("a_b.txt", Document.ValidateId("a_b.txt"));
+        Assert.Equal("abcdefghijklmnopqrstuvwxyz", Document.ValidateId("abcdefghijklmnopqrstuvwxyz"));
+        Assert.Equal("ABCDEFGHIJKLMNOPQRSTUVWXYZ", Document.ValidateId("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
+        Assert.Equal("01234567890", Document.ValidateId("01234567890"));
+        Assert.Equal("-_.", Document.ValidateId("-_."));
+
+        // Assert - Empty strings
+        Assert.Throws<ArgumentOutOfRangeException>(() => Document.ValidateId(""));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Document.ValidateId(null));
 
         // Assert - special chars
         Assert.Throws<ArgumentOutOfRangeException>(() => Document.ValidateId("a b.txt"));


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

* Fix #120 
* Fix incorrect tag name validation, `:` char should not be allowed
* Improve files/paths validation error messages

## High level description (Approach, Design)

Various improvements to input string validation

* Streams upload: fix bug, filename doesn't need to be a valid ID.
* Document ID: explicitly allow only alphanumeric (and some other chars).
* Tag: disallow ':' in tag names.
* Improve error messages to help debugging.
* Add tests.