### PR TITLE
Allow passing custom HttpClient

### DIFF
--- a/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
+++ b/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Identity;
@@ -21,15 +22,17 @@ public class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
     public AzureOpenAITextEmbeddingGenerator(
         AzureOpenAIConfig config,
         ITextTokenizer? textTokenizer = null,
-        ILoggerFactory? loggerFactory = null)
-        : this(config, textTokenizer, loggerFactory?.CreateLogger<AzureOpenAITextEmbeddingGenerator>())
+        ILoggerFactory? loggerFactory = null,
+        HttpClient? httpClient = null)
+        : this(config, textTokenizer, loggerFactory?.CreateLogger<AzureOpenAITextEmbeddingGenerator>(), httpClient)
     {
     }
 
     public AzureOpenAITextEmbeddingGenerator(
         AzureOpenAIConfig config,
         ITextTokenizer? textTokenizer = null,
-        ILogger<AzureOpenAITextEmbeddingGenerator>? log = null)
+        ILogger<AzureOpenAITextEmbeddingGenerator>? log = null,
+        HttpClient? httpClient = null)
     {
         this._log = log ?? DefaultLogger<AzureOpenAITextEmbeddingGenerator>.Instance;
 
@@ -52,7 +55,8 @@ public class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
                     deploymentName: config.Deployment,
                     modelId: config.Deployment,
                     endpoint: config.Endpoint,
-                    credential: new DefaultAzureCredential());
+                    credential: new DefaultAzureCredential(),
+                    httpClient: httpClient);
                 break;
 
             case AzureOpenAIConfig.AuthTypes.APIKey:
@@ -60,7 +64,8 @@ public class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
                     deploymentName: config.Deployment,
                     modelId: config.Deployment,
                     endpoint: config.Endpoint,
-                    apiKey: config.APIKey);
+                    apiKey: config.APIKey,
+                    httpClient: httpClient);
                 break;
 
             default:

--- a/extensions/AzureOpenAI/AzureOpenAITextGenerator.cs
+++ b/extensions/AzureOpenAI/AzureOpenAITextGenerator.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,15 +28,17 @@ public class AzureOpenAITextGenerator : ITextGenerator
     public AzureOpenAITextGenerator(
         AzureOpenAIConfig config,
         ITextTokenizer? textTokenizer = null,
-        ILoggerFactory? loggerFactory = null)
-        : this(config, textTokenizer, loggerFactory?.CreateLogger<AzureOpenAITextGenerator>())
+        ILoggerFactory? loggerFactory = null,
+        HttpClient? httpClient = null)
+        : this(config, textTokenizer, loggerFactory?.CreateLogger<AzureOpenAITextGenerator>(), httpClient)
     {
     }
 
     public AzureOpenAITextGenerator(
         AzureOpenAIConfig config,
         ITextTokenizer? textTokenizer = null,
-        ILogger<AzureOpenAITextGenerator>? log = null)
+        ILogger<AzureOpenAITextGenerator>? log = null,
+        HttpClient? httpClient = null)
     {
         this._log = log ?? DefaultLogger<AzureOpenAITextGenerator>.Instance;
 
@@ -72,6 +75,11 @@ public class AzureOpenAITextGenerator : ITextGenerator
                 ApplicationId = Telemetry.HttpUserAgent,
             }
         };
+
+        if (httpClient is not null)
+        {
+            options.Transport = new HttpClientTransport(httpClient);
+        }
 
         switch (config.Auth)
         {

--- a/extensions/OpenAI/OpenAITextEmbeddingGenerator.cs
+++ b/extensions/OpenAI/OpenAITextEmbeddingGenerator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -18,15 +19,17 @@ public class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
     public OpenAITextEmbeddingGenerator(
         OpenAIConfig config,
         ITextTokenizer? textTokenizer = null,
-        ILoggerFactory? loggerFactory = null)
-        : this(config, textTokenizer, loggerFactory?.CreateLogger<OpenAITextEmbeddingGenerator>())
+        ILoggerFactory? loggerFactory = null,
+        HttpClient? httpClient = null)
+        : this(config, textTokenizer, loggerFactory?.CreateLogger<OpenAITextEmbeddingGenerator>(), httpClient)
     {
     }
 
     public OpenAITextEmbeddingGenerator(
         OpenAIConfig config,
         ITextTokenizer? textTokenizer = null,
-        ILogger<OpenAITextEmbeddingGenerator>? log = null)
+        ILogger<OpenAITextEmbeddingGenerator>? log = null,
+        HttpClient? httpClient = null)
     {
         this._log = log ?? DefaultLogger<OpenAITextEmbeddingGenerator>.Instance;
 
@@ -45,7 +48,8 @@ public class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
         this._client = new OpenAITextEmbeddingGenerationService(
             modelId: config.EmbeddingModel,
             apiKey: config.APIKey,
-            organization: config.OrgId);
+            organization: config.OrgId,
+            httpClient: httpClient);
     }
 
     /// <inheritdoc/>

--- a/extensions/OpenAI/OpenAITextGenerator.cs
+++ b/extensions/OpenAI/OpenAITextGenerator.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,15 +28,17 @@ public class OpenAITextGenerator : ITextGenerator
     public OpenAITextGenerator(
         OpenAIConfig config,
         ITextTokenizer? textTokenizer = null,
-        ILoggerFactory? loggerFactory = null)
-        : this(config, textTokenizer, loggerFactory?.CreateLogger<OpenAITextGenerator>())
+        ILoggerFactory? loggerFactory = null,
+        HttpClient? httpClient = null)
+        : this(config, textTokenizer, loggerFactory?.CreateLogger<OpenAITextGenerator>(), httpClient)
     {
     }
 
     public OpenAITextGenerator(
         OpenAIConfig config,
         ITextTokenizer? textTokenizer = null,
-        ILogger<OpenAITextGenerator>? log = null)
+        ILogger<OpenAITextGenerator>? log = null,
+        HttpClient? httpClient = null)
     {
         var textModels = new List<string>
         {
@@ -77,6 +80,11 @@ public class OpenAITextGenerator : ITextGenerator
                 ApplicationId = Telemetry.HttpUserAgent,
             }
         };
+
+        if (httpClient is not null)
+        {
+            options.Transport = new HttpClientTransport(httpClient);
+        }
 
         this._client = new OpenAIClient(config.APIKey, options);
     }


### PR DESCRIPTION
## Motivation and Context
For some businesses and their teams, there is often a need for more detailed and personalized configuration when using HttpClient to make network requests. Semantic Kernel already supports this. However, inconsistencies in operation were found when using Semantic Kernel and Kernel Memory synchronously. To address this issue, this improvement PR has been submitted, aiming to standardize the corresponding features to be on par with the design of Semantic Kernel. Reference: https://github.com/microsoft/semantic-kernel/pull/743

## Description

Introduce a new optional parameter named `httpClient`. By setting its default value to `null`, we ensure that the existing user's code remains unaffected and backward compatible.
