### PR TITLE
Allow to retrieve list of indexes

### DIFF
--- a/dotnet/ClientLib/IKernelMemory.cs
+++ b/dotnet/ClientLib/IKernelMemory.cs
@@ -109,6 +109,13 @@ public interface IKernelMemory
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns a list of the indexes available in memory.
+    /// </summary>
+    /// <param name="cancellationToken">Async task cancellation token</param>
+    /// <returns>List of indexes</returns>
+    public IAsyncEnumerable<IndexDetails> ListIndexesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Delete an entire index.
     /// </summary>
     /// <param name="index">Optional index name, when empty the default index is deleted</param>

--- a/dotnet/ClientLib/IKernelMemory.cs
+++ b/dotnet/ClientLib/IKernelMemory.cs
@@ -113,7 +113,7 @@ public interface IKernelMemory
     /// </summary>
     /// <param name="cancellationToken">Async task cancellation token</param>
     /// <returns>List of indexes</returns>
-    public IAsyncEnumerable<IndexDetails> ListIndexesAsync(CancellationToken cancellationToken = default);
+    public Task<IEnumerable<IndexDetails>> ListIndexesAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete an entire index.

--- a/dotnet/ClientLib/MemoryWebClient.cs
+++ b/dotnet/ClientLib/MemoryWebClient.cs
@@ -124,6 +124,20 @@ public class MemoryWebClient : IKernelMemory
     }
 
     /// <inheritdoc />
+    public async Task<IEnumerable<IndexDetails>> ListIndexesAsync(CancellationToken cancellationToken = default)
+    {
+        const string URL = Constants.HttpIndexesEndpoint;
+        HttpResponseMessage? response = await this._client.GetAsync(URL, cancellationToken).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var data = JsonSerializer.Deserialize<IndexCollection>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? new IndexCollection();
+
+        return data.Results;
+    }
+
+    /// <inheritdoc />
     public async Task DeleteIndexAsync(string? index = null, CancellationToken cancellationToken = default)
     {
         index = IndexExtensions.CleanName(index);

--- a/dotnet/ClientLib/Models/IndexCollection.cs
+++ b/dotnet/ClientLib/Models/IndexCollection.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+#pragma warning disable IDE0130 // reduce number of "using" statements
+// ReSharper disable once CheckNamespace - reduce number of "using" statements
+namespace Microsoft.KernelMemory;
+
+public class IndexCollection
+{
+    [JsonPropertyName("results")]
+    [JsonPropertyOrder(1)]
+    public List<IndexDetails> Results { get; set; } = new();
+}

--- a/dotnet/ClientLib/Models/IndexDetails.cs
+++ b/dotnet/ClientLib/Models/IndexDetails.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json.Serialization;
+
+#pragma warning disable IDE0130 // reduce number of "using" statements
+// ReSharper disable once CheckNamespace - reduce number of "using" statements
+namespace Microsoft.KernelMemory;
+
+public class IndexDetails
+{
+    [JsonPropertyName("name")]
+    [JsonPropertyOrder(1)]
+    public string Name { get; set; } = string.Empty;
+}

--- a/dotnet/CoreLib/ContentStorage/DevTools/SimpleFileStorage.cs
+++ b/dotnet/CoreLib/ContentStorage/DevTools/SimpleFileStorage.cs
@@ -25,7 +25,7 @@ public class SimpleFileStorage : IContentStorage
                 break;
 
             case FileSystemTypes.Volatile:
-                this._fileSystem = VolatileFileSystem.GetInstance(this._log);
+                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, this._log);
                 break;
 
             default:

--- a/dotnet/CoreLib/FileSystem/DevTools/DiskFileSystem.cs
+++ b/dotnet/CoreLib/FileSystem/DevTools/DiskFileSystem.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -33,6 +34,7 @@ internal sealed class DiskFileSystem : IFileSystem
 
     #region Volume API
 
