### PR TITLE
Add more details to search/ask results

### DIFF
--- a/examples/001-dotnet-WebClient/Program.cs
+++ b/examples/001-dotnet-WebClient/Program.cs
@@ -147,9 +147,12 @@ if (retrieval)
     answer = await memory.AskAsync(question);
     Console.WriteLine($"\nAnswer: {answer.Result}\n\n  Sources:\n");
 
+    // Show sources / citations
     foreach (var x in answer.RelevantSources)
     {
-        Console.WriteLine($"  - {x.SourceName}  - {x.Link} [{x.Partitions.First().LastUpdate:D}]");
+        Console.WriteLine(x.SourceUrl != null
+            ? $"  - {x.SourceUrl} [{x.Partitions.First().LastUpdate:D}]"
+            : $"  - {x.SourceName}  - {x.Link} [{x.Partitions.First().LastUpdate:D}]");
     }
 
     if (useImages)
@@ -161,9 +164,12 @@ if (retrieval)
         answer = await memory.AskAsync(question);
         Console.WriteLine($"\nAnswer: {answer.Result}\n\n  Sources:\n");
 
+        // Show sources / citations
         foreach (var x in answer.RelevantSources)
         {
-            Console.WriteLine($"  - {x.SourceName}  - {x.Link} [{x.Partitions.First().LastUpdate:D}]");
+            Console.WriteLine(x.SourceUrl != null
+                ? $"  - {x.SourceUrl} [{x.Partitions.First().LastUpdate:D}]"
+                : $"  - {x.SourceName}  - {x.Link} [{x.Partitions.First().LastUpdate:D}]");
         }
     }
 
@@ -181,9 +187,12 @@ if (retrieval)
     answer = await memory.AskAsync(question, filter: MemoryFilters.ByTag("user", "Taylor"));
     Console.WriteLine($"\nTaylor Answer: {answer.Result}\n  Sources:\n");
 
+    // Show sources / citations
     foreach (var x in answer.RelevantSources)
     {
-        Console.WriteLine($"  - {x.SourceName}  - {x.Link} [{x.Partitions.First().LastUpdate:D}]");
+        Console.WriteLine(x.SourceUrl != null
+            ? $"  - {x.SourceUrl} [{x.Partitions.First().LastUpdate:D}]"
+            : $"  - {x.SourceName}  - {x.Link} [{x.Partitions.First().LastUpdate:D}]");
     }
 
     Console.WriteLine("\n====================================\n");

--- a/examples/003-dotnet-Serverless/Program.cs
+++ b/examples/003-dotnet-Serverless/Program.cs
@@ -162,9 +162,12 @@ if (retrieval)
     answer = await memory.AskAsync(question, minRelevance: 0.76);
     Console.WriteLine($"\nAnswer: {answer.Result}\n\n  Sources:\n");
 
+    // Show sources / citations
     foreach (var x in answer.RelevantSources)
     {
-        Console.WriteLine($"  - {x.SourceName}  - {x.Link} [{x.Partitions.First().LastUpdate:D}]");
+        Console.WriteLine(x.SourceUrl != null
+            ? $"  - {x.SourceUrl} [{x.Partitions.First().LastUpdate:D}]"
+            : $"  - {x.SourceName}  - {x.Link} [{x.Partitions.First().LastUpdate:D}]");
     }
 
     if (useImages)
@@ -176,9 +179,12 @@ if (retrieval)
         answer = await memory.AskAsync(question, minRelevance: 0.76);
         Console.WriteLine($"\nAnswer: {answer.Result}\n\n  Sources:\n");
 
+        // Show sources / citations
         foreach (var x in answer.RelevantSources)
         {
-            Console.WriteLine($"  - {x.SourceName}  - {x.Link} [{x.Partitions.First().LastUpdate:D}]");
+            Console.WriteLine(x.SourceUrl != null
+                ? $"  - {x.SourceUrl} [{x.Partitions.First().LastUpdate:D}]"
+                : $"  - {x.SourceName}  - {x.Link} [{x.Partitions.First().LastUpdate:D}]");
         }
     }
 
@@ -196,9 +202,12 @@ if (retrieval)
     answer = await memory.AskAsync(question, filter: MemoryFilters.ByTag("user", "Taylor"));
     Console.WriteLine($"\nTaylor Answer: {answer.Result}\n  Sources:\n");
 
+    // Show sources / citations
     foreach (var x in answer.RelevantSources)
     {
-        Console.WriteLine($"  - {x.SourceName}  - {x.Link} [{x.Partitions.First().LastUpdate:D}]");
+        Console.WriteLine(x.SourceUrl != null
+            ? $"  - {x.SourceUrl} [{x.Partitions.First().LastUpdate:D}]"
+            : $"  - {x.SourceName}  - {x.Link} [{x.Partitions.First().LastUpdate:D}]");
     }
 
     Console.WriteLine("\n====================================\n");

