### PR TITLE
Fix intermittent xunit errors

### DIFF
--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -1,7 +1,7 @@
 ﻿<Project>
     <PropertyGroup>
         <!-- Central version prefix - applies to all nuget packages. -->
-        <Version>0.6.0</Version>
+        <Version>0.7.0</Version>
 
         <!-- Default description and tags. Packages can override. -->
         <Authors>Microsoft</Authors>

--- a/tests/FunctionalTests/TestHelpers/RedirectConsole.cs
+++ b/tests/FunctionalTests/TestHelpers/RedirectConsole.cs
@@ -297,11 +297,25 @@ internal sealed class RedirectConsole : TextWriter
     {
         if (string.IsNullOrEmpty(s)) { return; }
 
-        this._output.WriteLine(s);
+        try
+        {
+            this._output.WriteLine(s);
+        }
+        catch (InvalidOperationException e) when (e.Message.Contains("no currently active test"))
+        {
+            // NOOP: Xunit thread out of scope
+        }
     }
 
     private void Line(string? s = null)
     {
-        this._output.WriteLine(s);
+        try
+        {
+            this._output.WriteLine(s);
+        }
+        catch (InvalidOperationException e) when (e.Message.Contains("no currently active test"))
+        {
+            // NOOP: Xunit thread out of scope
+        }
     }
 }


### PR DESCRIPTION
Fix some errors occurring when running xunit tests with multi-threads and output redirection. The console output sometimes is collected when a test already completed, leading to an InvalidOperationException