+    /// <inheritdoc />
     public Task CreateVolumeAsync(string volume, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -41,6 +43,7 @@ internal sealed class DiskFileSystem : IFileSystem
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public Task<bool> VolumeExistsAsync(string volume, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -48,6 +51,7 @@ internal sealed class DiskFileSystem : IFileSystem
         return Task.FromResult(Directory.Exists(path));
     }
 
+    /// <inheritdoc />
     public Task DeleteVolumeAsync(string volume, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -61,21 +65,24 @@ internal sealed class DiskFileSystem : IFileSystem
         return Task.CompletedTask;
     }
 
-    public Task<List<string>> ListVolumesAsync(CancellationToken cancellationToken = default)
+    /// <inheritdoc />
+    public Task<IEnumerable<string>> ListVolumesAsync(CancellationToken cancellationToken = default)
     {
         var result = new List<string>();
         if (Directory.Exists(this._dataPath))
         {
-            result.AddRange(Directory.GetDirectories(this._dataPath));
+            var list = Directory.GetDirectories(this._dataPath);
+            result.AddRange(list.Select(Path.GetFileName)!);
         }
 
-        return Task.FromResult(result);
+        return Task.FromResult((IEnumerable<string>)result);
     }
 
     #endregion
 
     #region Directory API
 
+    /// <inheritdoc />
     public Task CreateDirectoryAsync(string volume, string relPath, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -85,6 +92,7 @@ internal sealed class DiskFileSystem : IFileSystem
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public Task DeleteDirectoryAsync(string volume, string relPath, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -102,6 +110,7 @@ internal sealed class DiskFileSystem : IFileSystem
 
     #region File API
 
+    /// <inheritdoc />
     public Task WriteFileAsync(string volume, string relPath, string fileName, Stream streamContent, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -115,6 +124,7 @@ internal sealed class DiskFileSystem : IFileSystem
         return File.WriteAllBytesAsync(path, BinaryData.FromStream(streamContent).ToArray(), cancellationToken);
     }
 
+    /// <inheritdoc />
     public async Task WriteFileAsync(string volume, string relPath, string fileName, string data, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -128,6 +138,7 @@ internal sealed class DiskFileSystem : IFileSystem
         await File.WriteAllBytesAsync(path, new BinaryData(data).ToArray(), cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
     public async Task<BinaryData> ReadFileAsBinaryAsync(string volume, string relPath, string fileName, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -149,12 +160,14 @@ internal sealed class DiskFileSystem : IFileSystem
         return new BinaryData(await File.ReadAllBytesAsync(path, cancellationToken).ConfigureAwait(false));
     }
 
+    /// <inheritdoc />
     public async Task<string> ReadFileAsTextAsync(string volume, string relPath, string fileName, CancellationToken cancellationToken = default)
     {
         return (await this.ReadFileAsBinaryAsync(volume: volume, relPath: relPath, fileName: fileName, cancellationToken).ConfigureAwait(false))
             .ToString();
     }
 
+    /// <inheritdoc />
     public Task<IEnumerable<string>> GetAllFileNamesAsync(string volume, string relPath, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -183,6 +196,7 @@ internal sealed class DiskFileSystem : IFileSystem
         return Task.FromResult((IEnumerable<string>)result);
     }
 
+    /// <inheritdoc />
     public Task<bool> FileExistsAsync(string volume, string relPath, string fileName, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -191,6 +205,7 @@ internal sealed class DiskFileSystem : IFileSystem
         return Task.FromResult(File.Exists(path));
     }
 
+    /// <inheritdoc />
     public Task DeleteFileAsync(string volume, string relPath, string fileName, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -202,6 +217,7 @@ internal sealed class DiskFileSystem : IFileSystem
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public async Task<IDictionary<string, string>> ReadAllFilesAsTextAsync(string volume, string relPath, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);

--- a/dotnet/CoreLib/FileSystem/DevTools/DiskFileSystem.cs
+++ b/dotnet/CoreLib/FileSystem/DevTools/DiskFileSystem.cs
@@ -61,6 +61,17 @@ internal sealed class DiskFileSystem : IFileSystem
         return Task.CompletedTask;
     }
 
+    public Task<List<string>> ListVolumesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = new List<string>();
+        if (Directory.Exists(this._dataPath))
+        {
+            result.AddRange(Directory.GetDirectories(this._dataPath));
+        }
+
+        return Task.FromResult(result);
+    }
+
     #endregion
 
     #region Directory API

--- a/dotnet/CoreLib/FileSystem/DevTools/IFileSystem.cs
+++ b/dotnet/CoreLib/FileSystem/DevTools/IFileSystem.cs
@@ -15,7 +15,7 @@ internal interface IFileSystem
     Task CreateVolumeAsync(string volume, CancellationToken cancellationToken = default);
     Task<bool> VolumeExistsAsync(string volume, CancellationToken cancellationToken = default);
     Task DeleteVolumeAsync(string volume, CancellationToken cancellationToken = default);
-    Task<List<string>> ListVolumesAsync(CancellationToken cancellationToken = default);
+    Task<IEnumerable<string>> ListVolumesAsync(CancellationToken cancellationToken = default);
 
     #endregion
 

--- a/dotnet/CoreLib/FileSystem/DevTools/IFileSystem.cs
+++ b/dotnet/CoreLib/FileSystem/DevTools/IFileSystem.cs
@@ -15,6 +15,7 @@ internal interface IFileSystem
     Task CreateVolumeAsync(string volume, CancellationToken cancellationToken = default);
     Task<bool> VolumeExistsAsync(string volume, CancellationToken cancellationToken = default);
     Task DeleteVolumeAsync(string volume, CancellationToken cancellationToken = default);
+    Task<List<string>> ListVolumesAsync(CancellationToken cancellationToken = default);
 
     #endregion
 

--- a/dotnet/CoreLib/FileSystem/DevTools/VolatileFileSystem.cs
+++ b/dotnet/CoreLib/FileSystem/DevTools/VolatileFileSystem.cs
@@ -70,6 +70,11 @@ internal sealed class VolatileFileSystem : IFileSystem
         return Task.CompletedTask;
     }
 
+    public Task<List<string>> ListVolumesAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(this._volumes.Keys.ToList());
+    }
+
     #endregion
 
     #region Directory API

--- a/dotnet/CoreLib/FileSystem/DevTools/VolatileFileSystem.cs
+++ b/dotnet/CoreLib/FileSystem/DevTools/VolatileFileSystem.cs
@@ -20,11 +20,15 @@ internal sealed class VolatileFileSystem : IFileSystem
 {
     private const string DefaultVolumeName = "__default__";
     private const char DirSeparator = '/';
+
     private static readonly Regex s_invalidCharsRegex = new(@"[\s|\||\\|/|\0|'|\`|""|:|;|,|~|!|?|*|+|=|^|@|#|$|%|&]");
-    private static VolatileFileSystem? s_singleton;
+
+    /// <summary>
+    /// To avoid collisions, singletons are split by root directory
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, VolatileFileSystem> s_singletons = new();
 
     private readonly ILogger _log;
-
     private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, BinaryData>> _volumes = new();
 
     /// <summary>
@@ -36,16 +40,24 @@ internal sealed class VolatileFileSystem : IFileSystem
     }
 
     /// <summary>
-    /// Note: the volatile FS should be used as a singleton, in order to share state (directories and files)
-    /// across clients. E.g. the simple queue requires a shared instance to work properly.
+    /// Note: the volatile FS should be used as a singleton, in order to share state
+    /// (directories and files) across clients. E.g. the simple queue requires a shared
+    /// instance to work properly.
     /// </summary>
-    public static VolatileFileSystem GetInstance(ILogger? log = null)
+    public static VolatileFileSystem GetInstance(string directory, ILogger? log = null)
     {
-        return s_singleton ??= new VolatileFileSystem(log);
+        directory = directory.Trim('/').Trim('\\').ToLowerInvariant();
+        if (!s_singletons.ContainsKey(directory))
+        {
+            s_singletons[directory] = new VolatileFileSystem(log);
+        }
+
+        return s_singletons[directory];
     }
 
     #region Volume API
 
+    /// <inheritdoc />
     public Task CreateVolumeAsync(string volume, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -57,12 +69,14 @@ internal sealed class VolatileFileSystem : IFileSystem
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public Task<bool> VolumeExistsAsync(string volume, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
         return Task.FromResult(this._volumes.ContainsKey(volume));
     }
 
+    /// <inheritdoc />
     public Task DeleteVolumeAsync(string volume, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -70,25 +84,31 @@ internal sealed class VolatileFileSystem : IFileSystem
         return Task.CompletedTask;
     }
 
-    public Task<List<string>> ListVolumesAsync(CancellationToken cancellationToken = default)
+    /// <inheritdoc />
+    public Task<IEnumerable<string>> ListVolumesAsync(CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(this._volumes.Keys.ToList());
+        return Task.FromResult(this._volumes.Keys.Select(x => x));
     }
 
     #endregion
 
     #region Directory API
 
+    /// <inheritdoc />
     public async Task CreateDirectoryAsync(string volume, string relPath, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
+
         await this.CreateVolumeAsync(volume, cancellationToken).ConfigureAwait(false);
         relPath = ValidatePath(relPath);
-        // Note: the value has an / at the end
+
+        // Note: the value has a '/' at the end
         var path = JoinPaths(relPath, "");
+
         this._volumes[volume][path] = new(string.Empty);
     }
 
+    /// <inheritdoc />
     public async Task DeleteDirectoryAsync(string volume, string relPath, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -111,12 +131,14 @@ internal sealed class VolatileFileSystem : IFileSystem
 
     #region File API
 
+    /// <inheritdoc />
     public async Task WriteFileAsync(string volume, string relPath, string fileName, Stream streamContent, CancellationToken cancellationToken = default)
     {
+        volume = ValidateVolumeName(volume);
+
         await using (streamContent.ConfigureAwait(false))
         {
             var data = new BinaryData(streamContent.ReadAllBytes());
-            volume = ValidateVolumeName(volume);
             await this.ValidateVolumeExistsAsync(volume, cancellationToken).ConfigureAwait(false);
 
             if (!this._volumes.TryGetValue(volume, out ConcurrentDictionary<string, BinaryData>? volumeData))
@@ -132,6 +154,7 @@ internal sealed class VolatileFileSystem : IFileSystem
         }
     }
 
+    /// <inheritdoc />
     public async Task WriteFileAsync(string volume, string relPath, string fileName, string data, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -149,6 +172,14 @@ internal sealed class VolatileFileSystem : IFileSystem
         volumeData[path] = new BinaryData(data);
     }
 
+    /// <inheritdoc />
+    public async Task<string> ReadFileAsTextAsync(string volume, string relPath, string fileName, CancellationToken cancellationToken = default)
+    {
+        return (await this.ReadFileAsBinaryAsync(volume: volume, relPath: relPath, fileName: fileName, cancellationToken).ConfigureAwait(false))
+            .ToString();
+    }
+
+    /// <inheritdoc />
     public Task<BinaryData> ReadFileAsBinaryAsync(string volume, string relPath, string fileName, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -179,12 +210,7 @@ internal sealed class VolatileFileSystem : IFileSystem
         return Task.FromResult(result);
     }
 
-    public async Task<string> ReadFileAsTextAsync(string volume, string relPath, string fileName, CancellationToken cancellationToken = default)
-    {
-        return (await this.ReadFileAsBinaryAsync(volume: volume, relPath: relPath, fileName: fileName, cancellationToken).ConfigureAwait(false))
-            .ToString();
-    }
-
+    /// <inheritdoc />
     public Task<IEnumerable<string>> GetAllFileNamesAsync(string volume, string relPath, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -210,6 +236,7 @@ internal sealed class VolatileFileSystem : IFileSystem
         return Task.FromResult((IEnumerable<string>)result);
     }
 
+    /// <inheritdoc />
     public Task<bool> FileExistsAsync(string volume, string relPath, string fileName, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -217,7 +244,9 @@ internal sealed class VolatileFileSystem : IFileSystem
         var path = JoinPaths(relPath, fileName);
         try
         {
-            return Task.FromResult(this._volumes.ContainsKey(volume) && this._volumes[volume].ContainsKey(path) && !path.EndsWith($"{DirSeparator}", StringComparison.Ordinal));
+            return Task.FromResult(this._volumes.ContainsKey(volume)
+                                   && this._volumes[volume].ContainsKey(path)
+                                   && !path.EndsWith($"{DirSeparator}", StringComparison.Ordinal));
         }
         catch (KeyNotFoundException)
         {
@@ -225,6 +254,7 @@ internal sealed class VolatileFileSystem : IFileSystem
         }
     }
 
+    /// <inheritdoc />
     public Task DeleteFileAsync(string volume, string relPath, string fileName, CancellationToken cancellationToken = default)
     {
         volume = ValidateVolumeName(volume);
@@ -238,6 +268,7 @@ internal sealed class VolatileFileSystem : IFileSystem
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public Task<IDictionary<string, string>> ReadAllFilesAsTextAsync(string volume, string relPath, CancellationToken cancellationToken = default)
     {
         IDictionary<string, string> result = new Dictionary<string, string>();

--- a/dotnet/CoreLib/KernelMemoryBuilder.cs
+++ b/dotnet/CoreLib/KernelMemoryBuilder.cs
@@ -28,8 +28,6 @@ using Microsoft.KernelMemory.Pipeline.Queue.RabbitMq;
 using Microsoft.KernelMemory.Search;
 using Microsoft.SemanticKernel.AI.Embeddings;
 
-#pragma warning disable IDE0130 // reduce number of "using" statements
-// ReSharper disable once CheckNamespace - reduce number of "using" statements
 namespace Microsoft.KernelMemory;
 
 public class KernelMemoryBuilder

--- a/dotnet/CoreLib/Memory.cs
+++ b/dotnet/CoreLib/Memory.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -131,6 +132,18 @@ public class Memory : IKernelMemory
         using Stream content = new MemoryStream(Encoding.UTF8.GetBytes(uri.AbsoluteUri));
         return await this.ImportDocumentAsync(content, fileName: "content.url", documentId: documentId, tags: tags, index: index, steps: steps, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IndexDetails> ListIndexesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (string index in this._searchClient.ListIndexesAsync(cancellationToken).ConfigureAwait(false))
+        {
+            yield return new IndexDetails
+            {
+                Name = index
+            };
+        }
     }
 
     /// <inheritdoc />

--- a/dotnet/CoreLib/Memory.cs
+++ b/dotnet/CoreLib/Memory.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.CompilerServices;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -135,15 +135,10 @@ public class Memory : IKernelMemory
     }
 
     /// <inheritdoc />
-    public async IAsyncEnumerable<IndexDetails> ListIndexesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<IndexDetails>> ListIndexesAsync(CancellationToken cancellationToken = default)
     {
-        await foreach (string index in this._searchClient.ListIndexesAsync(cancellationToken).ConfigureAwait(false))
-        {
-            yield return new IndexDetails
-            {
-                Name = index
-            };
-        }
+        return (from index in await this._searchClient.ListIndexesAsync(cancellationToken).ConfigureAwait(false)
+                select new IndexDetails { Name = index });
     }
 
     /// <inheritdoc />

--- a/dotnet/CoreLib/MemoryService.cs
+++ b/dotnet/CoreLib/MemoryService.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.CompilerServices;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -119,15 +119,10 @@ public class MemoryService : IKernelMemory
     }
 
     /// <inheritdoc />
-    public async IAsyncEnumerable<IndexDetails> ListIndexesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<IndexDetails>> ListIndexesAsync(CancellationToken cancellationToken = default)
     {
-        await foreach (string index in this._searchClient.ListIndexesAsync(cancellationToken).ConfigureAwait(false))
-        {
-            yield return new IndexDetails
-            {
-                Name = index
-            };
-        }
+        return (from index in await this._searchClient.ListIndexesAsync(cancellationToken).ConfigureAwait(false)
+                select new IndexDetails { Name = index });
     }
 
     /// <inheritdoc />

--- a/dotnet/CoreLib/MemoryService.cs
+++ b/dotnet/CoreLib/MemoryService.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -115,6 +116,18 @@ public class MemoryService : IKernelMemory
                 steps: steps,
                 cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IndexDetails> ListIndexesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (string index in this._searchClient.ListIndexesAsync(cancellationToken).ConfigureAwait(false))
+        {
+            yield return new IndexDetails
+            {
+                Name = index
+            };
+        }
     }
 
     /// <inheritdoc />

--- a/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/AzureCognitiveSearchMemory.cs
+++ b/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/AzureCognitiveSearchMemory.cs
@@ -78,6 +78,16 @@ public class AzureCognitiveSearchMemory : IVectorDb
     }
 
     /// <inheritdoc />
+    public async IAsyncEnumerable<string> GetIndexesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var indexesAsync = this._adminClient.GetIndexesAsync(cancellationToken).ConfigureAwait(false);
+        await foreach (SearchIndex? index in indexesAsync)
+        {
+            yield return index.Name;
+        }
+    }
+
+    /// <inheritdoc />
     public Task DeleteIndexAsync(string indexName, CancellationToken cancellationToken = default)
     {
         indexName = this.NormalizeIndexName(indexName);
@@ -360,15 +370,6 @@ public class AzureCognitiveSearchMemory : IVectorDb
         }
 
         return client;
-    }
-
-    private async IAsyncEnumerable<string> GetIndexesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
-    {
-        var indexesAsync = this._adminClient.GetIndexesAsync(cancellationToken).ConfigureAwait(false);
-        await foreach (SearchIndex? index in indexesAsync)
-        {
-            yield return index.Name;
-        }
     }
 
     private static void ValidateSchema(VectorDbSchema schema)