--- a/examples/205-dotnet-extract-text-from-docs/Program.cs
+++ b/examples/205-dotnet-extract-text-from-docs/Program.cs
@@ -47,8 +47,11 @@ Console.WriteLine("=========================");
 Console.WriteLine("=== Text in file1.pdf ===");
 Console.WriteLine("=========================");
 
-text = new PdfDecoder().DocToText("file1.pdf");
-Console.WriteLine(text);
+var pages = new PdfDecoder().DocToText("file1.pdf");
+foreach (var page in pages)
+{
+    Console.WriteLine(page.Text);
+}
 
 Console.WriteLine("============================");
 Console.WriteLine("Press a Enter to continue...");
@@ -59,5 +62,8 @@ Console.WriteLine("=========================");
 Console.WriteLine("=== Text in file2.pdf ===");
 Console.WriteLine("=========================");
 
-text = new PdfDecoder().DocToText("file2.pdf");
-Console.WriteLine(text);
+pages = new PdfDecoder().DocToText("file2.pdf");
+foreach (var page in pages)
+{
+    Console.WriteLine(page.Text);
+}

--- a/service/Abstractions/Constants.cs
+++ b/service/Abstractions/Constants.cs
@@ -39,6 +39,7 @@ public static class Constants
     // Properties stored inside the payload
     public const string ReservedPayloadTextField = "text";
     public const string ReservedPayloadFileNameField = "file";
+    public const string ReservedPayloadUrlField = "url";
     public const string ReservedPayloadLastUpdateField = "last_update";
     public const string ReservedPayloadVectorProviderField = "vector_provider";
     public const string ReservedPayloadVectorGeneratorField = "vector_generator";

