### PR TITLE
Support ManualTokenCredential in AzureOpenAITextEmbeddingGenerator

### DIFF
--- a/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
+++ b/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
@@ -59,6 +59,15 @@ public class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
                     httpClient: httpClient);
                 break;
 
+            case AzureOpenAIConfig.AuthTypes.ManualTokenCredential:
+                this._client = new AzureOpenAITextEmbeddingGenerationService(
+                    deploymentName: config.Deployment,
+                    modelId: config.Deployment,
+                    endpoint: config.Endpoint,
+                    credential: config.GetTokenCredential(),
+                    httpClient: httpClient);
+                break;
+
             case AzureOpenAIConfig.AuthTypes.APIKey:
                 this._client = new AzureOpenAITextEmbeddingGenerationService(
                     deploymentName: config.Deployment,

--- a/extensions/AzureOpenAI/AzureOpenAITextGenerator.cs
+++ b/extensions/AzureOpenAI/AzureOpenAITextGenerator.cs
@@ -87,6 +87,10 @@ public class AzureOpenAITextGenerator : ITextGenerator
                 this._client = new OpenAIClient(new Uri(config.Endpoint), new DefaultAzureCredential(), options);
                 break;
 
+            case AzureOpenAIConfig.AuthTypes.ManualTokenCredential:
+                this._client = new OpenAIClient(new Uri(config.Endpoint), config.GetTokenCredential(), options);
+                break;
+
             case AzureOpenAIConfig.AuthTypes.APIKey:
                 if (string.IsNullOrEmpty(config.APIKey))
                 {
@@ -94,10 +98,6 @@ public class AzureOpenAITextGenerator : ITextGenerator
                 }
 
                 this._client = new OpenAIClient(new Uri(config.Endpoint), new AzureKeyCredential(config.APIKey), options);
-                break;
-
-            case AzureOpenAIConfig.AuthTypes.ManualTokenCredential:
-                this._client = new OpenAIClient(new Uri(config.Endpoint), config.GetTokenCredential(), options);
                 break;
 
             default:


### PR DESCRIPTION
Allow to use manual token credentials also with AzureOpenAITextEmbeddingGenerator.

see #290 

