### PR TITLE
Elasticsearchtests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Azure.Storage.Queues" Version="12.17.1"/>
     <PackageVersion Include="ClosedXML" Version="0.102.1"/>
     <PackageVersion Include="DocumentFormat.OpenXml" Version="2.20.0"/>
-    <PackageVersion Include="FreeMindLabs.KernelMemory.Elasticsearch" Version="0.8.1"/>
+    <PackageVersion Include="FreeMindLabs.KernelMemory.Elasticsearch" Version="0.9.2"/>
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.57"/>
     <PackageVersion Include="KernelMemory.MemoryStorage.SqlServer" Version="1.0.3"/>
     <PackageVersion Include="LLamaSharp" Version="0.8.1"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Azure.Storage.Queues" Version="12.17.1"/>
     <PackageVersion Include="ClosedXML" Version="0.102.1"/>
     <PackageVersion Include="DocumentFormat.OpenXml" Version="2.20.0"/>
+    <PackageVersion Include="FreeMindLabs.KernelMemory.Elasticsearch" Version="0.8.1"/>
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.57"/>
     <PackageVersion Include="KernelMemory.MemoryStorage.SqlServer" Version="1.0.3"/>
     <PackageVersion Include="LLamaSharp" Version="0.8.1"/>

--- a/KernelMemory.sln
+++ b/KernelMemory.sln
@@ -254,6 +254,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestHelpers", "service\test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQLServer.FunctionalTests", "extensions\SQLServer\SQLServer.FunctionalTests\SQLServer.FunctionalTests.csproj", "{668A48B7-F600-4056-B47E-3200893C0404}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elasticsearch.FunctionalTests", "extensions\Elasticsearch\Elasticsearch.FunctionalTests\Elasticsearch.FunctionalTests.csproj", "{C089DE42-9D39-4633-AC0C-5034BA0B98E1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -321,6 +323,7 @@ Global
 		{62B96766-AA6C-4CFF-A6FB-6370C89C2509} = {3C17F42B-CFC8-4900-8CFB-88936311E919}
 		{989061F4-164F-4D98-A3F9-601BC40EE216} = {5E7DD43D-B5E7-4827-B57D-447E5B428589}
 		{668A48B7-F600-4056-B47E-3200893C0404} = {3C17F42B-CFC8-4900-8CFB-88936311E919}
+		{C089DE42-9D39-4633-AC0C-5034BA0B98E1} = {3C17F42B-CFC8-4900-8CFB-88936311E919}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8A9FA587-7EBA-4D43-BE47-38D798B1C74C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -488,5 +491,8 @@ Global
 		{668A48B7-F600-4056-B47E-3200893C0404}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{668A48B7-F600-4056-B47E-3200893C0404}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{668A48B7-F600-4056-B47E-3200893C0404}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C089DE42-9D39-4633-AC0C-5034BA0B98E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C089DE42-9D39-4633-AC0C-5034BA0B98E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C089DE42-9D39-4633-AC0C-5034BA0B98E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/extensions/Elasticsearch/Elasticsearch.FunctionalTests/DefaultTests.cs
+++ b/extensions/Elasticsearch/Elasticsearch.FunctionalTests/DefaultTests.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using FreeMindLabs.KernelMemory.Elasticsearch;
+using FunctionalTests.DefaultTestCases;
+using Microsoft.KernelMemory;
+using Microsoft.TestHelpers;
+
+namespace Elasticsearch.FunctionalTests;
+
+public class DefaultTests : BaseFunctionalTestCase
+{
+    private readonly MemoryServerless _memory;
+    private readonly ElasticsearchConfig _elasticsearchConfig;
+
+    public DefaultTests(IConfiguration cfg, ITestOutputHelper output) : base(cfg, output)
+    {
+        Assert.False(string.IsNullOrEmpty(this.OpenAiConfig.APIKey));
+
+        this._elasticsearchConfig = cfg.GetSection("Services:Elasticsearch").Get<ElasticsearchConfig>()!;
+
+        this._memory = new KernelMemoryBuilder()
+            .WithSearchClientConfig(new SearchClientConfig { EmptyAnswer = NotFound })
+            .WithOpenAI(this.OpenAiConfig)
+            // .WithAzureOpenAITextGeneration(this.AzureOpenAITextConfiguration)
+            // .WithAzureOpenAITextEmbeddingGeneration(this.AzureOpenAIEmbeddingConfiguration)
+            .WithElasticsearch(this._elasticsearchConfig)
+            .Build<MemoryServerless>();
+    }
+
+    [Fact]
+    [Trait("Category", "Elasticsearch")]
+    public async Task ItSupportsASingleFilter()
+    {
+        await FilteringTest.ItSupportsASingleFilter(this._memory, this.Log);
+    }
+
+    [Fact]
+    [Trait("Category", "Elasticsearch")]
+    public async Task ItSupportsMultipleFilters()
+    {
+        await FilteringTest.ItSupportsMultipleFilters(this._memory, this.Log);
+    }
+
+    [Fact]
+    [Trait("Category", "Elasticsearch")]
+    public async Task ItIgnoresEmptyFilters()
+    {
+        await FilteringTest.ItIgnoresEmptyFilters(this._memory, this.Log, true);
+    }
+
+    [Fact]
+    [Trait("Category", "Elasticsearch")]
+    public async Task ItListsIndexes()
+    {
+        await IndexListTest.ItListsIndexes(this._memory, this.Log);
+    }
+
+    [Fact]
+    [Trait("Category", "Elasticsearch")]
+    public async Task ItNormalizesIndexNames()
+    {
+        await IndexListTest.ItNormalizesIndexNames(this._memory, this.Log);
+    }
+
+    [Fact]
+    [Trait("Category", "Elasticsearch")]
+    public async Task ItDeletesIndexes()
+    {
+        await IndexDeletionTest.ItDeletesIndexes(this._memory, this.Log);
+    }
+
+    [Fact]
+    [Trait("Category", "Elasticsearch")]
+    public async Task ItHandlesMissingIndexesConsistently()
+    {
+        await MissingIndexTest.ItHandlesMissingIndexesConsistently(this._memory, this.Log);
+    }
+
+    [Fact]
+    [Trait("Category", "Elasticsearch")]
+    public async Task ItUploadsPDFDocsAndDeletes()
+    {
+        await DocumentUploadTest.ItUploadsPDFDocsAndDeletes(this._memory, this.Log);
+    }
+
+    [Fact]
+    [Trait("Category", "Elasticsearch")]
+    public async Task ItSupportsTags()
+    {
+        await DocumentUploadTest.ItSupportsTags(this._memory, this.Log);
+    }
+}

--- a/extensions/Elasticsearch/Elasticsearch.FunctionalTests/DefaultTests.cs
+++ b/extensions/Elasticsearch/Elasticsearch.FunctionalTests/DefaultTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using FreeMindLabs.KernelMemory.Elasticsearch;
+using FreeMindLabs.KernelMemory.Elasticsearch; // For dluc: This is still needed for ElasticsearchConfig. I'll see to remove it.
 using FunctionalTests.DefaultTestCases;
 using Microsoft.KernelMemory;
+using Microsoft.KernelMemory.ContentStorage.DevTools;
+using Microsoft.KernelMemory.FileSystem.DevTools;
 using Microsoft.TestHelpers;
 
 namespace Elasticsearch.FunctionalTests;
@@ -24,6 +26,12 @@ public class DefaultTests : BaseFunctionalTestCase
             // .WithAzureOpenAITextGeneration(this.AzureOpenAITextConfiguration)
             // .WithAzureOpenAITextEmbeddingGeneration(this.AzureOpenAIEmbeddingConfiguration)
             .WithElasticsearch(this._elasticsearchConfig)
+            // For dluc: this is the only storage I could make work for now...
+            .WithSimpleFileStorage(new SimpleFileStorageConfig()
+            {
+                Directory = "ContentStorage",
+                StorageType = FileSystemTypes.Volatile
+            })
             .Build<MemoryServerless>();
     }
 