--- a/service/Abstractions/Models/Citation.cs
+++ b/service/Abstractions/Models/Citation.cs
@@ -8,60 +8,69 @@ namespace Microsoft.KernelMemory;
 
 public class Citation
 {
-    private TagCollection _tags = new();
-
     /// <summary>
     /// Link to the source, if available.
     /// </summary>
     [JsonPropertyName("link")]
     [JsonPropertyOrder(1)]
-
     public string Link { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Link to the source, if available.
+    /// </summary>
+    [JsonPropertyName("index")]
+    [JsonPropertyOrder(2)]
+    public string Index { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Link to the source, if available.
+    /// </summary>
+    [JsonPropertyName("documentId")]
+    [JsonPropertyOrder(3)]
+    public string DocumentId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Link to the source, if available.
+    /// </summary>
+    [JsonPropertyName("fileId")]
+    [JsonPropertyOrder(4)]
+    public string FileId { get; set; } = string.Empty;
 
     /// <summary>
     /// Type of source, e.g. PDF, Word, Chat, etc.
     /// </summary>
     [JsonPropertyName("sourceContentType")]
-    [JsonPropertyOrder(2)]
+    [JsonPropertyOrder(5)]
     public string SourceContentType { get; set; } = string.Empty;
 
     /// <summary>
     /// Name of the source, e.g. file name.
     /// </summary>
     [JsonPropertyName("sourceName")]
-    [JsonPropertyOrder(3)]
+    [JsonPropertyOrder(6)]
     public string SourceName { get; set; } = string.Empty;
+
+#pragma warning disable CA1056
+    /// <summary>
+    /// URL of the source, used for web pages and external data
+    /// </summary>
+    [JsonPropertyName("sourceUrl")]
+    [JsonPropertyOrder(7)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SourceUrl { get; set; } = null;
+#pragma warning restore CA1056
 
     /// <summary>
     /// List of chunks/blocks of text used.
     /// </summary>
     [JsonPropertyName("partitions")]
-    [JsonPropertyOrder(4)]
+    [JsonPropertyOrder(8)]
     public List<Partition> Partitions { get; set; } = new();
-
-    /// <summary>
-    /// List of document tags
-    /// </summary>
-    [JsonPropertyName("tags")]
-    [JsonPropertyOrder(5)]
-    public TagCollection Tags
-    {
-        get { return this._tags; }
-        set
-        {
-            this._tags = new();
-            foreach (KeyValuePair<string, List<string?>> tag in value)
-            {
-                // Exclude internal tags
-                if (tag.Key.StartsWith(Constants.ReservedTagsPrefix, StringComparison.OrdinalIgnoreCase)) { continue; }
-
-                this._tags[tag.Key] = tag.Value;
-            }
-        }
-    }
 
     public class Partition
     {
+        private TagCollection _tags = new();
+
         /// <summary>
         /// Content of the document partition, aka chunk/block of text.
         /// </summary>
@@ -81,7 +90,27 @@ public class Citation
         /// Timestamp about the file/text partition.
         /// </summary>
         [JsonPropertyName("lastUpdate")]
-        [JsonPropertyOrder(4)]
+        [JsonPropertyOrder(10)]
         public DateTimeOffset LastUpdate { get; set; } = DateTimeOffset.MinValue;
+
+        /// <summary>
+        /// List of document tags
+        /// </summary>
+        [JsonPropertyName("tags")]
+        [JsonPropertyOrder(100)]
+        public TagCollection Tags
+        {
+            get { return this._tags; }
+            set
+            {
+                this._tags = new();
+                foreach (KeyValuePair<string, List<string?>> tag in value)
+                {
+                    // Exclude internal tags
+                    // if (tag.Key.StartsWith(Constants.ReservedTagsPrefix, StringComparison.OrdinalIgnoreCase)) { continue; }
+                    this._tags[tag.Key] = tag.Value;
+                }
+            }
+        }
     }
 }

--- a/service/Abstractions/Models/MemoryAnswer.cs
+++ b/service/Abstractions/Models/MemoryAnswer.cs
@@ -19,11 +19,23 @@ public class MemoryAnswer
     [JsonPropertyOrder(1)]
     public string Question { get; set; } = string.Empty;
 
+    [JsonPropertyName("noResult")]
+    [JsonPropertyOrder(2)]
+    public bool NoResult { get; set; } = true;
+
+    /// <summary>
+    /// Content of the answer.
+    /// </summary>
+    [JsonPropertyName("noResultReason")]
+    [JsonPropertyOrder(3)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? NoResultReason { get; set; }
+
     /// <summary>
     /// Content of the answer.
     /// </summary>
     [JsonPropertyName("text")]
-    [JsonPropertyOrder(2)]
+    [JsonPropertyOrder(10)]
     public string Result { get; set; } = string.Empty;
 
     /// <summary>
@@ -32,7 +44,7 @@ public class MemoryAnswer
     /// Value = List of partitions used from the document.
     /// </summary>
     [JsonPropertyName("relevantSources")]
-    [JsonPropertyOrder(3)]
+    [JsonPropertyOrder(20)]
     public List<Citation> RelevantSources { get; set; } = new();
 
     /// <summary>

--- a/service/Abstractions/Models/SearchResult.cs
+++ b/service/Abstractions/Models/SearchResult.cs
@@ -20,6 +20,20 @@ public class SearchResult
     public string Query { get; set; } = string.Empty;
 
     /// <summary>
+    /// Whether the search didn't return any result
+    /// </summary>
+    [JsonPropertyName("noResult")]
+    [JsonPropertyOrder(2)]
+    public bool NoResult
+    {
+        get
+        {
+            return this.Results.Count == 0;
+        }
+        private set { }
+    }
+
+    /// <summary>
     /// List of the relevant sources used to produce the answer.
     /// Key = Document ID
     /// Value = List of partitions used from the document.

--- a/service/Core/DataFormats/DocumentPage.cs
+++ b/service/Core/DataFormats/DocumentPage.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.KernelMemory.DataFormats;
+
+public class DocumentPage
+{
+    /// <summary>
+    /// Page text content
+    /// </summary>
+    public string Text { get; }
+
+    /// <summary>
+    /// Page number
+    /// </summary>
+    public int Number { get; }
+
+    public DocumentPage(string? text, int number)
+    {
+        this.Number = number;
+        this.Text = text ?? string.Empty;
+    }
+}

--- a/service/Core/DataFormats/Pdf/PdfDecoder.cs
+++ b/service/Core/DataFormats/Pdf/PdfDecoder.cs
@@ -1,37 +1,40 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using UglyToad.PdfPig;
+using UglyToad.PdfPig.Content;
 using UglyToad.PdfPig.DocumentLayoutAnalysis.TextExtractor;
 
 namespace Microsoft.KernelMemory.DataFormats.Pdf;
 
 public class PdfDecoder
 {
-    public string DocToText(string filename)
+    public List<DocumentPage> DocToText(string filename)
     {
         using var stream = File.OpenRead(filename);
         return this.DocToText(stream);
     }
 
-    public string DocToText(BinaryData data)
+    public List<DocumentPage> DocToText(BinaryData data)
     {
         using var stream = data.ToStream();
         return this.DocToText(stream);
     }
 
-    public string DocToText(Stream data)
+    public List<DocumentPage> DocToText(Stream data)
     {
+        var result = new List<DocumentPage>();
         StringBuilder sb = new();
         using var pdfDocument = PdfDocument.Open(data);
-        foreach (var page in pdfDocument.GetPages())
+        foreach (Page? page in pdfDocument.GetPages())
         {
-            var text = ContentOrderTextExtractor.GetText(page);
-            sb.Append(text);
+            string? text = ContentOrderTextExtractor.GetText(page);
+            result.Add(new DocumentPage(text, page.Number));
         }
 
-        return sb.ToString().Trim();
+        return result;
     }
 }

--- a/service/Core/Handlers/TextExtractionHandler.cs
+++ b/service/Core/Handlers/TextExtractionHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -153,7 +154,19 @@ public class TextExtractionHandler : IPipelineStepHandler
 
             case MimeTypes.Pdf:
                 this._log.LogDebug("Extracting text from PDF file {0}", uploadedFile.Name);
-                text = new PdfDecoder().DocToText(fileContent);
+
+                // TODO: carry over page numbers, e.g. using special tokens
+                var pages = new PdfDecoder().DocToText(fileContent);
+                var textBuilder = new StringBuilder();
+                foreach (var page in pages)
+                {
+                    textBuilder.Append(page.Text.Trim());
+                    textBuilder.AppendLine();
+                    textBuilder.AppendLine();
+                }
+
+                text = textBuilder.ToString().Trim();
+
                 break;
 
             case MimeTypes.WebPageUrl:

--- a/service/Core/Prompts/answer-with-facts.txt
+++ b/service/Core/Prompts/answer-with-facts.txt
@@ -3,6 +3,6 @@ Facts:
 ======
 Given only the facts above, provide a comprehensive/detailed answer.
 You don't know where the knowledge comes from, just answer.
-If you don't have sufficient information, reply with 'INFO NOT FOUND'.
+If you don't have sufficient information, reply with '{{$notFound}}'.
 Question: {{$input}}
 Answer: 

--- a/service/Core/Search/SearchClient.cs
+++ b/service/Core/Search/SearchClient.cs
@@ -140,10 +140,13 @@ public class SearchClient : ISearchClient
             string fileId = memory.Tags[Constants.ReservedFileIdTag].FirstOrDefault() ?? string.Empty;
 
             // TODO: URL to access the file
-            string linkToFile = $"{documentId}/{fileId}";
+            string linkToFile = $"{index}/{documentId}/{fileId}";
 
             string fileContentType = memory.Tags[Constants.ReservedFileTypeTag].FirstOrDefault() ?? string.Empty;
             string fileName = memory.Payload[Constants.ReservedPayloadFileNameField].ToString() ?? string.Empty;
+
+            // URL the source, used for web pages and external data. Null when empty.
+            string? sourceUrl = memory.Payload[Constants.ReservedPayloadUrlField].ToString();
 
             var partitionText = memory.Payload[Constants.ReservedPayloadTextField].ToString()?.Trim() ?? "";
             if (string.IsNullOrEmpty(partitionText))
@@ -166,10 +169,13 @@ public class SearchClient : ISearchClient
             }
 
             // Add the partition to the list of citations
+            citation.Index = index;
+            citation.DocumentId = documentId;
+            citation.FileId = fileId;
             citation.Link = linkToFile;
             citation.SourceContentType = fileContentType;
             citation.SourceName = fileName;
-            citation.Tags = memory.Tags;
+            citation.SourceUrl = string.IsNullOrWhiteSpace(sourceUrl) ? null : sourceUrl;
 
 #pragma warning disable CA1806 // it's ok if parsing fails
             DateTimeOffset.TryParse(memory.Payload[Constants.ReservedPayloadLastUpdateField].ToString(), out var lastUpdate);
@@ -180,6 +186,7 @@ public class SearchClient : ISearchClient
                 Text = partitionText,
                 Relevance = (float)relevance,
                 LastUpdate = lastUpdate,
+                Tags = memory.Tags,
             });
         }
 
