### PR TITLE
Update upload-example.sh

### DIFF
--- a/examples/005-curl-calling-webservice/upload-example.sh
+++ b/examples/005-curl-calling-webservice/upload-example.sh
@@ -4,4 +4,4 @@ set -e
 
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/"
 
-../../tools/upload-file.sh -s http://127.0.0.1:9001 -f test.pdf -t "type=test"
+../../tools/upload-file.sh -s http://127.0.0.1:9001 -f test.pdf -t "type:test"


### PR DESCRIPTION
fix an issue where "=" is not accepted in KM.

<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
Error received when running upload example.sh
`Microsoft.KernelMemory.KernelMemoryException: A tag name cannot contain the '=' char`


## High level description (Approach, Design)
A simple fix for an error when running the sample
