### PR TITLE
Use Span when checking cosine similarity

### DIFF
--- a/service/Abstractions/AI/Embedding.cs
+++ b/service/Abstractions/AI/Embedding.cs
@@ -50,7 +50,7 @@ public struct Embedding : IEquatable<Embedding>
 
     public double CosineSimilarity(Embedding embedding)
     {
-        return TensorPrimitives.CosineSimilarity(this.Data.ToArray(), embedding.Data.ToArray());
+        return TensorPrimitives.CosineSimilarity(this.Data.Span, embedding.Data.Span);
     }
 
     /// <summary>


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)
Small tweak to optimize the cosine similarity logic.

## High level description (Approach, Design)
Avoid allocating the array again by using `Span` over `ToArray()`.