### PR TITLE
Refactor SHA256 in CoreLib

### DIFF
--- a/dotnet/CoreLib/Extensions/BinaryDataExtensions.cs
+++ b/dotnet/CoreLib/Extensions/BinaryDataExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.KernelMemory.Extensions;
 
 public static class BinaryDataExtensions
 {
-    public static string ToSHA256(this BinaryData binaryData)
+    public static string CalculateSHA256(this BinaryData binaryData)
     {
         byte[] byteArray = SHA256.HashData(binaryData.ToMemory().Span);
         return Convert.ToHexString(byteArray).ToLowerInvariant();

--- a/dotnet/CoreLib/Extensions/BinaryDataExtensions.cs
+++ b/dotnet/CoreLib/Extensions/BinaryDataExtensions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Security.Cryptography;
+
+namespace Microsoft.KernelMemory.Extensions;
+
+public static class BinaryDataExtensions
+{
+    public static string ToSHA256(this BinaryData binaryData)
+    {
+        byte[] byteArray = SHA256.HashData(binaryData.ToMemory().Span);
+        return Convert.ToHexString(byteArray).ToLowerInvariant();
+    }
+}

--- a/dotnet/CoreLib/Handlers/SummarizationHandler.cs
+++ b/dotnet/CoreLib/Handlers/SummarizationHandler.cs
@@ -104,7 +104,7 @@ public class SummarizationHandler : IPipelineStepHandler
                                 Size = summary.Length,
                                 MimeType = MimeTypes.PlainText,
                                 ArtifactType = DataPipeline.ArtifactTypes.SyntheticData,
-                                ContentSHA256 = summaryData.ToSHA256(),
+                                ContentSHA256 = summaryData.CalculateSHA256(),
                             });
                         }
 

--- a/dotnet/CoreLib/Handlers/SummarizationHandler.cs
+++ b/dotnet/CoreLib/Handlers/SummarizationHandler.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.AI;
 using Microsoft.KernelMemory.AI.Tokenizers.GPT3;
 using Microsoft.KernelMemory.Diagnostics;
+using Microsoft.KernelMemory.Extensions;
 using Microsoft.KernelMemory.Pipeline;
 using Microsoft.KernelMemory.Prompts;
 using Microsoft.SemanticKernel.Text;
@@ -92,8 +92,9 @@ public class SummarizationHandler : IPipelineStepHandler
                         (string summary, bool success) = await this.SummarizeAsync(content).ConfigureAwait(false);
                         if (success)
                         {
+                            var summaryData = new BinaryData(summary);
                             var destFile = uploadedFile.GetHandlerOutputFileName(this);
-                            await this._orchestrator.WriteFileAsync(pipeline, destFile, new BinaryData(summary), cancellationToken).ConfigureAwait(false);
+                            await this._orchestrator.WriteFileAsync(pipeline, destFile, summaryData, cancellationToken).ConfigureAwait(false);
 
                             summaryFiles.Add(destFile, new DataPipeline.GeneratedFileDetails
                             {
@@ -103,7 +104,7 @@ public class SummarizationHandler : IPipelineStepHandler
                                 Size = summary.Length,
                                 MimeType = MimeTypes.PlainText,
                                 ArtifactType = DataPipeline.ArtifactTypes.SyntheticData,
-                                ContentSHA256 = CalculateSHA256(summary),
+                                ContentSHA256 = summaryData.ToSHA256(),
                             });
                         }
 
@@ -195,11 +196,5 @@ public class SummarizationHandler : IPipelineStepHandler
         }
 
         return (content, true);
-    }
-
-    private static string CalculateSHA256(string value)
-    {
-        byte[] byteArray = SHA256.HashData(Encoding.UTF8.GetBytes(value));
-        return Convert.ToHexString(byteArray).ToLowerInvariant();
     }
 }

--- a/dotnet/CoreLib/Handlers/TextPartitioningHandler.cs
+++ b/dotnet/CoreLib/Handlers/TextPartitioningHandler.cs
@@ -125,7 +125,7 @@ public class TextPartitioningHandler : IPipelineStepHandler
                         Size = text.Length,
                         MimeType = MimeTypes.PlainText,
                         ArtifactType = DataPipeline.ArtifactTypes.TextPartition,
