### PR TITLE
Allowing the configuration of the virtual host of RabbitMQ

### DIFF
--- a/extensions/RabbitMQ/RabbitMQPipeline.cs
+++ b/extensions/RabbitMQ/RabbitMQPipeline.cs
@@ -34,6 +34,7 @@ public sealed class RabbitMQPipeline : IQueue
             Port = config.Port,
             UserName = config.Username,
             Password = config.Password,
+            VirtualHost = !string.IsNullOrWhiteSpace(config.VirtualHost) ? config.VirtualHost : "/",
             DispatchConsumersAsync = true
         };
 

--- a/extensions/RabbitMQ/RabbitMqConfig.cs
+++ b/extensions/RabbitMQ/RabbitMqConfig.cs
@@ -10,4 +10,5 @@ public class RabbitMqConfig
     public int Port { get; set; } = 0;
     public string Username { get; set; } = "";
     public string Password { get; set; } = "";
+    public string VirtualHost { get; set; } = "/";
 }

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -193,7 +193,8 @@
         "Host": "127.0.0.1",
         "Port": "5672",
         "Username": "user",
-        "Password": ""
+        "Password": "",
+        "VirtualHost": "/"
       },
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.

--- a/tools/InteractiveSetup/AppSettings.cs
+++ b/tools/InteractiveSetup/AppSettings.cs
@@ -10,6 +10,8 @@ namespace Microsoft.KernelMemory.InteractiveSetup;
 public static class AppSettings
 {
     private const string SettingsFile = "appsettings.Development.json";
+    private const string DefaultSettingsFile = "appsettings.json";
+    private static readonly JsonSerializerSettings s_jsonOptions = new() { Formatting = Formatting.Indented };
 
     public static void Change(Action<KernelMemoryConfig> configChanges)
     {
@@ -28,7 +30,7 @@ public static class AppSettings
 
         data["KernelMemory"] = JsonConvert.DeserializeObject<JObject>(JsonConvert.SerializeObject(config));
 
-        json = JsonConvert.SerializeObject(data, Formatting.Indented);
+        json = JsonConvert.SerializeObject(data, s_jsonOptions);
         File.WriteAllText(SettingsFile, json);
     }
 
@@ -70,8 +72,27 @@ public static class AppSettings
         JObject? data = JsonConvert.DeserializeObject<JObject>(json);
         if (data == null)
         {
-            throw new SetupException("Unable to parse file");
+            throw new SetupException($"Unable to parse `{SettingsFile}` file");
         }
+
+        // TODO: merge appsettings.json, only needed blocks
+        // if (File.Exists(DefaultSettingsFile))
+        // {
+        //     json = File.ReadAllText(DefaultSettingsFile);
+        //     JObject? defaultData = JsonConvert.DeserializeObject<JObject>(json);
+        //     if (defaultData == null)
+        //     {
+        //         throw new SetupException($"Unable to parse `{DefaultSettingsFile}` file");
+        //     }
+        //
+        //     defaultData.Merge(data, new JsonMergeSettings
+        //     {
+        //         MergeArrayHandling = MergeArrayHandling.Replace,
+        //         PropertyNameComparison = StringComparison.OrdinalIgnoreCase,
+        //     });
+        //
+        //     data = defaultData;
+        // }
 
         return data;
     }

--- a/tools/InteractiveSetup/Main.cs
+++ b/tools/InteractiveSetup/Main.cs
@@ -664,6 +664,7 @@ public static class Main
                 { "Port", "5672" },
                 { "Username", "user" },
                 { "Password", "" },
+                { "VirtualHost", "/" },
             };
         }
 
@@ -673,6 +674,7 @@ public static class Main
             { "Port", SetupUI.AskOpenQuestion("RabbitMQ <TCP port>", config["Port"].ToString()) },
             { "Username", SetupUI.AskOpenQuestion("RabbitMQ <username>", config["Username"].ToString()) },
             { "Password", SetupUI.AskPassword("RabbitMQ <password>", config["Password"].ToString()) },
+            { "VirtualHost", SetupUI.AskOpenQuestion("RabbitMQ <virtualhost>", config["VirtualHost"].ToString()) },
         });
     }
 

--- a/tools/InteractiveSetup/Main.cs
+++ b/tools/InteractiveSetup/Main.cs
@@ -171,6 +171,10 @@ public static class Main
                     QdrantSetup(true);
                     break;
 
+                case string x when x.Equals("RabbitMQ", StringComparison.OrdinalIgnoreCase):
+                    RabbitMQSetup(true);
+                    break;
+
                 case string x when x.Equals("Redis", StringComparison.OrdinalIgnoreCase):
                     RedisSetup(true);
                     break;
@@ -649,9 +653,9 @@ public static class Main
         });
     }
 
-    private static void RabbitMQSetup()
+    private static void RabbitMQSetup(bool force = false)
     {
-        if (!s_cfgRabbitMq.Value) { return; }
+        if (!s_cfgRabbitMq.Value && !force) { return; }
 
         s_cfgRabbitMq.Value = false;
         const string ServiceName = "RabbitMQ";


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
In a scenario where a RabbitMQ cluster is shared between multiples applications it would be nice to be allowed to connect into an isolated virtual host to better organize the queues and exchanges in the cluster.

## High level description (Approach, Design)

Adding the ``VirtualHost`` property in the RabbitMQ configuration and passing it to the RabbitMQ Client