### PR TITLE
Change the user secrets configuration source of Env.Var

### DIFF
--- a/service/Core/Configuration/Env.cs
+++ b/service/Core/Configuration/Env.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.KernelMemory.Configuration;
 
@@ -13,7 +14,7 @@ public sealed class Env
     public static string Var(string key)
     {
         var configuration = new ConfigurationBuilder()
-            .AddUserSecrets<Env>()
+            .AddUserSecrets(Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly())
             .Build();
 
         var value = configuration[key];


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

**Before:** 
Since the Core project does not configure UserSecretId, it is not possible to retrieve the configuration from UserSecrets through Env.Var().

**After:** 
The places where Env.Var() is used are usually the entry points for application configuration. Specifying EntryAssembly or CallingAssembly can retrieve the configuration in UserSecrets in the current project, if UserSecretId is configured.

## High level description (Approach, Design)