@@ -199,14 +206,18 @@ public class SearchClient : ISearchClient
         double minRelevance = 0,
         CancellationToken cancellationToken = default)
     {
+        var noAnswerFound = new MemoryAnswer
+        {
+            Question = question,
+            NoResult = true,
+            Result = this._config.EmptyAnswer,
+        };
+
         if (string.IsNullOrEmpty(question))
         {
             this._log.LogWarning("No question provided");
-            return new MemoryAnswer
-            {
-                Question = question,
-                Result = this._config.EmptyAnswer,
-            };
+            noAnswerFound.NoResultReason = "No question provided";
+            return noAnswerFound;
         }
 
         var facts = new StringBuilder();
@@ -220,12 +231,7 @@ public class SearchClient : ISearchClient
 
         var factsUsedCount = 0;
         var factsAvailableCount = 0;
-
-        var answer = new MemoryAnswer
-        {
-            Question = question,
-            Result = this._config.EmptyAnswer,
-        };
+        var answer = noAnswerFound;
 
         this._log.LogTrace("Fetching relevant memories");
         IAsyncEnumerable<(MemoryRecord, double)> matches = this._memoryDb.GetSimilarListAsync(
@@ -262,10 +268,13 @@ public class SearchClient : ISearchClient
             string fileId = memory.Tags[Constants.ReservedFileIdTag].FirstOrDefault() ?? string.Empty;
 
             // TODO: URL to access the file
-            string linkToFile = $"{documentId}/{fileId}";
+            string linkToFile = $"{index}/{documentId}/{fileId}";
 
             string fileContentType = memory.Tags[Constants.ReservedFileTypeTag].FirstOrDefault() ?? string.Empty;
             string fileName = memory.Payload[Constants.ReservedPayloadFileNameField].ToString() ?? string.Empty;
+
+            // URL the source, used for web pages and external data. Null when empty.
+            string? sourceUrl = memory.Payload[Constants.ReservedPayloadUrlField].ToString();
 
             factsAvailableCount++;
             var partitionText = memory.Payload[Constants.ReservedPayloadTextField].ToString()?.Trim() ?? "";
@@ -301,10 +310,13 @@ public class SearchClient : ISearchClient
             }
 
             // Add the partition to the list of citations
+            citation.Index = index;
+            citation.DocumentId = documentId;
+            citation.FileId = fileId;
             citation.Link = linkToFile;
             citation.SourceContentType = fileContentType;
             citation.SourceName = fileName;
-            citation.Tags = memory.Tags;
+            citation.SourceUrl = string.IsNullOrWhiteSpace(sourceUrl) ? null : sourceUrl;
 
 #pragma warning disable CA1806 // it's ok if parsing fails
             DateTimeOffset.TryParse(memory.Payload[Constants.ReservedPayloadLastUpdateField].ToString(), out var lastUpdate);
@@ -315,19 +327,22 @@ public class SearchClient : ISearchClient
                 Text = partitionText,
                 Relevance = (float)relevance,
                 LastUpdate = lastUpdate,
+                Tags = memory.Tags,
             });
         }
 
         if (factsAvailableCount > 0 && factsUsedCount == 0)
         {
             this._log.LogError("Unable to inject memories in the prompt, not enough tokens available");
-            return new MemoryAnswer { Question = question, Result = "INFO NOT FOUND" };
+            noAnswerFound.NoResultReason = "Unable to use memories";
+            return noAnswerFound;
         }
 
         if (factsUsedCount == 0)
         {
             this._log.LogWarning("No memories available");
-            return new MemoryAnswer { Question = question, Result = "INFO NOT FOUND" };
+            noAnswerFound.NoResultReason = "No memories available";
+            return noAnswerFound;
         }
 
         var text = new StringBuilder();