--- a/dotnet/CoreLib/MemoryStorage/DevTools/SimpleVectorDb.cs
+++ b/dotnet/CoreLib/MemoryStorage/DevTools/SimpleVectorDb.cs
@@ -31,7 +31,7 @@ public class SimpleVectorDb : IVectorDb
                 break;
 
             case FileSystemTypes.Volatile:
-                this._fileSystem = VolatileFileSystem.GetInstance(this._log);
+                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, this._log);
                 break;
 
             default:
@@ -46,13 +46,9 @@ public class SimpleVectorDb : IVectorDb
     }
 
     /// <inheritdoc />
-    public async IAsyncEnumerable<string> GetIndexesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public Task<IEnumerable<string>> GetIndexesAsync(CancellationToken cancellationToken = default)
     {
-        List<string> volumes = await this._fileSystem.ListVolumesAsync(cancellationToken);
-        foreach (string volume in volumes)
-        {
-            yield return volume;
-        }
+        return this._fileSystem.ListVolumesAsync(cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/CoreLib/MemoryStorage/DevTools/SimpleVectorDb.cs
+++ b/dotnet/CoreLib/MemoryStorage/DevTools/SimpleVectorDb.cs
@@ -46,6 +46,16 @@ public class SimpleVectorDb : IVectorDb
     }
 
     /// <inheritdoc />
+    public async IAsyncEnumerable<string> GetIndexesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        List<string> volumes = await this._fileSystem.ListVolumesAsync(cancellationToken);
+        foreach (string volume in volumes)
+        {
+            yield return volume;
+        }
+    }
+
+    /// <inheritdoc />
     public async Task<string> UpsertAsync(string indexName, MemoryRecord record, CancellationToken cancellationToken = default)
     {
         await this._fileSystem.WriteFileAsync(indexName, "", EncodeId(record.Id), JsonSerializer.Serialize(record), cancellationToken).ConfigureAwait(false);

--- a/dotnet/CoreLib/MemoryStorage/IVectorDb.cs
+++ b/dotnet/CoreLib/MemoryStorage/IVectorDb.cs
@@ -24,7 +24,7 @@ public interface IVectorDb
     /// </summary>
     /// <param name="cancellationToken"></param>
     /// <returns>List of indexes</returns>
-    IAsyncEnumerable<string> GetIndexesAsync(CancellationToken cancellationToken = default);
+    Task<IEnumerable<string>> GetIndexesAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete an index/collection

--- a/dotnet/CoreLib/MemoryStorage/IVectorDb.cs
+++ b/dotnet/CoreLib/MemoryStorage/IVectorDb.cs
@@ -19,17 +19,21 @@ public interface IVectorDb
         int vectorSize,
         CancellationToken cancellationToken = default);
 
