### PR TITLE
Changed call in "WithOpenAITextGeneration" from "AddOpenAITextEmbeddi…

### DIFF
--- a/dotnet/CoreLib/AI/OpenAI/DependencyInjection.cs
+++ b/dotnet/CoreLib/AI/OpenAI/DependencyInjection.cs
@@ -44,7 +44,7 @@ public static partial class KernelMemoryBuilderExtensions
 
     public static KernelMemoryBuilder WithOpenAITextGeneration(this KernelMemoryBuilder builder, OpenAIConfig config)
     {
-        builder.Services.AddOpenAITextEmbeddingGeneration(config);
+        builder.Services.AddOpenAITextGeneration(config);
         return builder;
     }
 }


### PR DESCRIPTION
…ngGeneration" to "AddOpenAITextGeneration"

<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
Changed call to TextEmbedding in TextGeneration method to the TextGeneration method, as this is the expected behaviour.
Resolves #157

## High level description (Approach, Design)