@@ -350,6 +365,11 @@ public class SearchClient : ISearchClient
         this._log.LogTrace("Answer generated in {0} msecs", watch.ElapsedMilliseconds);
 
         answer.Result = text.ToString();
+        answer.NoResult = string.Equals(answer.Result.Trim(), this._config.EmptyAnswer, StringComparison.OrdinalIgnoreCase);
+        if (answer.NoResult)
+        {
+            answer.NoResultReason = "No relevant memories found";
+        }
 
         return answer;
     }
@@ -362,6 +382,8 @@ public class SearchClient : ISearchClient
         question = question.Trim();
         question = question.EndsWith('?') ? question : $"{question}?";
         prompt = prompt.Replace("{{$input}}", question, StringComparison.OrdinalIgnoreCase);
+
+        prompt = prompt.Replace("{{$notFound}}", this._config.EmptyAnswer, StringComparison.OrdinalIgnoreCase);
 
         // TODO: receive options from API: https://github.com/microsoft/kernel-memory/issues/137
         var options = new TextGenerationOptions

--- a/service/nuget-package.props
+++ b/service/nuget-package.props
@@ -1,7 +1,7 @@
 ﻿<Project>
     <PropertyGroup>
         <!-- Central version prefix - applies to all nuget packages. -->
-        <Version>0.20.0</Version>
+        <Version>0.21.0</Version>
 
         <!-- Default description and tags. Packages can override. -->
         <Authors>Microsoft</Authors>

--- a/service/tests/FunctionalTests/ServerLess/AIClients/LlamaSharpTextGeneratorTest.cs
+++ b/service/tests/FunctionalTests/ServerLess/AIClients/LlamaSharpTextGeneratorTest.cs
@@ -43,6 +43,7 @@ public sealed class LlamaSharpTextGeneratorTest : BaseTestCase
         Console.WriteLine("GPT3 token count: " + GPT3Tokenizer.Encode(text).Count);
         Console.WriteLine($"Time: {this._timer.ElapsedMilliseconds / 1000} secs");
 