-    // TODO: revisit for custom schemas
-    // /// <summary>
-    // /// Create an index/collection
-    // /// </summary>
-    // /// <param name="indexName">Index/Collection name</param>
-    // /// <param name="schema">Index/Collection schema</param>
-    // /// <param name="cancellationToken">Task cancellation token</param>
-    // Task CreateIndexAsync(
-    //     string indexName,
-    //     VectorDbSchema schema,
-    //     CancellationToken cancellationToken = default);
+    /// <summary>
+    /// List indexes from the vector DB
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns>List of indexes</returns>
+    IAsyncEnumerable<string> GetIndexesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete an index/collection
+    /// </summary>
+    /// <param name="indexName">Index/Collection name</param>
+    /// <param name="cancellationToken">Task cancellation token</param>
+    Task DeleteIndexAsync(
+        string indexName,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Insert/Update a vector + payload
@@ -78,15 +82,6 @@ public interface IVectorDb
         ICollection<MemoryFilter>? filters = null,
         int limit = 1,
         bool withEmbeddings = false,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Delete an index/collection
-    /// </summary>
-    /// <param name="indexName">Index/Collection name</param>
-    /// <param name="cancellationToken">Task cancellation token</param>
-    Task DeleteIndexAsync(
-        string indexName,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/dotnet/CoreLib/MemoryStorage/Qdrant/QdrantMemory.cs
+++ b/dotnet/CoreLib/MemoryStorage/Qdrant/QdrantMemory.cs
@@ -34,6 +34,15 @@ public class QdrantMemory : IVectorDb
     }
 
     /// <inheritdoc />
+    public async Task<IEnumerable<string>> GetIndexesAsync(CancellationToken cancellationToken = default)
+    {
+        return await this._qdrantClient
+            .GetCollectionsAsync(cancellationToken)
+            .ToListAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
     public Task DeleteIndexAsync(
         string indexName,
         CancellationToken cancellationToken = default)

--- a/dotnet/CoreLib/Pipeline/Queue/DevTools/SimpleQueues.cs
+++ b/dotnet/CoreLib/Pipeline/Queue/DevTools/SimpleQueues.cs
@@ -86,7 +86,7 @@ public sealed class SimpleQueues : IQueue
                 break;
 
             case FileSystemTypes.Volatile:
-                this._fileSystem = VolatileFileSystem.GetInstance(this._log);
+                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, this._log);
                 break;
 
             default:

--- a/dotnet/CoreLib/Search/SearchClient.cs
+++ b/dotnet/CoreLib/Search/SearchClient.cs
@@ -45,7 +45,7 @@ public class SearchClient
         if (this._textGenerator == null) { throw new KernelMemoryException("Text generator not configured"); }
     }
 
-    public IAsyncEnumerable<string> ListIndexesAsync(CancellationToken cancellationToken = default)
+    public Task<IEnumerable<string>> ListIndexesAsync(CancellationToken cancellationToken = default)
     {
         return this._vectorDb.GetIndexesAsync(cancellationToken);
     }

--- a/dotnet/CoreLib/Search/SearchClient.cs
+++ b/dotnet/CoreLib/Search/SearchClient.cs
@@ -45,6 +45,11 @@ public class SearchClient
         if (this._textGenerator == null) { throw new KernelMemoryException("Text generator not configured"); }
     }
 
