### PR TITLE
RedisMemory

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="Pgvector" Version="0.2.0"/>
     <PackageVersion Include="Polly.Core" Version="8.2.0"/>
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1"/>
+    <PackageVersion Include="NRedisStack" Version="0.10.1"/>
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
     <PackageVersion Include="System.Linq.Async" Version="6.0.1"/>
     <PackageVersion Include="System.Memory.Data" Version="8.0.0"/>

--- a/KernelMemory.sln
+++ b/KernelMemory.sln
@@ -74,6 +74,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{CA49F1A1
 		tools\search.sh = tools\search.sh
 		tools\run-qdrant.sh = tools\run-qdrant.sh
 		tools\create-azure-webapp-publish-artifacts.sh = tools\create-azure-webapp-publish-artifacts.sh
+		tools\run-redis.sh = tools\run-redis.sh
 	EndProjectSection
 EndProject
 
@@ -240,6 +241,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "packages", "packages", "{16
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redis", "extensions\Redis\Redis.csproj", "{EC434C8D-4811-4B16-8F04-5E8FAD5BE233}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "redis-tests", "service\tests\redis-tests\redis-tests.csproj", "{A8EB745F-5767-42CC-9E3A-692060720F35}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -299,6 +302,7 @@ Global
 		{DD7ED79F-95D3-48AE-85AB-D7119F8530C2} = {5E7DD43D-B5E7-4827-B57D-447E5B428589}
 		{0675D9B5-B3BB-4C9A-A1A5-11540E2ED715} = {5E7DD43D-B5E7-4827-B57D-447E5B428589}
 		{EC434C8D-4811-4B16-8F04-5E8FAD5BE233} = {155DA079-E267-49AF-973A-D1D44681970F}
+		{A8EB745F-5767-42CC-9E3A-692060720F35} = {5E7DD43D-B5E7-4827-B57D-447E5B428589}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8A9FA587-7EBA-4D43-BE47-38D798B1C74C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -445,5 +449,8 @@ Global
 		{EC434C8D-4811-4B16-8F04-5E8FAD5BE233}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EC434C8D-4811-4B16-8F04-5E8FAD5BE233}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EC434C8D-4811-4B16-8F04-5E8FAD5BE233}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8EB745F-5767-42CC-9E3A-692060720F35}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8EB745F-5767-42CC-9E3A-692060720F35}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8EB745F-5767-42CC-9E3A-692060720F35}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/extensions/Redis/DependencyInjection.cs
+++ b/extensions/Redis/DependencyInjection.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.KernelMemory.MemoryStorage;
+using Microsoft.KernelMemory.MemoryDb.Redis;
+using StackExchange.Redis;
+
+#pragma warning disable IDE0130 // reduce number of "using" statements
+// ReSharper disable once CheckNamespace - reduce number of "using" statements
+namespace Microsoft.KernelMemory;
+
+/// <summary>
+/// DI pipelines for Redis Memory.
+/// </summary>
+public static partial class KernelMemoryBuilderExtensions
+{
+    /// <summary>
+    /// Adds RedisMemory as a service.
+    /// </summary>
+    /// <param name="builder">The kernel builder</param>
+    /// <param name="connString">The Redis connection string based on <see href="https://stackexchange.github.io/StackExchange.Redis/Configuration">StackExchange.Redis' connection string</see></param>
+    public static IKernelMemoryBuilder WithRedisMemoryDb(
+        this IKernelMemoryBuilder builder,
+        string connString)
+    {
+        builder.Services.AddRedisAsMemoryDb(new RedisConfig { ConnectionString = connString });
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds RedisMemory as a service.
+    /// </summary>
+    /// <param name="builder">The kernel builder</param>
+    /// <param name="redisConfig">Redis configuration.</param>
+    public static IKernelMemoryBuilder WithRedisMemoryDb(
+        this IKernelMemoryBuilder builder,
+        RedisConfig redisConfig)
+    {
+        builder.Services.AddRedisAsMemoryDb(redisConfig);
+        return builder;
+    }
+}
+
+/// <summary>
+/// setup Redis memory within the semantic kernel
+/// </summary>
+public static partial class DependencyInjection
+{
+    /// <summary>
+    /// Adds RedisMemory as a service.
+    /// </summary>
+    /// <param name="services">The services collection</param>
+    /// <param name="redisConfig">Redis configuration.</param>
+    public static IServiceCollection AddRedisAsMemoryDb(
+        this IServiceCollection services,
+        RedisConfig redisConfig)
+    {
+        return services
+            .AddSingleton(redisConfig)
+            .AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(redisConfig.ConnectionString))
+            .AddSingleton<IMemoryDb, RedisMemory>();
+    }
+}