+        // Note: value for llama-2-13b.Q2_K.gguf
         Assert.Equal(8, tokenCount);
     }
 

--- a/service/tests/FunctionalTests/ServerLess/MissingIndexTest.cs
+++ b/service/tests/FunctionalTests/ServerLess/MissingIndexTest.cs
@@ -36,7 +36,7 @@ public class MissingIndexTest : BaseTestCase
 
         // Act: Search a non-existing index
         var answer = await memory.AskAsync("What's the number after 9?", index: indexName);
-        Assert.Equal("INFO NOT FOUND", answer.Result);
+        Assert.Equal(NotFound, answer.Result);
 
         // Act: Search a non-existing index
         var searchResult = await memory.SearchAsync("some query", index: indexName);

--- a/service/tests/FunctionalTests/Service/FilteringTest.cs
+++ b/service/tests/FunctionalTests/Service/FilteringTest.cs
@@ -22,7 +22,6 @@ public class FilteringTest : BaseTestCase
     {
         string indexName = Guid.NewGuid().ToString("D");
         const string Id = "ItSupportsASingleFilter-file1-NASA-news.pdf";
-        const string NotFound = "INFO NOT FOUND";
         const string Found = "spacecraft";
 
         this.Log("Uploading document");
@@ -44,16 +43,19 @@ public class FilteringTest : BaseTestCase
         // Simple filter: unknown user cannot see the memory
         var answer = await this._memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("user", "someone"), index: indexName);
         this.Log(answer.Result);
+        Assert.True(answer.NoResult);
         Assert.Contains(NotFound, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         // Simple filter: test AND logic: valid type + invalid user
         answer = await this._memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("type", "news").ByTag("user", "someone"), index: indexName);
         this.Log(answer.Result);