+    public IAsyncEnumerable<string> ListIndexesAsync(CancellationToken cancellationToken = default)
+    {
+        return this._vectorDb.GetIndexesAsync(cancellationToken);
+    }
+
     public async Task<SearchResult> SearchAsync(
         string index,
         string query,

--- a/dotnet/Service/appsettings.json
+++ b/dotnet/Service/appsettings.json
@@ -59,19 +59,19 @@
         // Options: "Disk" or "Volatile". Volatile data is lost after each execution.
         "StorageType": "Volatile",
         // Directory where files are stored.
-        "Directory": "tmp-files"
+        "Directory": "_files"
       },
       "SimpleQueues": {
         // Options: "Disk" or "Volatile". Volatile data is lost after each execution.
         "StorageType": "Volatile",
         // Directory where files are stored.
-        "Directory": "tmp-queues"
+        "Directory": "_queues"
       },
       "SimpleVectorDb": {
         // Options: "Disk" or "Volatile". Volatile data is lost after each execution.
         "StorageType": "Volatile",
         // Directory where files are stored.
-        "Directory": "tmp-vectors"
+        "Directory": "_vectors"
       },
       "AzureBlobs": {
         // "ConnectionString" or "AzureIdentity". For other options see <AzureBlobConfig>.

--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -1,7 +1,7 @@
 ﻿<Project>
     <PropertyGroup>
         <!-- Central version prefix - applies to all nuget packages. -->
-        <Version>0.5.0</Version>
+        <Version>0.6.0</Version>
 
         <!-- Default description and tags. Packages can override. -->
         <Authors>Microsoft</Authors>

--- a/examples/009-dotnet-custom-LLM/appsettings.json
+++ b/examples/009-dotnet-custom-LLM/appsettings.json
@@ -57,19 +57,19 @@
         // Options: "Disk" or "Volatile". Volatile data is lost after each execution.
         "StorageType": "Volatile",
         // Directory where files are stored.
-        "Directory": "tmp-files"
+        "Directory": "_files"
       },
       "SimpleQueues": {
         // Options: "Disk" or "Volatile". Volatile data is lost after each execution.
         "StorageType": "Volatile",
         // Directory where files are stored.
-        "Directory": "tmp-queues"
+        "Directory": "_queues"
       },
       "SimpleVectorDb": {
         // Options: "Disk" or "Volatile". Volatile data is lost after each execution.
         "StorageType": "Volatile",
         // Directory where files are stored.
-        "Directory": "tmp-vectors"
+        "Directory": "_vectors"
       },
       "AzureBlobs": {
         // "ConnectionString" or "AzureIdentity". For other options see <AzureBlobConfig>.

--- a/tests/FunctionalTests/ServerLess/FilteringTest.cs
+++ b/tests/FunctionalTests/ServerLess/FilteringTest.cs
@@ -1,24 +1,18 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-// ReSharper disable InconsistentNaming
-
 using FunctionalTests.TestHelpers;
 using Microsoft.KernelMemory;
-using Microsoft.KernelMemory.ContentStorage.DevTools;
-using Microsoft.KernelMemory.FileSystem.DevTools;
-using Microsoft.KernelMemory.MemoryStorage.DevTools;
 using Xunit.Abstractions;
 
 namespace FunctionalTests.ServerLess;
 
+// ReSharper disable InconsistentNaming
 public class FilteringTest : BaseTestCase
 {
-    private IKernelMemory? _memory = null;
-    private readonly IConfiguration _cfg;
-
-    public FilteringTest(IConfiguration cfg, ITestOutputHelper output) : base(output)
+    public FilteringTest(
+        IConfiguration cfg,
+        ITestOutputHelper output) : base(cfg, output)
     {
-        this._cfg = cfg;
     }
 
     [Theory]
@@ -29,7 +23,7 @@ public class FilteringTest : BaseTestCase
     [InlineData("acs")]
     public async Task ItSupportsASingleFilter(string memoryType)
     {
-        this._memory = this.GetMemory(memoryType);
+        var memory = this.GetMemory(memoryType);
 
         string indexName = Guid.NewGuid().ToString("D");
         const string Id = "file1-NASA-news.pdf";
@@ -37,7 +31,7 @@ public class FilteringTest : BaseTestCase
         const string Found = "spacecraft";
 
         this.Log("Uploading document");
-        await this._memory.ImportDocumentAsync(
+        await memory.ImportDocumentAsync(
             new Document(Id)
                 .AddFile("file1-NASA-news.pdf")
                 .AddTag("type", "news")
@@ -46,44 +40,44 @@ public class FilteringTest : BaseTestCase
             index: indexName,
             steps: Constants.PipelineWithoutSummary);
 
-        while (!await this._memory.IsDocumentReadyAsync(documentId: Id, index: indexName))
+        while (!await memory.IsDocumentReadyAsync(documentId: Id, index: indexName))
         {
             this.Log("Waiting for memory ingestion to complete...");
             await Task.Delay(TimeSpan.FromSeconds(2));
         }
 
         // Simple filter: unknown user cannot see the memory
-        var answer = await this._memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("user", "someone"), index: indexName);
+        var answer = await memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("user", "someone"), index: indexName);
         this.Log(answer.Result);
         Assert.Contains(NotFound, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         // Simple filter: test AND logic: valid type + invalid user
-        answer = await this._memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("type", "news").ByTag("user", "someone"), index: indexName);
+        answer = await memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("type", "news").ByTag("user", "someone"), index: indexName);
         this.Log(answer.Result);
         Assert.Contains(NotFound, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         // Simple filter: test AND logic: invalid type + valid user
-        answer = await this._memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("type", "fact").ByTag("user", "owner"), index: indexName);
+        answer = await memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("type", "fact").ByTag("user", "owner"), index: indexName);
         this.Log(answer.Result);
         Assert.Contains(NotFound, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         // Simple filter: known user can see the memory
-        answer = await this._memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("user", "admin"), index: indexName);
+        answer = await memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("user", "admin"), index: indexName);
         this.Log(answer.Result);
         Assert.Contains(Found, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         // Simple filter: known user can see the memory
-        answer = await this._memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("user", "owner"), index: indexName);
+        answer = await memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("user", "owner"), index: indexName);
         this.Log(answer.Result);
         Assert.Contains(Found, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         // Simple filter: test AND logic with correct values
-        answer = await this._memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("type", "news").ByTag("user", "owner"), index: indexName);
+        answer = await memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("type", "news").ByTag("user", "owner"), index: indexName);
         this.Log(answer.Result);
         Assert.Contains(Found, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         this.Log("Deleting memories extracted from the document");
-        await this._memory.DeleteDocumentAsync(Id, index: indexName);
+        await memory.DeleteDocumentAsync(Id, index: indexName);
     }
 
     [Theory]