--- a/extensions/Elasticsearch/Elasticsearch.FunctionalTests/Elasticsearch.FunctionalTests.csproj
+++ b/extensions/Elasticsearch/Elasticsearch.FunctionalTests/Elasticsearch.FunctionalTests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <RollForward>LatestMajor</RollForward>
+        <IsTestProject>true</IsTestProject>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
+        <NoWarn>$(NoWarn);CA1859;</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FreeMindLabs.KernelMemory.Elasticsearch" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.abstractions"/>
+        <PackageReference Include="Xunit.DependencyInjection"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\service\tests\Core.FunctionalTests\Core.FunctionalTests.csproj"/>
+        <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/extensions/Elasticsearch/Elasticsearch.FunctionalTests/Startup.cs
+++ b/extensions/Elasticsearch/Elasticsearch.FunctionalTests/Startup.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+/* IMPORTANT: the Startup class must be at the root of the namespace and
+ * the namespace must match exactly (required by Xunit.DependencyInjection) */
+
+namespace Elasticsearch.FunctionalTests;
+
+public class Startup
+{
+    // ReSharper disable once UnusedMember.Global
+    public void ConfigureHost(IHostBuilder hostBuilder)
+    {
+        var config = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json")
+            .AddJsonFile("appsettings.development.json", optional: true)
+            .AddUserSecrets<Startup>()
+            .AddEnvironmentVariables()
+            .Build();
+
+        hostBuilder.ConfigureHostConfiguration(builder => builder.AddConfiguration(config));
+    }
+}