+        Assert.True(answer.NoResult);
         Assert.Contains(NotFound, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         // Simple filter: test AND logic: invalid type + valid user
         answer = await this._memory.AskAsync("What is Orion?", filter: MemoryFilters.ByTag("type", "fact").ByTag("user", "owner"), index: indexName);
         this.Log(answer.Result);
+        Assert.True(answer.NoResult);
         Assert.Contains(NotFound, answer.Result, StringComparison.OrdinalIgnoreCase);
 
         // Simple filter: known user can see the memory

--- a/service/tests/FunctionalTests/TestHelpers/BaseTestCase.cs
+++ b/service/tests/FunctionalTests/TestHelpers/BaseTestCase.cs
@@ -12,6 +12,8 @@ namespace FunctionalTests.TestHelpers;
 
 public abstract class BaseTestCase : IDisposable
 {
+    protected const string NotFound = "INFO NOT FOUND";
+
     private readonly IConfiguration _cfg;
     private readonly RedirectConsole _output;
 
@@ -44,11 +46,13 @@ public abstract class BaseTestCase : IDisposable
         {
             case "default":
                 return new KernelMemoryBuilder()
+                    .WithSearchClientConfig(new SearchClientConfig { EmptyAnswer = NotFound })
                     .WithOpenAIDefaults(openAIKey)
                     .Build<MemoryServerless>();
 
             case "simple_on_disk":
                 return new KernelMemoryBuilder()
+                    .WithSearchClientConfig(new SearchClientConfig { EmptyAnswer = NotFound })
                     .WithOpenAIDefaults(openAIKey)
                     .WithSimpleVectorDb(new SimpleVectorDbConfig { Directory = "_vectors", StorageType = FileSystemTypes.Disk })
                     .WithSimpleFileStorage(new SimpleFileStorageConfig { Directory = "_files", StorageType = FileSystemTypes.Disk })
@@ -56,6 +60,7 @@ public abstract class BaseTestCase : IDisposable
 
             case "simple_volatile":
                 return new KernelMemoryBuilder()
+                    .WithSearchClientConfig(new SearchClientConfig { EmptyAnswer = NotFound })
                     .WithOpenAIDefaults(openAIKey)
                     .WithSimpleVectorDb(new SimpleVectorDbConfig { StorageType = FileSystemTypes.Volatile })
                     .WithSimpleFileStorage(new SimpleFileStorageConfig { StorageType = FileSystemTypes.Volatile })
@@ -65,6 +70,7 @@ public abstract class BaseTestCase : IDisposable
                 var qdrantEndpoint = this.QdrantConfiguration.GetValue<string>("Endpoint");
                 Assert.False(string.IsNullOrEmpty(qdrantEndpoint));
                 return new KernelMemoryBuilder()
+                    .WithSearchClientConfig(new SearchClientConfig { EmptyAnswer = NotFound })
                     .WithOpenAIDefaults(openAIKey)
                     .WithQdrant(qdrantEndpoint)
                     .Build<MemoryServerless>();
@@ -75,6 +81,7 @@ public abstract class BaseTestCase : IDisposable
                 Assert.False(string.IsNullOrEmpty(acsEndpoint));
                 Assert.False(string.IsNullOrEmpty(acsKey));
                 return new KernelMemoryBuilder()
+                    .WithSearchClientConfig(new SearchClientConfig { EmptyAnswer = NotFound })
                     .WithOpenAIDefaults(openAIKey)
                     .WithAzureAISearch(acsEndpoint, acsKey)
                     .Build<MemoryServerless>();

--- a/service/tests/FunctionalTests/VectorDbComparison/TestMemoryFilters.cs
+++ b/service/tests/FunctionalTests/VectorDbComparison/TestMemoryFilters.cs
@@ -82,45 +82,65 @@ public class TestMemoryFilters
             await Task.Delay(TimeSpan.FromSeconds(2));
         }
 
-        this._log.WriteLine($"\n\n\n----- Azure AI Search -----");
-        await this.TestVectorDbFiltering(acs);
-        this._log.WriteLine($"\n\n\n----- Qdrant vector DB -----");
-        await this.TestVectorDbFiltering(qdrant);
-        this._log.WriteLine($"\n\n\n----- Simple vector DB -----");
-        await this.TestVectorDbFiltering(simpleVecDb);
+        for (int i = 1; i <= 3; i++)
+        {
+            this._log.WriteLine("----- Azure AI Search -----");
+            await this.TestVectorDbFiltering(acs, i);
+            this._log.WriteLine("\n----- Qdrant vector DB -----");
+            await this.TestVectorDbFiltering(qdrant, i);
+            this._log.WriteLine("\n----- Simple vector DB -----");
+            await this.TestVectorDbFiltering(simpleVecDb, i);
+            this._log.WriteLine("\n\n");
+        }
     }
 
-    private async Task TestVectorDbFiltering(IMemoryDb vectorDb)
+    // NOTE: result order does not matter, checking result count only
+    private async Task TestVectorDbFiltering(IMemoryDb vectorDb, int test)
     {
         // Single memory filter
-        var singleFilter = new List<MemoryFilter>() { MemoryFilters.ByTag("user", "Kaylee") };
-        var singleFilterResults = await vectorDb.GetListAsync(IndexName, filters: singleFilter, limit: int.MaxValue).ToListAsync();
-        this._log.WriteLine($"\n\nSingle memory filter: {singleFilterResults.Count} results");
-        foreach (MemoryRecord r in singleFilterResults)
+        if (test == 1)
         {
-            this._log.WriteLine($" - ID: {r.Id}, Tags: {string.Join(", ", r.Tags.Select(t => $"{t.Key}: {string.Join(", ", t.Value)}"))}");
+            var singleFilter = new List<MemoryFilter> { MemoryFilters.ByTag("user", "Kaylee") };
+            var singleFilterResults = await vectorDb.GetListAsync(IndexName, filters: singleFilter, limit: int.MaxValue).ToListAsync();
+            this._log.WriteLine($"\nSingle memory filter: {singleFilterResults.Count} results");
+            foreach (MemoryRecord r in singleFilterResults)
+            {
+                this._log.WriteLine($" - ID: {r.Id}, Tags: {string.Join(", ", r.Tags.Select(t => $"{t.Key}: {string.Join(", ", t.Value)}"))}");
+            }
+
+            Assert.Equal(5, singleFilterResults.Count);
         }
 
         // Single memory filter with multiple tags
-        var singleFilterMultipleTags = new List<MemoryFilter>() { MemoryFilters.ByTag("user", "Kaylee").ByTag("collection", "Work") };
-        var singleFilterMultipleTagsResults = await vectorDb.GetListAsync(IndexName, filters: singleFilterMultipleTags, limit: int.MaxValue).ToListAsync();
-        this._log.WriteLine($"\n\nSingle memory filter with multiple tags: {singleFilterMultipleTagsResults.Count} results");
-        foreach (MemoryRecord r in singleFilterMultipleTagsResults)
+        if (test == 2)
         {
-            this._log.WriteLine($" - ID: {r.Id}, Tags: {string.Join(", ", r.Tags.Select(t => $"{t.Key}: {string.Join(", ", t.Value)}"))}");
+            var singleFilterMultipleTags = new List<MemoryFilter> { MemoryFilters.ByTag("user", "Kaylee").ByTag("collection", "Work") };
+            var singleFilterMultipleTagsResults = await vectorDb.GetListAsync(IndexName, filters: singleFilterMultipleTags, limit: int.MaxValue).ToListAsync();
+            this._log.WriteLine($"\nSingle memory filter with multiple tags: {singleFilterMultipleTagsResults.Count} results");
+            foreach (MemoryRecord r in singleFilterMultipleTagsResults)
+            {
+                this._log.WriteLine($" - ID: {r.Id}, Tags: {string.Join(", ", r.Tags.Select(t => $"{t.Key}: {string.Join(", ", t.Value)}"))}");
+            }
+
+            Assert.Equal(1, singleFilterMultipleTagsResults.Count);
         }
 
         // Multiple memory filters with multiple tags
-        var multipleFilters = new List<MemoryFilter>()
+        if (test == 3)
         {
-            MemoryFilters.ByTag("user", "Kaylee").ByTag("collection", "Family"),
-            MemoryFilters.ByTag("user", "Madelynn").ByTag("collection", "Personal")
-        };
-        var multipleFiltersResults = await vectorDb.GetListAsync(IndexName, filters: multipleFilters, limit: int.MaxValue).ToListAsync();
-        this._log.WriteLine($"\n\nMultiple memory filters with multiple tags: {multipleFiltersResults.Count} results");
-        foreach (MemoryRecord r in multipleFiltersResults)
-        {
-            this._log.WriteLine($" - ID: {r.Id}, Tags: {string.Join(", ", r.Tags.Select(t => $"{t.Key}: {string.Join(", ", t.Value)}"))}");
+            var multipleFilters = new List<MemoryFilter>
+            {
+                MemoryFilters.ByTag("user", "Kaylee").ByTag("collection", "Family"),
+                MemoryFilters.ByTag("user", "Madelynn").ByTag("collection", "Personal")
+            };
+            var multipleFiltersResults = await vectorDb.GetListAsync(IndexName, filters: multipleFilters, limit: int.MaxValue).ToListAsync();
+            this._log.WriteLine($"\nMultiple memory filters with multiple tags: {multipleFiltersResults.Count} results");
+            foreach (MemoryRecord r in multipleFiltersResults)
+            {
+                this._log.WriteLine($" - ID: {r.Id}, Tags: {string.Join(", ", r.Tags.Select(t => $"{t.Key}: {string.Join(", ", t.Value)}"))}");
+            }
+
+            Assert.Equal(4, multipleFiltersResults.Count);
         }
     }
 }


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

