### PR TITLE
Update to SK 1.0.0-beta6

### DIFF
--- a/dotnet/CoreLib/AI/AzureOpenAI/DependencyInjection.cs
+++ b/dotnet/CoreLib/AI/AzureOpenAI/DependencyInjection.cs
@@ -35,7 +35,7 @@ public static partial class DependencyInjection
         {
             case AzureOpenAIConfig.AuthTypes.AzureIdentity:
                 return services
-                    .AddSingleton<ITextEmbeddingGeneration>(serviceProvider => new AzureTextEmbeddingGeneration(
+                    .AddSingleton<ITextEmbeddingGeneration>(serviceProvider => new AzureOpenAITextEmbeddingGeneration(
                         modelId: config.Deployment,
                         endpoint: config.Endpoint,
                         credential: new DefaultAzureCredential(),
@@ -43,7 +43,7 @@ public static partial class DependencyInjection
 
             case AzureOpenAIConfig.AuthTypes.APIKey:
                 return services
-                    .AddSingleton<ITextEmbeddingGeneration>(serviceProvider => new AzureTextEmbeddingGeneration(
+                    .AddSingleton<ITextEmbeddingGeneration>(serviceProvider => new AzureOpenAITextEmbeddingGeneration(
                         modelId: config.Deployment,
                         endpoint: config.Endpoint,
                         apiKey: config.APIKey,

--- a/dotnet/CoreLib/CoreLib.csproj
+++ b/dotnet/CoreLib/CoreLib.csproj
@@ -34,11 +34,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SemanticKernel.Core" VersionOverride="1.0.0-beta5">
+        <PackageReference Include="Microsoft.SemanticKernel.Core" VersionOverride="1.0.0-beta6">
             <PrivateAssets>none</PrivateAssets>
             <IncludeAssets>all</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" VersionOverride="1.0.0-beta5">
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" VersionOverride="1.0.0-beta6">
             <PrivateAssets>none</PrivateAssets>
             <IncludeAssets>all</IncludeAssets>
         </PackageReference>

--- a/examples/200-dotnet-nl2sql/nl2sql.console/KernelFactory.cs
+++ b/examples/200-dotnet-nl2sql/nl2sql.console/KernelFactory.cs
@@ -64,7 +64,7 @@ internal static class KernelFactory
                     configuration.GetValue<string>(SettingNameAzureModelEmbedding) ??
                     DefaultEmbedModel;
 
-                builder.WithAzureTextEmbeddingGenerationService(modelEmbedding, endpoint, apikey);
+                builder.WithAzureOpenAITextEmbeddingGenerationService(modelEmbedding, endpoint, apikey);
 
                 return builder.Build();
             }
@@ -117,7 +117,7 @@ internal static class KernelFactory
                     builder.WithAzureTextCompletionService(modelCompletion, endpoint, apikey);
                 }
 
-                builder.WithAzureChatCompletionService(modelCompletion, endpoint, apikey);
+                builder.WithAzureOpenAIChatCompletionService(modelCompletion, endpoint, apikey);
 
                 return builder.Build();
             }

--- a/examples/200-dotnet-nl2sql/nl2sql.library/Nl2Sql.Library.csproj
+++ b/examples/200-dotnet-nl2sql/nl2sql.library/Nl2Sql.Library.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.SqlClient" />
-        <PackageReference Include="Microsoft.SemanticKernel" VersionOverride="1.0.0-beta5" />
+        <PackageReference Include="Microsoft.SemanticKernel" VersionOverride="1.0.0-beta6" />
         <PackageReference Include="System.Linq.Async" />
     </ItemGroup>
 


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)
Aligns Kernel Memory with the latest version of Semantic Kernel.

Fixes #152.

## High level description (Approach, Design)
Update to Microsoft.SemanticKernel 1.0.0-beta6 and fixes associated regressions.