### PR TITLE
Redis Memory follow up

### DIFF
--- a/extensions/Redis/README.md
+++ b/extensions/Redis/README.md
@@ -20,6 +20,8 @@ You can run Redis Stack locally in docker with the following command:
 docker run -p 8001:8001 -p 6379:6379 redis/redis-stack
 ```
 
+This will run Redis on port 6379, as well as running a popular Redis GUI, [RedisInsight](https://redis.com/redis-enterprise/redis-insight/), on port 8001.
+
 ## Configuring Tag Filters
 
 Using tag filters with Redis requires you to to pre-define which tag fields you want. You can

--- a/extensions/Redis/Redis/RedisConfig.cs
+++ b/extensions/Redis/Redis/RedisConfig.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+using NRedisStack.Search;
+
 #pragma warning disable IDE0130 // reduce number of "using" statements
 // ReSharper disable once CheckNamespace - reduce number of "using" statements
 namespace Microsoft.KernelMemory;
@@ -19,6 +21,11 @@ public class RedisConfig
     /// inserted into Redis as part of Kernel Memory's operations.
     /// </summary>
     public string AppPrefix { get; }
+
+    /// <summary>
+    /// Gets or sets the Vector Algorithm to use. Defaults to HNSW.
+    /// </summary>
+    public Schema.VectorField.VectorAlgo VectorAlgorithm { get; set; } = Schema.VectorField.VectorAlgo.HNSW;
 
     /// <summary>
     /// The Collection of tags that you want to be able to search on.

--- a/tools/README.md
+++ b/tools/README.md
@@ -46,6 +46,7 @@ as an alternative to
 # run-redis.sh
 
 Script to start Redis using Docker, for local development/debugging.
+This will run Redis on port 6379, as well as running a popular Redis GUI, [RedisInsight](https://redis.com/redis-enterprise/redis-insight/), on port 8001.
 
 Redis is used to store and search vectors, as an alternative to
 [Azure AI Search](https://azure.microsoft.com/products/ai-services/ai-search/).

--- a/tools/run-redis.sh
+++ b/tools/run-redis.sh
@@ -1,1 +1,1 @@
-docker run -p 6379:6379 redis/redis-stack-server
+docker run -p 8001:8001 -p 6379:6379 redis/redis-stack


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
Couple follow on items from #208 

1. making vector algorithm configurable (defaulting to HNSW)
2. Updating Readme to explain the presence of Redis Insight
3. Changing tooling to launch redis-stack with Redis insight as well
4. throwing an exception when you attempt to add a tag with the defined separator in it. 

