### PR TITLE
Fix the reference to security-filters.md

### DIFF
--- a/examples/001-dotnet-WebClient/Program.cs
+++ b/examples/001-dotnet-WebClient/Program.cs
@@ -97,8 +97,8 @@ if (ingestion)
     toDelete.Add("webPage2");
     if (!await memory.IsDocumentReadyAsync("webPage2"))
     {
-        Console.WriteLine("Uploading https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/SECURITY_FILTERS.md");
-        await memory.ImportWebPageAsync("https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/SECURITY_FILTERS.md",
+        Console.WriteLine("Uploading https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/security/security-filters.md");
+        await memory.ImportWebPageAsync("https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/security/security-filters.md",
             documentId: "webPage2",
             steps: Constants.PipelineWithoutSummary);
     }

--- a/examples/001-dotnet-WebClient/Program.cs
+++ b/examples/001-dotnet-WebClient/Program.cs
@@ -234,7 +234,7 @@ Uploading Image file with a news about a conference sponsored by Microsoft
 Uploading a text file, a Word doc, and a PDF about Semantic Kernel
 Uploading a PDF with a news about NASA and Orion
 Uploading https://raw.githubusercontent.com/microsoft/kernel-memory/main/README.md
-Uploading https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/SECURITY_FILTERS.md
+Uploading https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/security/security-filters.md
 
 ====================================
 

--- a/examples/003-dotnet-Serverless/Program.cs
+++ b/examples/003-dotnet-Serverless/Program.cs
@@ -125,8 +125,8 @@ if (ingestion)
     toDelete.Add("webPage2");
     if (!await memory.IsDocumentReadyAsync("webPage2"))
     {
-        Console.WriteLine("Uploading https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/SECURITY_FILTERS.md");
-        await memory.ImportWebPageAsync("https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/SECURITY_FILTERS.md",
+        Console.WriteLine("Uploading https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/security/security-filters.md");
+        await memory.ImportWebPageAsync("https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/security/security-filters.md",
             documentId: "webPage2",
             steps: Constants.PipelineWithoutSummary);
     }
@@ -247,7 +247,7 @@ Uploading Image file with a news about a conference sponsored by Microsoft
 Uploading a text file, a Word doc, and a PDF about Semantic Kernel
 Uploading a PDF with a news about NASA and Orion
 Uploading https://raw.githubusercontent.com/microsoft/kernel-memory/main/README.md
-Uploading https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/SECURITY_FILTERS.md
+Uploading https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/security/security-filters.md
 
 ====================================
 


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)
Fix a bad web page reference in the example

was: https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/SECURITY_FILTERS.md
changed to: https://raw.githubusercontent.com/microsoft/kernel-memory/main/docs/security/security-filters.md