--- a/extensions/Elasticsearch/Elasticsearch.FunctionalTests/Usings.cs
+++ b/extensions/Elasticsearch/Elasticsearch.FunctionalTests/Usings.cs
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+global using Xunit;
+global using Xunit.Abstractions;

--- a/extensions/Elasticsearch/Elasticsearch.FunctionalTests/appsettings.json
+++ b/extensions/Elasticsearch/Elasticsearch.FunctionalTests/appsettings.json
@@ -1,0 +1,59 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
+  "Services": {
+    "Elasticsearch": {
+      "CertificateFingerPrint": "",
+      "Endpoint": "",
+      "UserName": "",
+      "Password": "",
+    },
+    "AzureOpenAIText": {
+      // "ApiKey" or "AzureIdentity"
+      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+      "Auth": "AzureIdentity",
+      "Endpoint": "https://<...>.openai.azure.com/",
+      "APIKey": "",
+      "Deployment": "",
+      // The max number of tokens supported by model deployed
+      // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+      "MaxTokenTotal": 16384,
+      // "ChatCompletion" or "TextCompletion"
+      "APIType": "ChatCompletion",
+      "MaxRetries": 10
+    },
+    "AzureOpenAIEmbedding": {
+      // "ApiKey" or "AzureIdentity"
+      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+      "Auth": "AzureIdentity",
+      "Endpoint": "https://<...>.openai.azure.com/",
+      "APIKey": "",
+      "Deployment": "",
+      // The max number of tokens supported by model deployed
+      // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+      "MaxTokenTotal": 8191,
+    },
+    "OpenAI": {
+      // Name of the model used to generate text (text completion or chat completion)
+      "TextModel": "gpt-3.5-turbo-16k",
+      // The max number of tokens supported by the text model.
+      "TextModelMaxTokenTotal": 16384,
+      // Name of the model used to generate text embeddings
+      "EmbeddingModel": "text-embedding-ada-002",
+      // The max number of tokens supported by the embedding model
+      // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
+      "EmbeddingModelMaxTokenTotal": 8191,
+      // OpenAI API Key
+      "APIKey": "",
+      // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
+      "OrgId": "",
+      // How many times to retry in case of throttling
+      "MaxRetries": 10
+    },
+  }
+}

