### PR TITLE
Upgrade Azure.Identity: fix CVE-2023-36414

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,18 +4,18 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="Azure.AI.FormRecognizer" Version="4.1.0"/>
-        <PackageVersion Include="Azure.Identity" Version="1.10.1"/>
+        <PackageVersion Include="Azure.Identity" Version="1.10.3"/>
         <PackageVersion Include="Azure.Search.Documents" Version="11.5.0-beta.4"/>
         <PackageVersion Include="Azure.Storage.Blobs" Version="12.18.0"/>
         <PackageVersion Include="Azure.Storage.Queues" Version="12.16.0"/>
         <PackageVersion Include="DocumentFormat.OpenXml" Version="2.20.0"/>
-        <PackageVersion Include="HtmlAgilityPack" Version="1.11.53"/>
-        <PackageVersion Include="LLamaSharp" Version="0.5.1"/>
-        <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.1"/>
+        <PackageVersion Include="HtmlAgilityPack" Version="1.11.54"/>
+        <PackageVersion Include="LLamaSharp" Version="0.6.0"/>
+        <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.2"/>
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
         <PackageVersion Include="PdfPig" Version="0.1.8"/>
         <PackageVersion Include="Polly.Core" Version="8.0.0"/>
-        <PackageVersion Include="RabbitMQ.Client" Version="6.5.0"/>
+        <PackageVersion Include="RabbitMQ.Client" Version="6.6.0"/>
         <PackageVersion Include="ReadLine" Version="2.0.1"/>
         <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
         <PackageVersion Include="System.Linq.Async" Version="6.0.1"/>
@@ -38,9 +38,12 @@
     <ItemGroup>
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
         <PackageVersion Include="Moq" Version="4.20.69"/>
-        <PackageVersion Include="xunit" Version="2.5.1"/>
+        <PackageVersion Include="xunit" Version="2.5.3"/>
         <PackageVersion Include="Xunit.DependencyInjection" Version="8.9.0"/>
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
         <PackageVersion Include="coverlet.collector" Version="6.0.0"/>
     </ItemGroup>
     <!-- Symbols -->
@@ -69,12 +72,18 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.5.0"/>
+        <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.6.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
         <PackageReference Include="Roslynator.CodeAnalysis.Analyzers">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.5.0"/>
+        <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.6.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
         <PackageReference Include="Roslynator.Formatting.Analyzers">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Upgrade Azure.Identity: fix CVE-2023-36414

Upgrade other packages:
* HtmlAgilityPack (used by handlers)
* RabbitMQ.Client (async pipelines)
* Xunit (tests)
* Roslynator (code analyzers)
* LLamaSharp (used only in examples)
* SqlClient (used only in examples)