### PR TITLE
-Changed the reference to the latest Elasticsearch plugin nuget (0.9.5)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.KernelMemory.Abstractions" Version="0.26.240104.1" />
     <PackageVersion Include="KernelMemory.MemoryStorage.SqlServer" Version="1.0.3" />
-    <PackageVersion Include="FreeMindLabs.KernelMemory.Elasticsearch" Version="0.9.2" />
+    <PackageVersion Include="FreeMindLabs.KernelMemory.Elasticsearch" Version="0.9.5" />
   </ItemGroup>
   <!-- Semantic Kernel -->
   <ItemGroup>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

The upgrade to version 0.9.5 of FreeMindLabs.KernelMemory.Elasticsearch resolved a series of issues:
-Filters with multiple tags resulted in only the last tag to be considered.
-Ensured that deletes and upserts wait for the data to be available for search before continuing. Tests would fail sporadically.

## High level description (Approach, Design)

The changes are in the FMKL nuget, but the following links are related to the "eventually consistent" timing issue:
1. https://stackoverflow.com/questions/40676324/elasticsearch-updates-are-not-immediate-how-do-you-wait-for-elasticsearch-to-fi
2. https://www.jillesvangurp.com/blog/2014-12-04-eventual-consistency-now-using-elasticsearch-and-redis.html