When using Search and Ask API, some source details are missing, e.g. Index name, Document ID, file ID, tags per partition, web pages URL.
These details can be useful to refine search and UIs.

## High level description (Approach, Design)

* Change Search and Ask result schema to include: 
   * Index name (`index`), Document ID (`documentId`), File ID (`fileId`)
   * `noResult` boolean indicating whether there is a result or not, so clients don't need to parse text to figure it out
   * `noResultReason` with a brief explanation about why there are no results
* When a memory is extracted from a web page, include the URL in the citations (`sourceUrl`)
* Move Tags from File to Partition, considering that tags can differ for synthetic data (breaking change)
* Added some new code to deal with page numbers, not in use yet. Future PR needed to include in citations also the Page Number (for PDF, PowerPoint, Word, Excel).

Example 1: new `index`, `documentId`, `fileId`, `noResult`, `noResultReason` fields
```json
{
  "question": "what is foo bar?",
  "noResult": true,
  "noResultReason": "No relevant memories found",
  "text": "INFO NOT FOUND",
  "relevantSources": [
    {
      "link": "default/doc002/a35339fe0f85485baa97198b07ceec2b",
      "index": "default",
      "documentId": "doc002",
      "fileId": "a35339fe0f85485baa97198b07ceec2b",
      "sourceContentType": "application/msword",
      "sourceName": "file3-lorem-ipsum.docx",
    ....
```

Example 2: new `sourceUrl` field and `tags` at the partition level
```json
    ....
    {
      "link": "default/webPage1/94d456b1f3874029929caa4cb0f529ce",
      "index": "default",
      "documentId": "webPage1",
      "fileId": "94d456b1f3874029929caa4cb0f529ce",
      "sourceContentType": "text/x-uri",
      "sourceName": "content.url",
      "sourceUrl": "https://raw.githubusercontent.com/microsoft/kernel-memory/main/README.md",
      "partitions": [
        {
          "text": "...some text...",
          "relevance": 0.6471523,
          "lastUpdate": "2023-12-14T01:12:52-08:00",
          "tags": {
            "__document_id": [
              "webPage1"
            ],
            "__file_type": [
              "text/x-uri"
            ],
            "__file_id": [
              "94d456b1f3874029929caa4cb0f529ce"
            ],
            "__file_part": [
              "9337f7e8ae84473b900a2b666855d132"
            ]
          }
        }
      ]
    }
    ....
```
