### PR TITLE
Update kernel-memory to Current Semantic-Kernel Package (beta5)

### DIFF
--- a/dotnet/CoreLib/CoreLib.csproj
+++ b/dotnet/CoreLib/CoreLib.csproj
@@ -34,11 +34,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SemanticKernel.Core" VersionOverride="1.0.0-beta4">
+        <PackageReference Include="Microsoft.SemanticKernel.Core" VersionOverride="1.0.0-beta5">
             <PrivateAssets>none</PrivateAssets>
             <IncludeAssets>all</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" VersionOverride="1.0.0-beta4">
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" VersionOverride="1.0.0-beta5">
             <PrivateAssets>none</PrivateAssets>
             <IncludeAssets>all</IncludeAssets>
         </PackageReference>

--- a/examples/200-dotnet-nl2sql/nl2sql.library/Nl2Sql.Library.csproj
+++ b/examples/200-dotnet-nl2sql/nl2sql.library/Nl2Sql.Library.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.SqlClient" />
-        <PackageReference Include="Microsoft.SemanticKernel" VersionOverride="1.0.0-beta4" />
+        <PackageReference Include="Microsoft.SemanticKernel" VersionOverride="1.0.0-beta5" />
         <PackageReference Include="System.Linq.Async" />
     </ItemGroup>
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

SemanticKernel 1.0.0-beta5 was published during the update to beta4.  Delta is small.

## High level description (Approach, Design)

