### PR TITLE
Consistently handle "index not found" across different memory DBs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ tmp-*/
 out/
 _files/
 _vectors/
+_queues/
 _textdb/
 
 ## Ignore Visual Studio temporary files, build results, and

--- a/service/tests/FunctionalTests/ServerLess/FilteringTest.cs
+++ b/service/tests/FunctionalTests/ServerLess/FilteringTest.cs
@@ -20,10 +20,10 @@ public class FilteringTest : BaseTestCase
     [InlineData("simple_on_disk")]
     [InlineData("simple_volatile")]
     [InlineData("qdrant")]
-    [InlineData("acs")]
+    [InlineData("az_ai_search")]
     public async Task ItSupportsASingleFilter(string memoryType)
     {
-        var memory = this.GetMemory(memoryType);
+        var memory = this.GetServerlessMemory(memoryType);
 
         string indexName = Guid.NewGuid().ToString("D");
         const string Id = "file1-NASA-news.pdf";
@@ -88,10 +88,10 @@ public class FilteringTest : BaseTestCase
     [InlineData("simple_on_disk")]
     [InlineData("simple_volatile")]
     [InlineData("qdrant")]
-    [InlineData("acs")]
+    [InlineData("az_ai_search")]
     public async Task ItSupportsMultipleFilters(string memoryType)
     {
-        var memory = this.GetMemory(memoryType);
+        var memory = this.GetServerlessMemory(memoryType);
 
         string indexName = Guid.NewGuid().ToString("D");
         const string Id = "file1-NASA-news.pdf";
@@ -171,10 +171,10 @@ public class FilteringTest : BaseTestCase
     [InlineData("simple_on_disk")]
     [InlineData("simple_volatile")]
     [InlineData("qdrant")]
-    [InlineData("acs")]
+    [InlineData("az_ai_search")]
     public async Task ItIgnoresEmptyFilters(string memoryType)
     {
-        var memory = this.GetMemory(memoryType);
+        var memory = this.GetServerlessMemory(memoryType);
 
         string indexName = Guid.NewGuid().ToString("D");
         const string Id = "file1-NASA-news.pdf";

--- a/service/tests/FunctionalTests/ServerLess/IndexListTest.cs
+++ b/service/tests/FunctionalTests/ServerLess/IndexListTest.cs
@@ -20,11 +20,11 @@ public class IndexListTest : BaseTestCase
     [InlineData("simple_on_disk")]
     [InlineData("simple_volatile")]
     [InlineData("qdrant")]
-    [InlineData("acs")]
+    [InlineData("az_ai_search")]
     public async Task ItListsIndexes(string memoryType)
     {
         // Arrange
-        var memory = this.GetMemory(memoryType);
+        var memory = this.GetServerlessMemory(memoryType);
         string indexName1 = Guid.NewGuid().ToString("D");
         string indexName2 = Guid.NewGuid().ToString("D");
         Console.WriteLine("Index 1:" + indexName1);

--- a/service/tests/FunctionalTests/ServerLess/MissingIndexTest.cs
+++ b/service/tests/FunctionalTests/ServerLess/MissingIndexTest.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using FunctionalTests.TestHelpers;
+using Microsoft.KernelMemory;
+using Xunit.Abstractions;
+
+namespace FunctionalTests.ServerLess;
+
+// ReSharper disable InconsistentNaming
+public class MissingIndexTest : BaseTestCase
+{
+    public MissingIndexTest(
+        IConfiguration cfg,
+        ITestOutputHelper output) : base(cfg, output)
+    {
+    }
+
+    [Theory]
+    [InlineData("default")]
+    [InlineData("simple_on_disk")]
+    [InlineData("simple_volatile")]
+    [InlineData("qdrant")]
+    [InlineData("az_ai_search")]
+    public async Task ItHandlesMissingIndexesConsistently(string memoryType)
+    {
+        // Arrange
+        var memory = this.GetServerlessMemory(memoryType);
+        string indexName = Guid.NewGuid().ToString("D");
+        await memory.DeleteIndexAsync(indexName);
+
+        // Act: verify the index doesn't exist
+        IEnumerable<IndexDetails> list = await memory.ListIndexesAsync();
+        Assert.False(list.Any(x => x.Name == indexName));
+
+        // Act: Delete a non-existing index, no exception
+        await memory.DeleteIndexAsync(indexName);
+
+        // Act: Search a non-existing index
+        var answer = await memory.AskAsync("What's the number after 9?", index: indexName);
+        Assert.Equal("INFO NOT FOUND", answer.Result);
+
+        // Act: Search a non-existing index
+        var searchResult = await memory.SearchAsync("some query", index: indexName);
+        Assert.Equal(0, searchResult.Results.Count);
+
+        // Act: delete doc from non existing index
+        await memory.DeleteDocumentAsync(documentId: Guid.NewGuid().ToString("D"), index: indexName);
+
+        // Act: get status of non existing doc/index
+        bool isReady = await memory.IsDocumentReadyAsync(documentId: Guid.NewGuid().ToString("D"), index: indexName);
+        Assert.Equal(false, isReady);
+
+        // Act: get status of non existing doc/index
+        DataPipelineStatus? status = await memory.GetDocumentStatusAsync(documentId: Guid.NewGuid().ToString("D"), index: indexName);
+        Assert.Null(status);
+
+        // Assert: verify the index doesn't exist yet
+        list = await memory.ListIndexesAsync();
+        Assert.False(list.Any(x => x.Name == indexName));
+
+        // Act: import into a non existing index - the index is created
+        var id = await memory.ImportTextAsync("some text", documentId: "foo", index: indexName);
+        Assert.NotEmpty(id);
+
+        // Assert: verify the index has been created
+        list = await memory.ListIndexesAsync();
+        Assert.True(list.Any(x => x.Name == indexName));
+    }
+}

--- a/service/tests/FunctionalTests/ServerLess/OpenAITest.cs
+++ b/service/tests/FunctionalTests/ServerLess/OpenAITest.cs
@@ -8,11 +8,11 @@ using Xunit.Abstractions;
 namespace FunctionalTests.ServerLess;
 
 // ReSharper disable InconsistentNaming
-public class OpenAITests : BaseTestCase
+public class OpenAITest : BaseTestCase
 {
     private readonly string _openAIKey;
 
-    public OpenAITests(
+    public OpenAITest(
         IConfiguration cfg,
         ITestOutputHelper output) : base(cfg, output)
     {

--- a/service/tests/FunctionalTests/TestHelpers/BaseTestCase.cs
+++ b/service/tests/FunctionalTests/TestHelpers/BaseTestCase.cs
@@ -27,7 +27,7 @@ public abstract class BaseTestCase : IDisposable
         Console.SetOut(this._output);
     }
 
-    protected IKernelMemory GetMemory(string memoryType)
+    protected IKernelMemory GetServerlessMemory(string memoryType)
     {
         var openAIKey = this.OpenAIConfiguration.GetValue<string>("APIKey")
                         ?? throw new TestCanceledException("OpenAI API key is missing");
@@ -61,7 +61,7 @@ public abstract class BaseTestCase : IDisposable
                     .WithQdrant(qdrantEndpoint)
                     .Build<MemoryServerless>();
 
-            case "acs":
+            case "az_ai_search":
                 var acsEndpoint = this.AzureAISearchConfiguration.GetValue<string>("Endpoint");
                 var acsKey = this.AzureAISearchConfiguration.GetValue<string>("APIKey");
                 Assert.False(string.IsNullOrEmpty(acsEndpoint));


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

When using an index that doesn't exist, the final result should be consistent regardless of the memory DB selected.  E.g. see #95.

## High level description (Approach, Design)

When using a non-existing index:
* Delete index: no error
* Delete document: no error
* Ask/Search: empty result
* Checking if a document is ready: return false
* Fetch document status: return null
* Importing documents: the index is created by "save-records" handler

Fixes #95 