### PR TITLE
002-dotnet-SemanticKernelPlugin example: A couple of calls to KernelBuilder methods don't match the new names in SK rc3

### DIFF
--- a/examples/002-dotnet-SemanticKernelPlugin/Program.cs
+++ b/examples/002-dotnet-SemanticKernelPlugin/Program.cs
@@ -21,11 +21,11 @@ public static class Program
         var builder = new KernelBuilder();
         builder
             // For OpenAI:
-            // .AddOpenAIChatCompletion(
+            //.WithOpenAIChatCompletion(
             //     modelId: "gpt-3.5-turbo",
             //     apiKey: EnvVar("OPENAI_API_KEY"))
-            // Azure OpenAI:
-            .AddAzureOpenAIChatCompletion(
+            // Azure OpenAI:            
+            .WithAzureOpenAIChatCompletion(
                 deploymentName: EnvVar("AOAI_DEPLOYMENT_TEXT"),
                 modelId: EnvVar("AOAI_DEPLOYMENT_TEXT"),
                 endpoint: EnvVar("AOAI_ENDPOINT"),


### PR DESCRIPTION
I downloaded the latest build and I ran in a compilation issue of Program.cs in 002-dotnet-SemanticKernelPlugin
The problem is at lines 23 to 32, where the methods AddXXX should be replaced with WithXXX

-Add -> WithOpenAIChatCompletion
-Add -> WithAzureOpenAIChatCompletion

<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
The solution didn't compile.
