### PR TITLE
Improve error message used when token count is too high (+ docs)

### DIFF
--- a/docs/how-to/custom-partitioning.md
+++ b/docs/how-to/custom-partitioning.md
@@ -1,0 +1,79 @@
+---
+nav_order: 1
+parent: How-to guides
+title: Partitioning & chunking
+permalink: /how-to/custom-partitioning
+layout: default
+---
+================
+# Custom Text Partitioning / Chunking
+
+Kernel Memory extracts text from images, pages, and documents, and then partitions the text into
+smaller chunks. This partitioning step is essential for efficient processing.
+
+By default, the partitioning process is managed by the
+[TextPartitioningHandler](https://github.com/microsoft/kernel-memory/blob/main/service/Core/Handlers/TextPartitioningHandler.cs),
+which uses settings defined in
+[TextPartitioningOptions](https://github.com/microsoft/kernel-memory/blob/main/service/Core/Handlers/TextPartitioningOptions.cs).
+
+## Partitioning Process
+
+The handler performs the following steps:
+
+1. **Split text into lines**: If a line is too long, it stops and starts a new line.
+2. **Form paragraphs**: Concatenate consecutive lines together up to a maximum paragraph size.
+3. **Overlap**: When starting a new paragraph, retain a certain number of lines from the previous paragraph.
+
+## Default Settings
+
+The default values used by `TextPartitioningHandler` are:
+
+| Setting          | Value           |
+|------------------|-----------------|
+| Paragraph length | 1000 tokens max |
+| Line length      | 300 tokens max  |
+| Overlap          | 100 tokens      |
+
+Lengths are expressed in tokens, which depend on the large language model (LLM) in use and its
+tokenization logic. KernelMemoryBuilder allows specifying a custom tokenizer for each LLM during setup.
+
+## Customizing Partitioning Options
+
+Normally, the default settings are much lower than the maximum number of tokens supported by a model.
+However, when working with custom models, **some of these might have a lower limit, leading to errors** such as:
+
+{: .warning }
+> The configured partition size **(1000 tokens)** is too big for one of the embedding generators in use.
+> The max value allowed is **256 tokens**.
+
+To avoid these errors, or to customize Kernel Memory's behavior, you can modify `TextPartitioningOptions`.
+Although the [service configuration file](https://github.com/microsoft/kernel-memory/blob/main/service/Service/appsettings.json)
+does not support these settings yet, you can edit [Program.cs](https://github.com/microsoft/kernel-memory/blob/main/service/Service/Program.cs)
+as follows:
+
+```csharp
+var memory = new KernelMemoryBuilder(appBuilder.Services)
+    .FromAppSettings()
+    .With(new TextPartitioningOptions
+    {
+        MaxTokensPerParagraph = 256,
+        MaxTokensPerLine = 256,
+        OverlappingTokens = 50,
+    })
+    .Build();
+
+```
+
+For serverless memory, use this code:
+
+```csharp
+var memory = new KernelMemoryBuilder()
+    .WithOpenAIDefaults(...)
+    .With(new TextPartitioningOptions
+    {
+        MaxTokensPerParagraph = 256,
+        MaxTokensPerLine = 256,
+        OverlappingTokens = 50,
+    })
+    .Build<MemoryServerless>();
+```

--- a/docs/how-to/custom-pipelines.md
+++ b/docs/how-to/custom-pipelines.md
@@ -1,5 +1,5 @@
 ---
-nav_order: 2
+nav_order: 3
 parent: How-to guides
 title: Custom pipelines
 permalink: /how-to/custom-pipelines

--- a/docs/how-to/custom-prompts.md
+++ b/docs/how-to/custom-prompts.md
@@ -1,5 +1,5 @@
 ---
-nav_order: 1
+nav_order: 2
 parent: How-to guides
 title: Custom prompts
 permalink: /how-to/custom-prompts

--- a/docs/how-to/hugging-face.md
+++ b/docs/how-to/hugging-face.md
@@ -1,5 +1,5 @@
 ---
-nav_order: 3
+nav_order: 4
 parent: How-to guides
 title: Hugging Face models
 permalink: /how-to/hugging-face

--- a/service/Core/Configuration/InternalConstants.cs
+++ b/service/Core/Configuration/InternalConstants.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+#pragma warning disable IDE0130 // reduce number of "using" statements
+// ReSharper disable once CheckNamespace - reduce number of "using" statements
+namespace Microsoft.KernelMemory;
+
+/// <summary>
+/// Constants used internally only in this assembly, without need of shared Abstractions
+/// </summary>
+internal static class InternalConstants
+{
+    public const string DocsBaseUrl = "https://microsoft.github.io/kernel-memory";
+}

--- a/service/Core/Handlers/TextPartitioningHandler.cs
+++ b/service/Core/Handlers/TextPartitioningHandler.cs
@@ -60,7 +60,8 @@ public class TextPartitioningHandler : IPipelineStepHandler
             {
 #pragma warning disable CA2254 // the msg is always used
                 var errMsg = $"The configured partition size ({this._options.MaxTokensPerParagraph} tokens) is too big for one " +
-                             $"of the embedding generators in use. The max value allowed is {this._maxTokensPerPartition} tokens";
+                             $"of the embedding generators in use. The max value allowed is {this._maxTokensPerPartition} tokens. " +
+                             $"Consider changing the partitioning options, see {InternalConstants.DocsBaseUrl}/how-to/custom-partitioning for details.";
                 this._log.LogError(errMsg);
                 throw new ConfigurationException(errMsg);
 #pragma warning restore CA2254


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

When using a custom embedding generator that supports less than the default partitioning settings, the app shows an error without providing a path to resolution.

## High level description (Approach, Design)

Previous error message:
> The configured partition size (1000 tokens) is too big for one of the embedding generators in use. The max value allowed is 256 tokens

New error message:
> The configured partition size (1000 tokens) is too big for one of the embedding generators in use. The max value allowed is 256 tokens. Consider changing the partitioning options, see https://microsoft.github.io/kernel-memory/how-to/custom-partitioning for details.