### PR TITLE
Remove summary step from the default pipeline

### DIFF
--- a/dotnet/ClientLib/Constants.cs
+++ b/dotnet/ClientLib/Constants.cs
@@ -58,6 +58,7 @@ public static class Constants
     public const string DeleteIndexPipelineStepName = "private_delete_index";
 
     // Pipeline steps
-    public static readonly string[] DefaultPipeline = { "extract", "partition", "gen_embeddings", "save_embeddings", "summarize", "gen_embeddings", "save_embeddings" };
+    public static readonly string[] DefaultPipeline = { "extract", "partition", "gen_embeddings", "save_embeddings" };
     public static readonly string[] PipelineWithoutSummary = { "extract", "partition", "gen_embeddings", "save_embeddings" };
+    public static readonly string[] PipelineWithSummary = { "extract", "partition", "gen_embeddings", "save_embeddings", "summarize", "gen_embeddings", "save_embeddings" };
 }

--- a/dotnet/CoreLib/Configuration/KernelMemoryConfig.cs
+++ b/dotnet/CoreLib/Configuration/KernelMemoryConfig.cs
@@ -43,6 +43,8 @@ public class KernelMemoryConfig
         /// * partition: spit the text in small chunks
         /// * gen_embeddings: generate embeddings for each chunk
         /// * save_embeddings: save the embeddings
+        ///
+        /// Other steps not included by default:
         /// * summarize: use LLMs to summarize the document (this step can be slow, so it's meant to run after gen_embeddings/save_embeddings)
         /// * gen_embeddings: generate embeddings for new chunks (e.g. the summary)
         /// * save_embeddings: save new embeddings

--- a/dotnet/Service/README.md
+++ b/dotnet/Service/README.md
@@ -85,7 +85,7 @@ The service depends on three main components:
   [GPT3.5 and GPT4](https://platform.openai.com/docs/models/overview)
   which we recommend. The number of tokens available is also an important
   factor affecting summarization and answer generations, so you might
-  get better results with 16k and 32k models.
+  get better results with 16k, 32k and bigger models.
 
 
 * **Vector storage**: service used to persist embeddings. Currently, the

--- a/dotnet/Service/appsettings.json
+++ b/dotnet/Service/appsettings.json
@@ -43,9 +43,6 @@
         // "partition",
         // "gen_embeddings",
         // "save_embeddings",
-        // "summarize",       // summarize after gen/save embeddings, because it can take long
-        // "gen_embeddings",  // gen embeddings for the summary
-        // "save_embeddings"  // save the summary embeddings
       ]
     },
     "Retrieval": {

--- a/examples/009-dotnet-custom-LLM/appsettings.json
+++ b/examples/009-dotnet-custom-LLM/appsettings.json
@@ -41,9 +41,6 @@
         // "partition",
         // "gen_embeddings",
         // "save_embeddings",
-        // "summarize",       // summarize after gen/save embeddings, because it can take long
-        // "gen_embeddings",  // gen embeddings for the summary
-        // "save_embeddings"  // save the summary embeddings
       ]
     },
     "Retrieval": {

--- a/tests/FunctionalTests/ServerLess/FilteringTest.cs
+++ b/tests/FunctionalTests/ServerLess/FilteringTest.cs
@@ -78,6 +78,9 @@ public class FilteringTest : BaseTestCase
 
         this.Log("Deleting memories extracted from the document");
         await memory.DeleteDocumentAsync(Id, index: indexName);
+
+        this.Log("Deleting index");
+        await memory.DeleteIndexAsync(indexName);
     }
 
     [Theory]
@@ -158,6 +161,9 @@ public class FilteringTest : BaseTestCase
 
         this.Log("Deleting memories extracted from the document");
         await memory.DeleteDocumentAsync(Id, index: indexName);
+
+        this.Log("Deleting index");
+        await memory.DeleteIndexAsync(indexName);
     }
 
     [Theory]
@@ -202,5 +208,8 @@ public class FilteringTest : BaseTestCase
 
         this.Log("Deleting memories extracted from the document");
         await memory.DeleteDocumentAsync(Id, index: indexName);
+
+        this.Log("Deleting index");
+        await memory.DeleteIndexAsync(indexName);
     }
 }


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

The summary step currently doesn't bring much value to RAG while it slows down ingestion by default.

## High level description (Approach, Design)

Remove the summarization step fomr the default pipeline, letting users choose when to use it.

This helps also new users trying KM for the first time, avoiding the long time required to generate summaries.