@@ -94,7 +88,7 @@ public class FilteringTest : BaseTestCase
     [InlineData("acs")]
     public async Task ItSupportsMultipleFilters(string memoryType)
     {
-        this._memory = this.GetMemory(memoryType);
+        var memory = this.GetMemory(memoryType);
 
         string indexName = Guid.NewGuid().ToString("D");
         const string Id = "file1-NASA-news.pdf";
@@ -102,7 +96,7 @@ public class FilteringTest : BaseTestCase
         const string Found = "spacecraft";
 
         this.Log("Uploading document");
-        await this._memory.ImportDocumentAsync(
+        await memory.ImportDocumentAsync(
             new Document(Id)
                 .AddFile("file1-NASA-news.pdf")
                 .AddTag("type", "news")
@@ -111,14 +105,14 @@ public class FilteringTest : BaseTestCase
             index: indexName,
             steps: Constants.PipelineWithoutSummary);
 
-        while (!await this._memory.IsDocumentReadyAsync(documentId: Id, index: indexName))
+        while (!await memory.IsDocumentReadyAsync(documentId: Id, index: indexName))
         {
             this.Log("Waiting for memory ingestion to complete...");
             await Task.Delay(TimeSpan.FromSeconds(2));
         }
 
         // Multiple filters: unknown users cannot see the memory
-        var answer = await this._memory.AskAsync("What is Orion?", filters: new List<MemoryFilter>
+        var answer = await memory.AskAsync("What is Orion?", filters: new List<MemoryFilter>
         {
             MemoryFilters.ByTag("user", "someone1"),
             MemoryFilters.ByTag("user", "someone2"),
@@ -127,7 +121,7 @@ public class FilteringTest : BaseTestCase
         Assert.Contains(NotFound, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         // Multiple filters: unknown users cannot see the memory even if the type is correct (testing AND logic)
-        answer = await this._memory.AskAsync("What is Orion?", filters: new List<MemoryFilter>
+        answer = await memory.AskAsync("What is Orion?", filters: new List<MemoryFilter>
         {
             MemoryFilters.ByTag("user", "someone1").ByTag("type", "news"),
             MemoryFilters.ByTag("user", "someone2").ByTag("type", "news"),
@@ -136,7 +130,7 @@ public class FilteringTest : BaseTestCase
         Assert.Contains(NotFound, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         // Multiple filters: AND + OR logic works
-        answer = await this._memory.AskAsync("What is Orion?", filters: new List<MemoryFilter>
+        answer = await memory.AskAsync("What is Orion?", filters: new List<MemoryFilter>
         {
             MemoryFilters.ByTag("user", "someone1").ByTag("type", "news"),
             MemoryFilters.ByTag("user", "admin").ByTag("type", "fact"),
@@ -145,7 +139,7 @@ public class FilteringTest : BaseTestCase
         Assert.Contains(NotFound, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         // Multiple filters: OR logic works
-        answer = await this._memory.AskAsync("What is Orion?", filters: new List<MemoryFilter>
+        answer = await memory.AskAsync("What is Orion?", filters: new List<MemoryFilter>
         {
             MemoryFilters.ByTag("user", "someone1"),
             MemoryFilters.ByTag("user", "admin"),
@@ -154,7 +148,7 @@ public class FilteringTest : BaseTestCase
         Assert.Contains(Found, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         // Multiple filters: OR logic works
-        answer = await this._memory.AskAsync("What is Orion?", filters: new List<MemoryFilter>
+        answer = await memory.AskAsync("What is Orion?", filters: new List<MemoryFilter>
         {
             MemoryFilters.ByTag("user", "someone1").ByTag("type", "news"),
             MemoryFilters.ByTag("user", "admin").ByTag("type", "news"),
@@ -163,7 +157,7 @@ public class FilteringTest : BaseTestCase
         Assert.Contains(Found, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         this.Log("Deleting memories extracted from the document");
-        await this._memory.DeleteDocumentAsync(Id, index: indexName);
+        await memory.DeleteDocumentAsync(Id, index: indexName);
     }
 
     [Theory]
@@ -174,14 +168,14 @@ public class FilteringTest : BaseTestCase
     [InlineData("acs")]
     public async Task ItIgnoresEmptyFilters(string memoryType)
     {
-        this._memory = this.GetMemory(memoryType);
+        var memory = this.GetMemory(memoryType);
 
         string indexName = Guid.NewGuid().ToString("D");
         const string Id = "file1-NASA-news.pdf";
         const string Found = "spacecraft";
 
         this.Log("Uploading document");
-        await this._memory.ImportDocumentAsync(
+        await memory.ImportDocumentAsync(
             new Document(Id)
                 .AddFile("file1-NASA-news.pdf")
                 .AddTag("type", "news")
@@ -190,71 +184,23 @@ public class FilteringTest : BaseTestCase
             index: indexName,
             steps: Constants.PipelineWithoutSummary);
 
-        while (!await this._memory.IsDocumentReadyAsync(documentId: Id, index: indexName))
+        while (!await memory.IsDocumentReadyAsync(documentId: Id, index: indexName))
         {
             this.Log("Waiting for memory ingestion to complete...");
             await Task.Delay(TimeSpan.FromSeconds(2));
         }
 
         // Simple filter: empty filters have no impact
-        var answer = await this._memory.AskAsync("What is Orion?", filter: new(), index: indexName);
+        var answer = await memory.AskAsync("What is Orion?", filter: new(), index: indexName);
         this.Log(answer.Result);
         Assert.Contains(Found, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         // Multiple filters: empty filters have no impact
-        answer = await this._memory.AskAsync("What is Orion?", filters: new List<MemoryFilter> { new() }, index: indexName);
+        answer = await memory.AskAsync("What is Orion?", filters: new List<MemoryFilter> { new() }, index: indexName);
         this.Log(answer.Result);
         Assert.Contains(Found, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         this.Log("Deleting memories extracted from the document");
-        await this._memory.DeleteDocumentAsync(Id, index: indexName);
-    }
-
-    private IKernelMemory GetMemory(string memoryType)
-    {
-        var openAIKey = Env.Var("OPENAI_API_KEY");
-
-        switch (memoryType)
-        {
-            case "default":
-                return new KernelMemoryBuilder()
-                    .WithOpenAIDefaults(openAIKey)
-                    .BuildServerlessClient();
-
-            case "simple_on_disk":
-                return new KernelMemoryBuilder()
-                    .WithOpenAIDefaults(openAIKey)
-                    .WithSimpleVectorDb(new SimpleVectorDbConfig { Directory = "_vectors", StorageType = FileSystemTypes.Disk })
-                    .WithSimpleFileStorage(new SimpleFileStorageConfig { Directory = "_files", StorageType = FileSystemTypes.Disk })
-                    .BuildServerlessClient();
-
-            case "simple_volatile":
-                return new KernelMemoryBuilder()
-                    .WithOpenAIDefaults(openAIKey)
-                    .WithSimpleVectorDb(new SimpleVectorDbConfig { StorageType = FileSystemTypes.Volatile })
-                    .WithSimpleFileStorage(new SimpleFileStorageConfig { StorageType = FileSystemTypes.Volatile })
-                    .BuildServerlessClient();
-
-            case "qdrant":
-                var qdrantEndpoint = this._cfg.GetSection("Services").GetSection("Qdrant").GetValue<string>("Endpoint");
-                Assert.False(string.IsNullOrEmpty(qdrantEndpoint));
-                return new KernelMemoryBuilder()
-                    .WithOpenAIDefaults(openAIKey)
-                    .WithQdrant(qdrantEndpoint)
-                    .BuildServerlessClient();
-
-            case "acs":
-                var acsEndpoint = this._cfg.GetSection("Services").GetSection("AzureCognitiveSearch").GetValue<string>("Endpoint");
-                var acsKey = this._cfg.GetSection("Services").GetSection("AzureCognitiveSearch").GetValue<string>("APIKey");
-                Assert.False(string.IsNullOrEmpty(acsEndpoint));
-                Assert.False(string.IsNullOrEmpty(acsKey));
-                return new KernelMemoryBuilder()
-                    .WithOpenAIDefaults(openAIKey)
-                    .WithAzureCognitiveSearch(acsEndpoint, acsKey)
-                    .BuildServerlessClient();
-
-            default:
-                throw new ArgumentOutOfRangeException($"{memoryType} not supported");
-        }
+        await memory.DeleteDocumentAsync(Id, index: indexName);
     }
 }

--- a/tests/FunctionalTests/ServerLess/ImportFilesTest.cs
+++ b/tests/FunctionalTests/ServerLess/ImportFilesTest.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-// ReSharper disable InconsistentNaming
-
 using System.Reflection;
 using FunctionalTests.TestHelpers;
 using Microsoft.KernelMemory;
@@ -12,12 +10,15 @@ using Xunit.Abstractions;
 
 namespace FunctionalTests.ServerLess;
 
+// ReSharper disable InconsistentNaming
 public class ImportFilesTest : BaseTestCase
 {
     private readonly IKernelMemory _memory;
     private readonly string? _fixturesPath;
 
-    public ImportFilesTest(ITestOutputHelper output) : base(output)
+    public ImportFilesTest(
+        IConfiguration cfg,
+        ITestOutputHelper output) : base(cfg, output)
     {
         this._fixturesPath = FindFixturesDir();
         Assert.NotNull(this._fixturesPath);

--- a/tests/FunctionalTests/ServerLess/IndexDeletionTest.cs
+++ b/tests/FunctionalTests/ServerLess/IndexDeletionTest.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-// ReSharper disable InconsistentNaming
-
 using FunctionalTests.TestHelpers;
 using Microsoft.KernelMemory;
 using Microsoft.KernelMemory.ContentStorage.DevTools;
@@ -11,9 +9,14 @@ using Xunit.Abstractions;
 
 namespace FunctionalTests.ServerLess;
 
+// ReSharper disable InconsistentNaming
 public class IndexDeletionTest : BaseTestCase
 {
-    public IndexDeletionTest(ITestOutputHelper output) : base(output) { }
+    public IndexDeletionTest(
+        IConfiguration cfg,
+        ITestOutputHelper output) : base(cfg, output)
+    {
+    }
 
     [Fact]
     public async Task ItDeletesSimpleVectorDbIndexes()

--- a/tests/FunctionalTests/ServerLess/IndexListTest.cs
+++ b/tests/FunctionalTests/ServerLess/IndexListTest.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using FunctionalTests.TestHelpers;
+using Microsoft.KernelMemory;
+using Xunit.Abstractions;
+
+namespace FunctionalTests.ServerLess;
+
+// ReSharper disable InconsistentNaming
+public class IndexListTest : BaseTestCase
+{
+    public IndexListTest(
+        IConfiguration cfg,
+        ITestOutputHelper output) : base(cfg, output)
+    {
+    }
+
+    [Theory]
+    [InlineData("default")]
+    [InlineData("simple_on_disk")]
+    [InlineData("simple_volatile")]
+    [InlineData("qdrant")]
+    [InlineData("acs")]
+    public async Task ItListsIndexes(string memoryType)
+    {
+        // Arrange
+        var memory = this.GetMemory(memoryType);
+        string indexName1 = Guid.NewGuid().ToString("D");
+        string indexName2 = Guid.NewGuid().ToString("D");
+        Console.WriteLine("Index 1:" + indexName1);
+        Console.WriteLine("Index 2:" + indexName2);
+        await memory.ImportTextAsync("text1", index: indexName1, steps: Constants.PipelineWithoutSummary);
+        await memory.ImportTextAsync("text2", index: indexName2, steps: Constants.PipelineWithoutSummary);
+
+        // Act
+        List<IndexDetails> list = (await memory.ListIndexesAsync()).ToList();
+        Console.WriteLine("Indexes found:");
+        foreach (var index in list)
+        {
+            Console.WriteLine(" - " + index.Name);
+        }
+
+        // Clean up before exceptions can occur
+        await memory.DeleteIndexAsync(indexName1);
+        await memory.DeleteIndexAsync(indexName2);
+
+        // Assert
+        Assert.True(list.Any(x => x.Name == indexName1));
+        Assert.True(list.Any(x => x.Name == indexName2));
+    }
+}

--- a/tests/FunctionalTests/Service/DocumentUploadTest.cs
+++ b/tests/FunctionalTests/Service/DocumentUploadTest.cs
@@ -1,18 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-// ReSharper disable InconsistentNaming
-
 using FunctionalTests.TestHelpers;
 using Microsoft.KernelMemory;
 using Xunit.Abstractions;
 
 namespace FunctionalTests.Service;
 
+// ReSharper disable InconsistentNaming
 public class DocumentUploadTest : BaseTestCase
 {
     private readonly IKernelMemory _memory;
 
-    public DocumentUploadTest(ITestOutputHelper output) : base(output)
+    public DocumentUploadTest(
+        IConfiguration cfg,
+        ITestOutputHelper output) : base(cfg, output)
     {
         this._memory = KernelMemoryBuilder.BuildWebClient("http://127.0.0.1:9001/");
     }

--- a/tests/FunctionalTests/Service/FilteringTest.cs
+++ b/tests/FunctionalTests/Service/FilteringTest.cs
@@ -1,18 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-// ReSharper disable InconsistentNaming
-
 using FunctionalTests.TestHelpers;
 using Microsoft.KernelMemory;
 using Xunit.Abstractions;
 
 namespace FunctionalTests.Service;
 
+// ReSharper disable InconsistentNaming
 public class FilteringTest : BaseTestCase
 {
     private readonly IKernelMemory _memory;
 
-    public FilteringTest(ITestOutputHelper output) : base(output)
+    public FilteringTest(
+        IConfiguration cfg,
+        ITestOutputHelper output) : base(cfg, output)
     {
         this._memory = KernelMemoryBuilder.BuildWebClient("http://127.0.0.1:9001/");
     }

--- a/tests/FunctionalTests/Service/ImportFilesTest.cs
+++ b/tests/FunctionalTests/Service/ImportFilesTest.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-// ReSharper disable InconsistentNaming
-
 using System.Reflection;
 using FunctionalTests.TestHelpers;
 using Microsoft.KernelMemory;
@@ -9,12 +7,15 @@ using Xunit.Abstractions;
 
 namespace FunctionalTests.Service;
 
+// ReSharper disable InconsistentNaming
 public class ImportFilesTest : BaseTestCase
 {
     private readonly IKernelMemory _memory;
     private readonly string? _fixturesPath;
 
-    public ImportFilesTest(ITestOutputHelper output) : base(output)
+    public ImportFilesTest(
+        IConfiguration cfg,
+        ITestOutputHelper output) : base(cfg, output)
     {
         this._fixturesPath = FindFixturesDir();
         Assert.NotNull(this._fixturesPath);

--- a/tests/FunctionalTests/Service/IndexListTest.cs
+++ b/tests/FunctionalTests/Service/IndexListTest.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using FunctionalTests.TestHelpers;
+using Microsoft.KernelMemory;
+using Xunit.Abstractions;
+
+namespace FunctionalTests.Service;
+
+// ReSharper disable InconsistentNaming
+public class IndexListTest : BaseTestCase
+{
+    private readonly IKernelMemory _memory;
+
+    public IndexListTest(
+        IConfiguration cfg,
+        ITestOutputHelper output) : base(cfg, output)
+    {
+        this._memory = KernelMemoryBuilder.BuildWebClient("http://127.0.0.1:9001/");
+    }
+
+    [Fact]
+    public async Task ItListsIndexes()
+    {
+        // Arrange
+        string indexName1 = Guid.NewGuid().ToString("D");
+        string indexName2 = Guid.NewGuid().ToString("D");
+        Console.WriteLine("Index 1:" + indexName1);
+        Console.WriteLine("Index 2:" + indexName2);
+        string id1 = await this._memory.ImportTextAsync("text1", index: indexName1, steps: Constants.PipelineWithoutSummary);
+        string id2 = await this._memory.ImportTextAsync("text2", index: indexName2, steps: Constants.PipelineWithoutSummary);
+
+        while (!await this._memory.IsDocumentReadyAsync(documentId: id1, index: indexName1))
+        {
+            this.Log("Waiting for memory ingestion to complete...");
+            await Task.Delay(TimeSpan.FromSeconds(2));
+        }
+
+        while (!await this._memory.IsDocumentReadyAsync(documentId: id2, index: indexName2))
+        {
+            this.Log("Waiting for memory ingestion to complete...");
+            await Task.Delay(TimeSpan.FromSeconds(2));
+        }
+
+        // Act
+        List<IndexDetails> list = (await this._memory.ListIndexesAsync()).ToList();
+        Console.WriteLine("Indexes found:");
+        foreach (var index in list)
+        {
+            Console.WriteLine(" - " + index.Name);
+        }
+
+        // Clean up before exceptions can occur
+        await this._memory.DeleteIndexAsync(indexName1);
+        await this._memory.DeleteIndexAsync(indexName2);
+
+        // Assert
+        Assert.True(list.Any(x => x.Name == indexName1));
+        Assert.True(list.Any(x => x.Name == indexName2));
+    }
+}

--- a/tests/FunctionalTests/TestHelpers/BaseTestCase.cs
+++ b/tests/FunctionalTests/TestHelpers/BaseTestCase.cs
@@ -1,17 +1,71 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using Microsoft.KernelMemory;
+using Microsoft.KernelMemory.ContentStorage.DevTools;
+using Microsoft.KernelMemory.FileSystem.DevTools;
+using Microsoft.KernelMemory.MemoryStorage.DevTools;
 using Xunit.Abstractions;
 
 namespace FunctionalTests.TestHelpers;
 
 public abstract class BaseTestCase : IDisposable
 {
+    private readonly IConfiguration _cfg;
     private readonly RedirectConsole _output;
 
-    protected BaseTestCase(ITestOutputHelper output)
+    protected BaseTestCase(IConfiguration cfg, ITestOutputHelper output)
     {
+        this._cfg = cfg;
         this._output = new RedirectConsole(output);
         Console.SetOut(this._output);
+    }
+
+    protected IKernelMemory GetMemory(string memoryType)
+    {
+        var openAIKey = Env.Var("OPENAI_API_KEY");
+
+        switch (memoryType)
+        {
+            case "default":
+                return new KernelMemoryBuilder()
+                    .WithOpenAIDefaults(openAIKey)
+                    .BuildServerlessClient();
+
+            case "simple_on_disk":
+                return new KernelMemoryBuilder()
+                    .WithOpenAIDefaults(openAIKey)
+                    .WithSimpleVectorDb(new SimpleVectorDbConfig { Directory = "_vectors", StorageType = FileSystemTypes.Disk })
+                    .WithSimpleFileStorage(new SimpleFileStorageConfig { Directory = "_files", StorageType = FileSystemTypes.Disk })
+                    .BuildServerlessClient();
+
+            case "simple_volatile":
+                return new KernelMemoryBuilder()
+                    .WithOpenAIDefaults(openAIKey)
+                    .WithSimpleVectorDb(new SimpleVectorDbConfig { StorageType = FileSystemTypes.Volatile })
+                    .WithSimpleFileStorage(new SimpleFileStorageConfig { StorageType = FileSystemTypes.Volatile })
+                    .BuildServerlessClient();
+
+            case "qdrant":
+                var qdrantEndpoint = this._cfg.GetSection("Services").GetSection("Qdrant").GetValue<string>("Endpoint");
+                Assert.False(string.IsNullOrEmpty(qdrantEndpoint));
+                return new KernelMemoryBuilder()
+                    .WithOpenAIDefaults(openAIKey)
+                    .WithQdrant(qdrantEndpoint)
+                    .BuildServerlessClient();
+
+            case "acs":
+                var acsEndpoint = this._cfg.GetSection("Services").GetSection("AzureCognitiveSearch").GetValue<string>("Endpoint");
+                var acsKey = this._cfg.GetSection("Services").GetSection("AzureCognitiveSearch").GetValue<string>("APIKey");
+                Assert.False(string.IsNullOrEmpty(acsEndpoint));
+                Assert.False(string.IsNullOrEmpty(acsKey));
+                return new KernelMemoryBuilder()
+                    .WithOpenAIDefaults(openAIKey)
+                    .WithAzureCognitiveSearch(acsEndpoint, acsKey)
+                    .BuildServerlessClient();
+
+            default:
+                throw new ArgumentOutOfRangeException($"{memoryType} not supported");
+        }
     }
 
     public void Dispose()


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

Allow to list the indexes, for admin tools, and to apply future semantic logic to index selection.

## High level description (Approach, Design)

New API to retrieve the list of indexes.

Other:
* Fix volatile memory implementation not to leak volumes between clients using a different root directory