--- a/extensions/Elasticsearch/Elasticsearch.FunctionalTests/appsettings.json
+++ b/extensions/Elasticsearch/Elasticsearch.FunctionalTests/appsettings.json
@@ -7,9 +7,15 @@
   "Services": {
     "Elasticsearch": {
       "CertificateFingerPrint": "",
-      "Endpoint": "",
-      "UserName": "",
+      "Endpoint": "https://localhost:9200",
+      "UserName": "elastic",
       "Password": "",
+      "IndexPrefix": "kmtests-"
+    },
+    "SimpleFileStorage": {
+      // This is temporary... FIX IT
+      "Directory": "bin//Debug//net6.0/.storage",
+      "StorageType": "Disk"
     },
     "AzureOpenAIText": {
       // "ApiKey" or "AzureIdentity"
@@ -36,7 +42,7 @@
       "Deployment": "",
       // The max number of tokens supported by model deployed
       // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-      "MaxTokenTotal": 8191,
+      "MaxTokenTotal": 8191
     },
     "OpenAI": {
       // Name of the model used to generate text (text completion or chat completion)
@@ -54,6 +60,6 @@
       "OrgId": "",
       // How many times to retry in case of throttling
       "MaxRetries": 10
-    },
+    }
   }
 }

--- a/extensions/Elasticsearch/README.md
+++ b/extensions/Elasticsearch/README.md
@@ -1,0 +1,45 @@
+# Kernel Memory with Elasticsearch
+
+[![Nuget package](https://img.shields.io/nuget/v/FreeMindLabs.KernelMemory.Elasticsearch)](https://www.nuget.org/packages/FreeMindLabs.KernelMemory.Elasticsearch/)
+[![Discord](https://img.shields.io/discord/1063152441819942922?label=Discord&logo=discord&logoColor=white&color=d82679)](https://aka.ms/KMdiscord)
+
+This folder contains tests for the [Elastisearch](https://www.elastic.co/) extension for Kernel Memory
+maintained by [FreemindLabs](https://github.com/freemindlabsinc/FreeMindLabs.KernelMemory.Elasticsearch).
+
+Configuration (appsettings.json):
+
+```json
+  // ...
+    "Elasticsearch": {
+        "Endpoint": "",
+        "UserName": "",
+        "CertificateFingerPrint": "",
+        "Password": "",
+    },
+  // ...
+```
+
+You can test the connector locally with Docker:
+
+```shell
+docker run -it -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" --rm elasticsearch:8.11.3
+```
+
+The command should print on screen configuration details, such as fingerprint and default password. Copy
+the values in `appsettings.development.json`. For example:
+
+```json
+  // ...
+    "Elasticsearch": {
+      "Endpoint": "https://localhost:9200",
+      "UserName": "elastic",
+      "CertificateFingerPrint": "b2ffe859bde01ece5734526a29b1ce7646b36030835cbbe81424a26151f5f2c5",
+      "Password": "defg...."
+    },
+  // ...
+```
+
+For more information about the Elasticsearch extension:
+
+- https://github.com/freemindlabsinc/FreeMindLabs.KernelMemory.Elasticsearch
+- https://devblogs.microsoft.com/semantic-kernel/elasticsearch-kernelmemory


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

@dluc created the Elasticsearch functional tests for the Elasticsearch connector and notified me that pretty much all of them were failing. I fixed a few issues in my package FreeMindLabs.KernelMemory.Elasticsearch and ensured the test all passed.

## High level description (Approach, Design)
This is the list of changes:
1. Changed ref to FreeMindLabs nuget to 0.9.2
2. All Elasticsearch functional tests pass
3. I changed appSettings.json to include the new configuration options.
4. Left a couple of notes for dluc in DefaultTests.cs

One issue arose at least one time during tests:
1. The test ItSupportsASingleFilter does not always succeed. Timing issues with the documents being saved in ES before the read? 