### PR TITLE
Update Document.cs

### DIFF
--- a/service/Abstractions/Models/Document.cs
+++ b/service/Abstractions/Models/Document.cs
@@ -127,7 +127,7 @@ public class Document
 
         if (!IsValid(id))
         {
-            throw new ArgumentOutOfRangeException(nameof(id), "The document ID contains invalid chars (allowed: A-B, a-b, 0-9, '.', '_', '-')");
+            throw new ArgumentOutOfRangeException(nameof(id)+" OR fileName", "The document ID contains invalid chars (allowed: A-B, a-b, 0-9, '.', '_', '-')");
         }
 
         return id!;


### PR DESCRIPTION
Check fileName error
Add message to coder

<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
This my code  ：
```
documentName = "1700736918251108_VEO_Botox study safety report (interim).docx";

var result = await _semanticMemoryClient.ImportDocumentAsync(
    stream,
    documentName,
    documentId, 
    null, 
    _config.Services.Qdrant.DefaultIndex);
```

When the filename does not comply with the rules, an error is reported
---System.ArgumentOutOfRangeException: The document ID contains invalid symbols (Parameter 'id')
This prompt misleads me to spend time troubleshooting ID issues

## High level description (Approach, Design)