--- a/extensions/Redis/README.md
+++ b/extensions/Redis/README.md
@@ -2,4 +2,28 @@
 
 [![Discord](https://img.shields.io/discord/1063152441819942922?label=Discord&logo=discord&logoColor=white&color=d82679)](https://aka.ms/KMdiscord)
 
-This project will contain the [Redis](https://redis.io) adapter allowing to use Kernel Memory with Redis.
+## Notes about Redis Vector Search:
+
+Redis Vector search requires the use of
+Redis' [Search and Query capabilities](https://redis.io/docs/interact/search-and-query/).
+
+This is available in:
+
+* [Redis Stack](https://redis.io/docs/about/about-stack/)
+* [Azure Cache for Redis](https://azure.microsoft.com/en-us/products/cache) - Enterprise Tier only
+* [Redis Cloud](https://app.redislabs.com/)
+* [Redis Enterprise](https://redis.io/docs/about/redis-enterprise/)
+
+You can run Redis Stack locally in docker with the following command:
+
+```sh
+docker run -p 8001:8001 -p 6379:6379 redis/redis-stack
+```
+
+## Configuring Tag Filters
+
+Using tag filters with Redis requires you to to pre-define which tag fields you want. You can
+do so using the `RedisMemoryConfiguration.Tags` property (with the characters being the tag separators)
+while creating the dependency-injection pipeline. It's important that you pick a separator that will
+not appear in your data (otherwise your tags might over-match)
+

--- a/extensions/Redis/Redis.csproj
+++ b/extensions/Redis/Redis.csproj
@@ -24,7 +24,7 @@
     <Import Project="../../nuget-package.props"/>
 
     <PropertyGroup>
-        <IsPackable>true</IsPackable>
+        <IsPackable>false</IsPackable>
         <PackageId>Microsoft.KernelMemory.MemoryDb.Redis</PackageId>
         <Product>Redis connector for Kernel Memory</Product>
         <Description>Redis connector for Microsoft Kernel Memory, to store and search memory using Redis vector search and other Redis features.</Description>

--- a/extensions/Redis/Redis.csproj
+++ b/extensions/Redis/Redis.csproj
@@ -5,7 +5,9 @@
         <RollForward>LatestMajor</RollForward>
         <AssemblyName>Microsoft.KernelMemory.MemoryDb.Redis</AssemblyName>
         <RootNamespace>Microsoft.KernelMemory.MemoryDb.Redis</RootNamespace>
-        <NoWarn>$(NoWarn);CA1724;CS1591;</NoWarn>
+        <NoWarn>$(NoWarn);CA1724;CS1591;CA1308;CA1859;</NoWarn>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
@@ -14,10 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="System.Linq.Async"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <InternalsVisibleTo Include="Microsoft.UnitTests"/>
+        <PackageReference Include="NRedisStack"/>
     </ItemGroup>
 
     <Import Project="../../code-analysis.props"/>
@@ -25,15 +24,15 @@
     <Import Project="../../nuget-package.props"/>
 
     <PropertyGroup>
-        <IsPackable>false</IsPackable>
+        <IsPackable>true</IsPackable>
         <PackageId>Microsoft.KernelMemory.MemoryDb.Redis</PackageId>
         <Product>Redis connector for Kernel Memory</Product>
         <Description>Redis connector for Microsoft Kernel Memory, to store and search memory using Redis vector search and other Redis features.</Description>
-        <PackageTags>Memory, RAG, Kernel Memory, Redis, HNSW, AI, Artificial Intelligence, Embeddings, Vector DB, Vector Search, ETL</PackageTags>
+        <PackageTags>Redis Memory, RAG, Kernel Memory, Redis, HNSW, AI, Artificial Intelligence, Embeddings, Vector DB, Vector Search, ETL</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>
         <None Include="README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
     </ItemGroup>
-
+    
 </Project>

--- a/extensions/Redis/RedisConfig.cs
+++ b/extensions/Redis/RedisConfig.cs
@@ -1,10 +1,54 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 
 #pragma warning disable IDE0130 // reduce number of "using" statements
 // ReSharper disable once CheckNamespace - reduce number of "using" statements
 namespace Microsoft.KernelMemory;
 
+/// <summary>
+/// Lays out the tag fields that you want redis to index.
+/// </summary>
 public class RedisConfig
 {
-    // TODO
+    /// <summary>
+    /// Connection string required to connect to Redis
+    /// </summary>
+    public string ConnectionString { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the Prefix to use for prefix index names and all documents
+    /// inserted into Redis as part of Kernel Memory's operations.
+    /// </summary>
+    public string AppPrefix { get; }
+
+    /// <summary>
+    /// The Collection of tags that you want to be able to search on.
+    /// The Key is the tag name, and the char is the separator that you
+    /// want Redis to use to separate your tag fields. The default separator
+    /// is ','.
+    /// </summary>
+    public Dictionary<string, char?> Tags { get; } = new()
+    {
+        { Constants.ReservedDocumentIdTag, '|' },
+        { Constants.ReservedFileIdTag, '|' },
+        { Constants.ReservedFilePartitionTag, '|' },
+        { Constants.ReservedFileTypeTag, '|' },
+    };
+
+    /// <summary>
+    /// Initializes an instance of RedisMemoryConfiguration.
+    /// </summary>
+    /// <param name="appPrefix">The prefix to use for the index name and all documents inserted into Redis.</param>
+    /// <param name="tags">The collection of tags you want to be able to search on. The key</param>
+    public RedisConfig(string appPrefix = "km", Dictionary<string, char?>? tags = null)
+    {
+        this.AppPrefix = appPrefix;
+
+        if (tags is not null)
+        {
+            foreach (var tag in tags)
+            {
+                this.Tags[tag.Key] = tag.Value;
+            }
+        }
+    }
 }

--- a/extensions/Redis/RedisEmbeddingExtensions.cs
+++ b/extensions/Redis/RedisEmbeddingExtensions.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.KernelMemory.MemoryDb.Redis;
+
+/// <summary>
+/// Helper method for Embeddings.
+/// </summary>
+internal static class RedisEmbeddingExtensions
+{
+    public static byte[] VectorBlob(this Embedding embedding) => embedding.Data.ToArray().SelectMany(BitConverter.GetBytes).ToArray();
+}

--- a/extensions/Redis/RedisException.cs
+++ b/extensions/Redis/RedisException.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
-
 namespace Microsoft.KernelMemory.MemoryDb.Redis;
 
 public class RedisException : KernelMemoryException

--- a/extensions/Redis/RedisMemory.cs
+++ b/extensions/Redis/RedisMemory.cs
@@ -1,82 +1,352 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.AI;
 using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.KernelMemory.MemoryStorage;
+using NRedisStack;
+using NRedisStack.RedisStackCommands;
+using NRedisStack.Search;
+using NRedisStack.Search.Literals.Enums;
+using StackExchange.Redis;
 
 namespace Microsoft.KernelMemory.MemoryDb.Redis;
 
-/// <inheritdoc />
-public class RedisMemory : IMemoryDb
+/// <summary>
+/// Implementation of an IMemoryDb using Redis.
+/// </summary>
+public sealed class RedisMemory : IMemoryDb
 {
+    private readonly IDatabase _db;
+    private readonly ISearchCommandsAsync _search;
+    private readonly RedisConfig _config;
     private readonly ITextEmbeddingGenerator _embeddingGenerator;
-    private readonly ILogger<RedisMemory> _log;
+    private readonly ILogger<RedisMemory> _logger;
 
     /// <summary>
-    /// Create new instance
+    /// Initializes the <see cref="RedisMemory"/> instance
     /// </summary>
-    /// <param name="config">Redis connector configuration</param>
-    /// <param name="embeddingGenerator">Text embedding generator</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="multiplexer"></param>
+    /// <param name="config"></param>
+    /// <param name="embeddingGenerator"></param>
+    /// <param name="logger"></param>
     public RedisMemory(
         RedisConfig config,
+        IConnectionMultiplexer multiplexer,
         ITextEmbeddingGenerator embeddingGenerator,
-        ILogger<RedisMemory>? log = null)
+        ILogger<RedisMemory>? logger = null)
     {
+        this._config = config;
         this._embeddingGenerator = embeddingGenerator;
+        this._logger = logger ?? DefaultLogger<RedisMemory>.Instance;
+        this._search = multiplexer.GetDatabase().FT();
+        this._db = multiplexer.GetDatabase();
+    }
 
-        if (this._embeddingGenerator == null)
+    /// <inheritdoc />
+    public async Task CreateIndexAsync(string index, int vectorSize, CancellationToken cancellationToken = default)
+    {
+        var normalizedIndexName = NormalizeIndexName(index, this._config.AppPrefix);
+        var schema = new Schema().AddVectorField(EmbeddingFieldName, Schema.VectorField.VectorAlgo.HNSW, new Dictionary<string, object>()
         {
-            throw new RedisException("Embedding generator not configured");
+            { "TYPE", "FLOAT32" },
+            { "DIM", vectorSize },
+            { "DISTANCE_METRIC", "COSINE" }
+        });
+
+        var ftParams = new FTCreateParams().On(IndexDataType.HASH).Prefix($"{normalizedIndexName}:");
+
+        foreach (var tag in this._config.Tags)
+        {
+            var fieldName = tag.Key;
+            var separator = tag.Value ?? DefaultSeparator;
+            schema.AddTagField(fieldName, separator: separator.ToString());
         }
 
-        this._log = log ?? DefaultLogger<RedisMemory>.Instance;
+        try
+        {
+            await this._search.CreateAsync(normalizedIndexName, ftParams, schema).ConfigureAwait(false);
+        }
+        catch (RedisServerException ex)
+        {
+            if (!ex.Message.Contains("Index already exists", StringComparison.OrdinalIgnoreCase))
+            {
+                throw;
+            }
+        }
     }
 
     /// <inheritdoc />
-    public Task CreateIndexAsync(string index, int vectorSize, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<string>> GetIndexesAsync(CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        var result = await this._search._ListAsync().ConfigureAwait(false);
+        return result.Select(x => (string)x!);
     }
 
     /// <inheritdoc />
-    public Task<IEnumerable<string>> GetIndexesAsync(CancellationToken cancellationToken = default)
+    public async Task DeleteIndexAsync(string index, CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        var normalizedIndexName = NormalizeIndexName(index, this._config.AppPrefix);
+        try
+        {
+            // we are explicitly dropping all records associated with the index here.
+            await this._search.DropIndexAsync(normalizedIndexName, dd: true).ConfigureAwait(false);
+        }
+        catch (RedisServerException exception)
+        {
+            if (!exception.Message.Equals("unknown index name", StringComparison.OrdinalIgnoreCase))
+            {
+                throw;
+            }
+        }
     }
 
     /// <inheritdoc />
-    public Task DeleteIndexAsync(string index, CancellationToken cancellationToken = default)
+    public async Task<string> UpsertAsync(string index, MemoryRecord record, CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        var normalizedIndexName = NormalizeIndexName(index, this._config.AppPrefix);
+        var key = Key(normalizedIndexName, record.Id);
+        var fields = new List<HashEntry>();
+        fields.Add(new HashEntry(EmbeddingFieldName, record.Vector.VectorBlob()));
+        foreach (var item in record.Tags)
+        {
+            var isIndexed = this._config.Tags.TryGetValue(item.Key, out var c);
+            var separator = c ?? DefaultSeparator;
+            if (!isIndexed)
+            {
+                this._logger.LogWarning("Inserting un-indexed tag field: {Key}, will not be able to filter on it", item.Key);
+            }
+
+            if (item.Value.Any(s => s is not null && s.Contains(separator.ToString(), StringComparison.InvariantCulture)))
+            {
+                this._logger.LogWarning("Inserting indexed tag field with the selected separator: '{Separator}' in it", separator);
+            }
+
+            fields.Add(new HashEntry(item.Key, string.Join(separator, item.Value)));
+        }
+
+        if (record.Payload.Count != 0)
+        {
+            fields.Add(new HashEntry(PayloadFieldName, JsonSerializer.Serialize(record.Payload))); // assumption: it's safe to serialize/deserialize the payload to/from JSON.
+        }
+
+        await this._db.HashSetAsync(key, fields.ToArray()).ConfigureAwait(false);
+
+        return record.Id;
     }
 
     /// <inheritdoc />
-    public Task<string> UpsertAsync(string index, MemoryRecord record, CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<(MemoryRecord, double)> GetSimilarListAsync(string index, string text, ICollection<MemoryFilter>? filters = null, double minRelevance = 0, int limit = 1, bool withEmbeddings = false, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        var normalizedIndexName = NormalizeIndexName(index, this._config.AppPrefix);
+        var embedding = await this._embeddingGenerator.GenerateEmbeddingAsync(text, cancellationToken).ConfigureAwait(false);
+        var blob = embedding.VectorBlob();
+        var parameters = new Dictionary<string, object>
+        {
+            { "blob", blob },
+            { "limit", limit }
+        };
+
+        var sb = new StringBuilder();
+        if (filters != null && filters.Any(x => x.Pairs.Any()))
+        {
+            foreach ((string key, string? value) in filters.SelectMany(x => x.Pairs))
+            {
+                if (value is null)
+                {
+                    this._logger.LogWarning("Attempted to perform null check on tag field. This behavior is not supported by Redis");
+                }
+
+                sb.Append(CultureInfo.InvariantCulture, $"@{key}:{{{value}}} ");
+            }
+        }
+        else
+        {
+            sb.Append('*');
+        }
+
+        sb.Append($"=>[KNN $limit @{EmbeddingFieldName} $blob]");
+
+        var query = new Query(sb.ToString());
+        query.Params(parameters);
+        query.Limit(0, limit);
+        query.Dialect(2);
+
+        var result = await this._search.SearchAsync(normalizedIndexName, query).ConfigureAwait(false);
+        foreach (var doc in result.Documents)
+        {
+            var next = this.FromDocument(doc, withEmbeddings);
+            if (1 - next.Item2 > minRelevance)
+            {
+                yield return next;
+            }
+        }
     }
 
     /// <inheritdoc />
-    public IAsyncEnumerable<(MemoryRecord, double)> GetSimilarListAsync(string index, string text, ICollection<MemoryFilter>? filters = null, double minRelevance = 0, int limit = 1, bool withEmbeddings = false, CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<MemoryRecord> GetListAsync(string index, ICollection<MemoryFilter>? filters = null, int limit = 1, bool withEmbeddings = false, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
-    }
+        var normalizedIndexName = NormalizeIndexName(index, this._config.AppPrefix);
+        var sb = new StringBuilder();
+        if (filters != null && filters.Any(x => x.Pairs.Any()))
+        {
+            foreach ((string key, string? value) in filters.SelectMany(x => x.Pairs))
+            {
+                if (value is null)
+                {
+                    this._logger.LogWarning("Attempted to perform null check on tag field. This behavior is not supported by Redis");
+                }
 
-    /// <inheritdoc />
-    public IAsyncEnumerable<MemoryRecord> GetListAsync(string index, ICollection<MemoryFilter>? filters = null, int limit = 1, bool withEmbeddings = false, CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
+                sb.Append(CultureInfo.InvariantCulture, $" @{key}:{{{EscapeTagField(value!)}}}");
+            }
+        }
+        else
+        {
+            sb.Append('*');
+        }
+
+        var query = new Query(sb.ToString());
+        query.Limit(0, limit);
+        var result = await this._search.SearchAsync(normalizedIndexName, query).ConfigureAwait(false);
+        foreach (var doc in result.Documents)
+        {
+            yield return this.FromDocument(doc, withEmbeddings).Item1;
+        }
     }
 
     /// <inheritdoc />
     public Task DeleteAsync(string index, MemoryRecord record, CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        var normalizedIndexName = NormalizeIndexName(index, this._config.AppPrefix);
+        var key = Key(normalizedIndexName, record.Id);
+        return this._db.KeyDeleteAsync(key);
     }
+
+    #region private ================================================================================
+
+    private const string EmbeddingFieldName = "embedding";
+    private const string PayloadFieldName = "payload";
+    private const char DefaultSeparator = ',';
+    private const string DistanceFieldName = $"__{EmbeddingFieldName}_score";
+
+    /// <summary>
+    /// Characters to escape when serializing a tag expression.
+    /// </summary>
+    private static readonly char[] s_tagEscapeChars =
+    {
+        ',', '.', '<', '>', '{', '}', '[', ']', '"', '\'', ':', ';',
+        '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '-', '+', '=', '~', '|', ' ', '/',
+    };
+
+    /// <summary>
+    /// Special chars to specifically replace within index names to keep
+    /// index names consistent with other connectors.
+    /// </summary>
+    private static readonly Regex s_replaceIndexNameCharsRegex = new(@"[\s|\\|/|.|_|:]");
+
+    /// <summary>
+    /// Use designated KM separator
+    /// </summary>
+    private const string KmSeparator = "-";
+
+    private (MemoryRecord, double) FromDocument(NRedisStack.Search.Document doc, bool withEmbedding)
+    {
+        double distance = 0;
+        var memoryRecord = new MemoryRecord();
+        memoryRecord.Id = doc.Id.Split(":", 2)[1];
+        foreach (var field in doc.GetProperties())
+        {
+            if (field.Key == EmbeddingFieldName)
+            {
+                if (withEmbedding)
+                {
+                    var floats = ByteArrayToFloatArray((byte[])field.Value!);
+                    memoryRecord.Vector = new Embedding(floats);
+                }
+            }
+            else if (field.Key == PayloadFieldName)
+            {
+                var payload = JsonSerializer.Deserialize<Dictionary<string, object>>(field.Value.ToString());
+                memoryRecord.Payload = payload ?? new Dictionary<string, object>();
+            }
+            else if (field.Key == DistanceFieldName)
+            {
+                distance = (double)field.Value;
+            }
+            else
+            {
+                this._config.Tags.TryGetValue(field.Key, out var c);
+                var separator = c ?? DefaultSeparator;
+                var values = ((string)field.Value!).Split(separator);
+                memoryRecord.Tags.Add(new KeyValuePair<string, List<string?>>(field.Key, new List<string?>(values)));
+            }
+        }
+
+        return (memoryRecord, distance);
+    }
+
+    /// <summary>
+    /// Normalizes the provided index name to maintain consistent looking
+    /// index names across connections. Naturally Redis's index names
+    /// are binary safe so this is purely for consistency.
+    /// </summary>
+    private static string NormalizeIndexName(string index, string? prefix = null)
+    {
+        if (string.IsNullOrWhiteSpace(index))
+        {
+            index = Constants.DefaultIndex;
+        }
+
+        var indexWithPrefix = !string.IsNullOrWhiteSpace(prefix) ? $"{prefix}-{index}" : index;
+
+        indexWithPrefix = s_replaceIndexNameCharsRegex.Replace(indexWithPrefix.Trim().ToLowerInvariant(), KmSeparator);
+
+        return indexWithPrefix;
+    }
+
+    /// <summary>
+    /// Escapes a tag field string.
+    /// </summary>
+    /// <param name="text">the text toe escape.</param>
+    /// <returns>The Escaped Text.</returns>
+    private static string EscapeTagField(string text)
+    {
+        var sb = new StringBuilder();
+        foreach (var c in text)
+        {
+            if (s_tagEscapeChars.Contains(c))
+            {
+                sb.Append('\\');
+            }
+
+            sb.Append(c);
+        }
+
+        return sb.ToString();
+    }
+
+    private static RedisKey Key(string indexWithPrefix, string id) => $"{indexWithPrefix}:{id}";
+
+    private static float[] ByteArrayToFloatArray(byte[] bytes)
+    {
+        if (bytes.Length % 4 != 0)
+        {
+            throw new InvalidOperationException("Encountered an unbalanced array of bytes for float array conversion");
+        }
+
+        var res = new float[bytes.Length / 4];
+        for (int i = 0; i < bytes.Length / 4; i++)
+        {
+            res[i] = BitConverter.ToSingle(bytes, i * 4);
+        }
+
+        return res;
+    }
+
+    #endregion
 }

--- a/service/tests/redis-tests/MockEmbeddingGenerator.cs
+++ b/service/tests/redis-tests/MockEmbeddingGenerator.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.KernelMemory;
+using Microsoft.KernelMemory.AI;
+
+namespace redis_tests;
+
+internal class MockEmbeddingGenerator : ITextEmbeddingGenerator
+{
+    private readonly Dictionary<string, float[]> _embeddings = new();
+
+    internal void AddFakeEmbedding(string str, float[] floats)
+    {
+        this._embeddings.Add(str, floats);
+    }
+
+    /// <inheritdoc />
+    public int CountTokens(string text) => 0;
+
+    /// <inheritdoc />
+    public int MaxTokens => 0;
+
+    /// <inheritdoc />
+    public Task<Embedding> GenerateEmbeddingAsync(string text, CancellationToken cancellationToken = default) =>
+        Task.FromResult(new Embedding(this._embeddings[text]));
+}

--- a/service/tests/redis-tests/Program.cs
+++ b/service/tests/redis-tests/Program.cs
@@ -1,0 +1,104 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using Microsoft.KernelMemory;
+using Microsoft.KernelMemory.MemoryDb.Redis;
+using Microsoft.KernelMemory.MemoryStorage;
+using StackExchange.Redis;
+using redis_tests;
+
+var muxer = await ConnectionMultiplexer.ConnectAsync("localhost");
+var embeddingGenerator = new MockEmbeddingGenerator();
+var tags = new Dictionary<string, char?>()
+{
+    { "updated", '|' },
+    { "type", '|' }
+};
+var memory = new RedisMemory(new RedisConfig(tags: tags), muxer, embeddingGenerator);
+
+Console.WriteLine("===== DELETE INDEX =====");
+
+await memory.DeleteIndexAsync("test");
+
+Console.WriteLine("===== CREATE INDEX =====");
+
+await memory.CreateIndexAsync("test", 5);
+
+Console.WriteLine("===== INSERT RECORD 1 =====");
+
+const string Text = "test1";
+var embedding = new[] { 0f, 0, 1, 0, 1 };
+embeddingGenerator.AddFakeEmbedding(Text, embedding);
+
+var memoryRecord1 = new MemoryRecord
+{
+    Id = "memory 1",
+    Vector = embedding,
+    Tags = new TagCollection { { "updated", "no" }, { "type", "email" } },
+    Payload = new Dictionary<string, object>()
+};
+
+var id1 = await memory.UpsertAsync("test", memoryRecord1);
+Console.WriteLine($"Insert 1: {id1} {memoryRecord1.Id}");
+
+Console.WriteLine("===== INSERT RECORD 2 =====");
+
+var memoryRecord2 = new MemoryRecord
+{
+    Id = "memory two",
+    Vector = new[] { 0f, 0, 1, 0, 1 },
+    Tags = new TagCollection { { "type", "news" } },
+    Payload = new Dictionary<string, object>()
+};
+
+var id2 = await memory.UpsertAsync("test", memoryRecord2);
+Console.WriteLine($"Insert 2: {id2} {memoryRecord2.Id}");
+
+Console.WriteLine("===== UPDATE RECORD 2 =====");
+memoryRecord2.Tags.Add("updated", "yes");
+id2 = await memory.UpsertAsync("test", memoryRecord2);
+Console.WriteLine($"Update 2: {id2} {memoryRecord2.Id}");
+
+Console.WriteLine("===== SEARCH 1 =====");
+
+var similarList = memory.GetSimilarListAsync("test", text: Text,
+    limit: 10, withEmbeddings: true);
+await foreach ((MemoryRecord, double) record in similarList)
+{
+    Console.WriteLine(record.Item1.Id);
+    Console.WriteLine("  tags: " + record.Item1.Tags.Count);
+    Console.WriteLine("  size: " + record.Item1.Vector.Length);
+}
+
+Console.WriteLine("===== SEARCH 2 =====");
+
+similarList = memory.GetSimilarListAsync("test", text: Text,
+    limit: 10, withEmbeddings: true, filters: new List<MemoryFilter> { MemoryFilters.ByTag("type", "email") });
+await foreach ((MemoryRecord, double) record in similarList)
+{
+    Console.WriteLine(record.Item1.Id);
+    Console.WriteLine("  type: " + record.Item1.Tags["type"].First());
+}
+
+Console.WriteLine("===== LIST =====");
+
+var list = memory.GetListAsync("test", limit: 10, withEmbeddings: false);
+await foreach (MemoryRecord record in list)
+{
+    Console.WriteLine(record.Id);
+    Console.WriteLine("  type: " + record.Tags["type"].First());
+}
+
+Console.WriteLine("===== DELETE =====");
+
+await memory.DeleteAsync("test", new MemoryRecord { Id = "memory 1" });
+
+Console.WriteLine("===== LIST AFTER DELETE =====");
+
+list = memory.GetListAsync("test", limit: 10, withEmbeddings: false);
+await foreach (MemoryRecord record in list)
+{
+    Console.WriteLine(record.Id);
+    Console.WriteLine("  type: " + record.Tags["type"].First());
+}
+
+Console.WriteLine("== Done ==");

--- a/service/tests/redis-tests/redis-tests.csproj
+++ b/service/tests/redis-tests/redis-tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <RootNamespace>redis_tests</RootNamespace>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);CA1050,CA2007,CA1826,CA1303,CA1307,SKEXP0001</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\extensions\Redis\Redis.csproj" />
+      <ProjectReference Include="..\..\Abstractions\Abstractions.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tools/README.md
+++ b/tools/README.md
@@ -42,3 +42,10 @@ Script to start RabbitMQ using Docker, for local development/debugging.
 RabbitMQ is used to provides queues for the asynchronous pipelines,
 as an alternative to
 [Azure Queues](https://learn.microsoft.com/azure/storage/queues/storage-queues-introduction).
+
+# run-redis.sh
+
+Script to start Redis using Docker, for local development/debugging.
+
+Redis is used to store and search vectors, as an alternative to
+[Azure AI Search](https://azure.microsoft.com/products/ai-services/ai-search/).

--- a/tools/run-redis.sh
+++ b/tools/run-redis.sh
@@ -1,0 +1,1 @@
+docker run -p 6379:6379 redis/redis-stack-server


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
Implements #199 

## High level description (Approach, Design)
Adds [Redis Vector Search](https://redis.io/docs/get-started/vector-database/) as an `IMemoryDb`.

Couple of high-level notes:

1. Tags in Redis need to be pre-defined if you want to filter on them. Also the way the Redis stores tags in a hash means you use a separator character to mark individual tags e.g. `'topics': ['tech', 'microsoft', 'redis']` would be stored in Redis as `HSET key topics tech,microsoft,redis` then when you search on the tag e.g. `@topics:{redis}` it will match. What this means from the user's perspective if that if they want to use tags they will need to predefined it before they create the index. I've added a bit to the dependency injection to note this. I also added as a blurb in the README (don't know if there's anywhere else to add those notes to socialize it better)
2. Redis Vector Search uses outputs a cosinal distance rather than cosinal relevance (hence the weird 1 - distance in the post-filter) 
3. WRT compatibility - I wrote this against the latest Redis Search and Query library, so the items that are listed in the README (Azure Cache for Redis Enterprise tier, Redis Enterprise, Redis Cloud, Redis Stack).

I also added a new test project in line with the other console test projects I saw in here. There's really not too much to test at a unit level here so idk if there's anything else you want on that end.