-                        ContentSHA256 = textData.ToSHA256(),
+                        ContentSHA256 = textData.CalculateSHA256(),
                     };
                     newFiles.Add(destFile, destFileDetails);
                     destFileDetails.MarkProcessedBy(this);

--- a/dotnet/CoreLib/Handlers/TextPartitioningHandler.cs
+++ b/dotnet/CoreLib/Handlers/TextPartitioningHandler.cs
@@ -2,13 +2,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.AI.Tokenizers.GPT3;
 using Microsoft.KernelMemory.Diagnostics;
+using Microsoft.KernelMemory.Extensions;
 using Microsoft.KernelMemory.Pipeline;
 using Microsoft.SemanticKernel.Text;
 
@@ -110,12 +109,13 @@ public class TextPartitioningHandler : IPipelineStepHandler
                 for (int index = 0; index < paragraphs.Count; index++)
                 {
                     string text = paragraphs[index];
+                    BinaryData textData = new(text);
 
                     int gpt3TokenCount = GPT3Tokenizer.Encode(text).Count;
                     this._log.LogDebug("Partition size: {0} tokens", gpt3TokenCount);
 
                     var destFile = uploadedFile.GetPartitionFileName(index);
-                    await this._orchestrator.WriteFileAsync(pipeline, destFile, new BinaryData(text), cancellationToken).ConfigureAwait(false);
+                    await this._orchestrator.WriteFileAsync(pipeline, destFile, textData, cancellationToken).ConfigureAwait(false);
 
                     var destFileDetails = new DataPipeline.GeneratedFileDetails
                     {
@@ -125,7 +125,7 @@ public class TextPartitioningHandler : IPipelineStepHandler
                         Size = text.Length,
                         MimeType = MimeTypes.PlainText,
                         ArtifactType = DataPipeline.ArtifactTypes.TextPartition,
-                        ContentSHA256 = CalculateSHA256(text),
+                        ContentSHA256 = textData.ToSHA256(),
                     };
                     newFiles.Add(destFile, destFileDetails);
                     destFileDetails.MarkProcessedBy(this);
@@ -142,11 +142,5 @@ public class TextPartitioningHandler : IPipelineStepHandler
         }
 
         return (true, pipeline);
-    }
-
-    private static string CalculateSHA256(string value)
-    {
-        byte[] byteArray = SHA256.HashData(Encoding.UTF8.GetBytes(value));
-        return Convert.ToHexString(byteArray).ToLowerInvariant();
     }
 }

--- a/tests/UnitTests/Extensions/BinaryDataExtensionsTest.cs
+++ b/tests/UnitTests/Extensions/BinaryDataExtensionsTest.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.KernelMemory.Extensions;
+using UnitTests.TestHelpers;
+using Xunit.Abstractions;
+
+namespace UnitTests.Extensions;
+
+// ReSharper disable StringLiteralTypo
+public class BinaryDataExtensionsTest : BaseTestCase
+{
+    public BinaryDataExtensionsTest(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void ItHashesDataConsistently()
+    {
+        // Act
+        var hash1 = new BinaryData("24362 34 dsf.gs/.df gsdfg sd").CalculateSHA256();
+        Console.WriteLine(hash1);
+
+        var hash2 = new BinaryData("DGFHE35§£¢∞§#V%EFH F 2463456......").CalculateSHA256();
+        Console.WriteLine(hash2);
+
+        var hash3 = new BinaryData("").CalculateSHA256();
+        Console.WriteLine(hash3);
+
+        // Assert
+        Assert.Equal("ffa7270c6d29bc7c76b82e2c6c0c94741d09db242245ecc63aa3824bac79b9b6", hash1);
+        Assert.Equal("789ecf31d032c493a98bd83c1ac53ae3f93d0dd530e2a4495aeb911f72b487b0", hash2);
+        Assert.Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hash3);
+    }
+}


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)
Optimize the hashing logic in some of the pipeline handlers.

## High level description (Approach, Design)
- Add `BinaryDataExtensions.ToSHA256`
- Refactor the SHA256 calculation to use `ToMemory` on the `BinaryData` object which removes an array allocation