### PR TITLE
Remove ACS KNN increase when filtering

### DIFF
--- a/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/README.md
+++ b/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/README.md
@@ -1,9 +1,4 @@
 ﻿Notes about Azure Cognitive Search:
 
-* Pre-filtering is not supported yet, and when searching using both vector
-  search and filters, vector search is applying before applying the remaining
-  filters. This requires clients to increase the value of "limit" ("top")
-  to allow for vectors to be filtered out without leaving an empty result set.
-
 * Hybrid search, combining vector search with full text search, is not
   implemented at this stage.


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)
Cognitive Search API version `2023-10-01-Preview` defaults to `preFilter`. This makes the previously required KNN increase redundant and unnecessarily retrieving a larger than required result set.

From the [docs](https://learn.microsoft.com/en-us/azure/search/vector-search-how-to-query?tabs=query-2023-10-01-Preview%2Cfilter-2023-10-01-Preview#vector-query-with-filter):
```text
In 2023-10-01-Preview, you can apply a filter before or after query execution. The default is pre-query. If you want post-query filtering instead, set the vectorFiltermode parameter.

In 2023-07-01-Preview, a filter in a pure vector query is processed as a post-query operation.
```

Fixes #92.
Fixes #125.

## High level description (Approach, Design)
- Remove the KNN increase when filtering
- Set `VectorFilterMode` to `PreFilter` (default) for clarity