### PR TITLE
Align config files schema across tests, service and examples + Config fixes

### DIFF
--- a/KernelMemory.sln.DotSettings
+++ b/KernelMemory.sln.DotSettings
@@ -237,6 +237,7 @@ public void It$SOMENAME$()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=greaterthan/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hhmmssfffffff/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hmmss/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=HNSW/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=inheritdoc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=INPROCESS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Joinable/@EntryIndexedValue">True</s:Boolean>

--- a/extensions/AzureAISearch/AzureAISearch.FunctionalTests/appsettings.json
+++ b/extensions/AzureAISearch/AzureAISearch.FunctionalTests/appsettings.json
@@ -1,34 +1,36 @@
 {
-  "ServiceAuthorization": {
-    "Endpoint": "http://127.0.0.1:9001/",
-    "AccessKey": "",
-  },
-  "Services": {
-    "AzureAISearch": {
-      // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-      "Auth": "AzureIdentity",
-      "Endpoint": "https://<...>",
-      "APIKey": "",
+  "KernelMemory": {
+    "ServiceAuthorization": {
+      "Endpoint": "http://127.0.0.1:9001/",
+      "AccessKey": ""
     },
-    "OpenAI": {
-      // Name of the model used to generate text (text completion or chat completion)
-      "TextModel": "gpt-3.5-turbo-16k",
-      // The max number of tokens supported by the text model.
-      "TextModelMaxTokenTotal": 16384,
-      // Name of the model used to generate text embeddings
-      "EmbeddingModel": "text-embedding-ada-002",
-      // The max number of tokens supported by the embedding model
-      // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
-      "EmbeddingModelMaxTokenTotal": 8191,
-      // OpenAI API Key
-      "APIKey": "",
-      // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
-      "OrgId": "",
-      // How many times to retry in case of throttling
-      "MaxRetries": 10
-    },
+    "Services": {
+      "AzureAISearch": {
+        // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>",
+        "APIKey": ""
+      },
+      "OpenAI": {
+        // Name of the model used to generate text (text completion or chat completion)
+        "TextModel": "gpt-3.5-turbo-16k",
+        // The max number of tokens supported by the text model.
+        "TextModelMaxTokenTotal": 16384,
+        // Name of the model used to generate text embeddings
+        "EmbeddingModel": "text-embedding-ada-002",
+        // The max number of tokens supported by the embedding model
+        // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
+        "EmbeddingModelMaxTokenTotal": 8191,
+        // OpenAI API Key
+        "APIKey": "",
+        // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
+        "OrgId": "",
+        // How many times to retry in case of throttling
+        "MaxRetries": 10
+      }
+    }
   },
   "Logging": {
     "LogLevel": {

--- a/extensions/AzureAISearch/AzureAISearch.UnitTests/AzureAISearchFilteringTest.cs
+++ b/extensions/AzureAISearch/AzureAISearch.UnitTests/AzureAISearchFilteringTest.cs
@@ -14,6 +14,8 @@ public class AzureAISearchFilteringTest : BaseUnitTestCase
     }
 
     [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AzAISearch")]
     public void ItRendersEmptyFilters()
     {
         // Arrange
@@ -32,6 +34,8 @@ public class AzureAISearchFilteringTest : BaseUnitTestCase
     }
 
     [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AzAISearch")]
     public void ItRendersSimpleFilter()
     {
         // Arrange
@@ -46,6 +50,8 @@ public class AzureAISearchFilteringTest : BaseUnitTestCase
     }
 
     [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AzAISearch")]
     public void ItRendersSimpleFilters()
     {
         // Arrange
@@ -64,6 +70,8 @@ public class AzureAISearchFilteringTest : BaseUnitTestCase
     }
 
     [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AzAISearch")]
     public void ItRendersUsingSearchIn()
     {
         // Arrange
@@ -82,6 +90,8 @@ public class AzureAISearchFilteringTest : BaseUnitTestCase
     }
 
     [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AzAISearch")]
     public void ItUsesSearchInWithAlternativeSeparators()
     {
         // Arrange
@@ -108,6 +118,8 @@ public class AzureAISearchFilteringTest : BaseUnitTestCase
     }
 
     [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AzAISearch")]
     public void ItHandlesComplexFilters()
     {
         // Arrange
@@ -128,6 +140,8 @@ public class AzureAISearchFilteringTest : BaseUnitTestCase
     }
 
     [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AzAISearch")]
     public void ItHandlesEdgeCase0()
     {
         // Arrange
@@ -147,6 +161,8 @@ public class AzureAISearchFilteringTest : BaseUnitTestCase
     }
 
     [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AzAISearch")]
     public void ItHandlesEdgeCase1()
     {
         // Arrange
@@ -169,6 +185,8 @@ public class AzureAISearchFilteringTest : BaseUnitTestCase
     }
 
     [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AzAISearch")]
     public void ItHandlesEdgeCase2()
     {
         // Arrange
@@ -191,6 +209,8 @@ public class AzureAISearchFilteringTest : BaseUnitTestCase
     }
 
     [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AzAISearch")]
     public void ItHandlesEdgeCase3()
     {
         // Arrange
@@ -209,6 +229,8 @@ public class AzureAISearchFilteringTest : BaseUnitTestCase
     }
 
     [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AzAISearch")]
     public void ItHandlesEdgeCase4()
     {
         // Arrange
@@ -228,6 +250,8 @@ public class AzureAISearchFilteringTest : BaseUnitTestCase
     }
 
     [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AzAISearch")]
     public void ItHandlesEdgeCase5()
     {
         // Arrange
@@ -246,6 +270,8 @@ public class AzureAISearchFilteringTest : BaseUnitTestCase
     }
 
     [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AzAISearch")]
     public void ItHandlesEdgeCase6()
     {
         // Arrange

--- a/extensions/Elasticsearch/Elasticsearch.FunctionalTests/DefaultTests.cs
+++ b/extensions/Elasticsearch/Elasticsearch.FunctionalTests/DefaultTests.cs
@@ -22,7 +22,7 @@ public class DefaultTests : BaseFunctionalTestCase
     {
         Assert.False(string.IsNullOrEmpty(this.OpenAiConfig.APIKey));
 
-        this._elasticsearchConfig = cfg.GetSection("Services:Elasticsearch").Get<ElasticsearchConfig>()!;
+        this._elasticsearchConfig = cfg.GetSection("KernelMemory:Services:Elasticsearch").Get<ElasticsearchConfig>()!;
 
         this._memory = new KernelMemoryBuilder()
             .WithSearchClientConfig(new SearchClientConfig { EmptyAnswer = NotFound })

--- a/extensions/Elasticsearch/Elasticsearch.FunctionalTests/appsettings.json
+++ b/extensions/Elasticsearch/Elasticsearch.FunctionalTests/appsettings.json
@@ -4,56 +4,65 @@
       "Default": "Information"
     }
   },
-  "Services": {
-    "Elasticsearch": {
-      "CertificateFingerPrint": "",
-      "Endpoint": "",
-      "UserName": "",
-      "Password": "",
-    },
-    "AzureOpenAIText": {
-      // "ApiKey" or "AzureIdentity"
-      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-      "Auth": "AzureIdentity",
-      "Endpoint": "https://<...>.openai.azure.com/",
-      "APIKey": "",
-      "Deployment": "",
-      // The max number of tokens supported by model deployed
-      // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-      "MaxTokenTotal": 16384,
-      // "ChatCompletion" or "TextCompletion"
-      "APIType": "ChatCompletion",
-      "MaxRetries": 10
-    },
-    "AzureOpenAIEmbedding": {
-      // "ApiKey" or "AzureIdentity"
-      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-      "Auth": "AzureIdentity",
-      "Endpoint": "https://<...>.openai.azure.com/",
-      "APIKey": "",
-      "Deployment": "",
-      // The max number of tokens supported by model deployed
-      // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-      "MaxTokenTotal": 8191,
-    },
-    "OpenAI": {
-      // Name of the model used to generate text (text completion or chat completion)
-      "TextModel": "gpt-3.5-turbo-16k",
-      // The max number of tokens supported by the text model.
-      "TextModelMaxTokenTotal": 16384,
-      // Name of the model used to generate text embeddings
-      "EmbeddingModel": "text-embedding-ada-002",
-      // The max number of tokens supported by the embedding model
-      // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
-      "EmbeddingModelMaxTokenTotal": 8191,
-      // OpenAI API Key
-      "APIKey": "",
-      // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
-      "OrgId": "",
-      // How many times to retry in case of throttling
-      "MaxRetries": 10
-    },
+  "KernelMemory": {
+    "Services": {
+      "Elasticsearch": {
+        // SHA-256 fingerprint. When running the docker image this is printed after starting the server
+        // See https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-stack-security.html#_use_the_ca_fingerprint_5
+        "CertificateFingerPrint": "",
+        // e.g. https://localhost:9200
+        "Endpoint": "",
+        // e.g. "elastic"
+        "UserName": "",
+        "Password": "",
+        "IndexPrefix": "",
+        "ShardCount": 1,
+        "Replicas": 0
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
+        "MaxRetries": 10
+      },
+      "AzureOpenAIEmbedding": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 8191
+      },
+      "OpenAI": {
+        // Name of the model used to generate text (text completion or chat completion)
+        "TextModel": "gpt-3.5-turbo-16k",
+        // The max number of tokens supported by the text model.
+        "TextModelMaxTokenTotal": 16384,
+        // Name of the model used to generate text embeddings
+        "EmbeddingModel": "text-embedding-ada-002",
+        // The max number of tokens supported by the embedding model
+        // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
+        "EmbeddingModelMaxTokenTotal": 8191,
+        // OpenAI API Key
+        "APIKey": "",
+        // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
+        "OrgId": "",
+        // How many times to retry in case of throttling
+        "MaxRetries": 10
+      }
+    }
   }
 }

--- a/extensions/LlamaSharp/LlamaSharp.FunctionalTests/LlamaSharpTextGeneratorTest.cs
+++ b/extensions/LlamaSharp/LlamaSharp.FunctionalTests/LlamaSharpTextGeneratorTest.cs
@@ -76,18 +76,13 @@ public sealed class LlamaSharpTextGeneratorTest : BaseFunctionalTestCase
     {
         // Arrange
         var prompt = """
-                     Facts:
-                     The public Kernel Memory project kicked off around May 2023.
-                     Now, in December 2023, we are integrating LLama compatibility
-                     into KM, following the steady addition of numerous features.
-                     By January, we anticipate to complete this update and potentially
-                     introduce more models by February.
-                     Instructions: Reply in JSON.
-                     Question: What's the current month?
+                     # Current date: 12/12/2024.
+                     # Instructions: use JSON syntax.
+                     # Deduction: { "DayOfWeek": "Monday", "MonthName":
                      """;
         var options = new TextGenerationOptions
         {
-            MaxTokens = 30,
+            MaxTokens = 60,
             Temperature = 0,
             StopSequences = new List<string> { "Question" }
         };
@@ -106,7 +101,7 @@ public sealed class LlamaSharpTextGeneratorTest : BaseFunctionalTestCase
         var answer = result.ToString();
 
         // Assert
-        Console.WriteLine($"=============================\n{answer}\n=============================");
+        Console.WriteLine($"Model Output:\n=============================\n{answer}\n=============================");
         Console.WriteLine($"Time: {this._timer.ElapsedMilliseconds / 1000} secs");
         Assert.Contains("december", answer, StringComparison.OrdinalIgnoreCase);
     }

--- a/extensions/LlamaSharp/LlamaSharp.FunctionalTests/appsettings.json
+++ b/extensions/LlamaSharp/LlamaSharp.FunctionalTests/appsettings.json
@@ -1,60 +1,62 @@
 {
-  "ServiceAuthorization": {
-    "Endpoint": "http://127.0.0.1:9001/",
-    "AccessKey": "",
-  },
-  "Services": {
-    "SimpleVectorDb": {
-      // Options: "Disk" or "Volatile". Volatile data is lost after each execution.
-      "StorageType": "Volatile",
-      // Directory where files are stored.
-      "Directory": "_vectors"
+  "KernelMemory": {
+    "ServiceAuthorization": {
+      "Endpoint": "http://127.0.0.1:9001/",
+      "AccessKey": ""
     },
-    "AzureAISearch": {
-      // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-      "Auth": "AzureIdentity",
-      "Endpoint": "https://<...>",
-      "APIKey": "",
-    },
-    "Postgres": {
-      // Postgres instance connection string
-      "ConnectionString": "Host=localhost;Port=5432;Username=public;Password=",
-      // Mandatory prefix to add to the name of table managed by KM,
-      // e.g. to exclude other tables in the same schema.
-      "TableNamePrefix": "tests-"
-    },
-    "Qdrant": {
-      "Endpoint": "http://127.0.0.1:6333",
-      "APIKey": "",
-    },
-    "OpenAI": {
-      // Name of the model used to generate text (text completion or chat completion)
-      "TextModel": "gpt-3.5-turbo-16k",
-      // The max number of tokens supported by the text model.
-      "TextModelMaxTokenTotal": 16384,
-      // Name of the model used to generate text embeddings
-      "EmbeddingModel": "text-embedding-ada-002",
-      // The max number of tokens supported by the embedding model
-      // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
-      "EmbeddingModelMaxTokenTotal": 8191,
-      // OpenAI API Key
-      "APIKey": "",
-      // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
-      "OrgId": "",
-      // How many times to retry in case of throttling
-      "MaxRetries": 10
-    },
-    "LlamaSharp": {
-      // path to file, e.g. "llama-2-7b-chat.Q6_K.gguf"
-      "ModelPath": "",
-      // Max number of tokens supported by the model
-      "MaxTokenTotal": 4096
-      // Optional parameters
-      // "GpuLayerCount": 32,
-      // "Seed": 1337,
-    },
+    "Services": {
+      "SimpleVectorDb": {
+        // Options: "Disk" or "Volatile". Volatile data is lost after each execution.
+        "StorageType": "Volatile",
+        // Directory where files are stored.
+        "Directory": "_vectors"
+      },
+      "AzureAISearch": {
+        // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>",
+        "APIKey": ""
+      },
+      "Postgres": {
+        // Postgres instance connection string
+        "ConnectionString": "Host=localhost;Port=5432;Username=public;Password=",
+        // Mandatory prefix to add to the name of table managed by KM,
+        // e.g. to exclude other tables in the same schema.
+        "TableNamePrefix": "tests-"
+      },
+      "Qdrant": {
+        "Endpoint": "http://127.0.0.1:6333",
+        "APIKey": ""
+      },
+      "OpenAI": {
+        // Name of the model used to generate text (text completion or chat completion)
+        "TextModel": "gpt-3.5-turbo-16k",
+        // The max number of tokens supported by the text model.
+        "TextModelMaxTokenTotal": 16384,
+        // Name of the model used to generate text embeddings
+        "EmbeddingModel": "text-embedding-ada-002",
+        // The max number of tokens supported by the embedding model
+        // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
+        "EmbeddingModelMaxTokenTotal": 8191,
+        // OpenAI API Key
+        "APIKey": "",
+        // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
+        "OrgId": "",
+        // How many times to retry in case of throttling
+        "MaxRetries": 10
+      },
+      "LlamaSharp": {
+        // path to file, e.g. "llama-2-7b-chat.Q6_K.gguf"
+        "ModelPath": "",
+        // Max number of tokens supported by the model
+        "MaxTokenTotal": 4096
+        // Optional parameters
+        // "GpuLayerCount": 32,
+        // "Seed": 1337,
+      }
+    }
   },
   "Logging": {
     "LogLevel": {

--- a/extensions/Postgres/Postgres.FunctionalTests/appsettings.json
+++ b/extensions/Postgres/Postgres.FunctionalTests/appsettings.json
@@ -4,57 +4,59 @@
       "Default": "Information"
     }
   },
-  "Services": {
-    "Postgres": {
-      // Postgres instance connection string
-      "ConnectionString": "Host=localhost;Port=5432;Username=public;Password=",
-      // Mandatory prefix to add to the name of table managed by KM,
-      // e.g. to exclude other tables in the same schema.
-      "TableNamePrefix": "tests-"
-    },
-    "AzureOpenAIText": {
-      // "ApiKey" or "AzureIdentity"
-      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-      "Auth": "AzureIdentity",
-      "Endpoint": "https://<...>.openai.azure.com/",
-      "APIKey": "",
-      "Deployment": "",
-      // The max number of tokens supported by model deployed
-      // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-      "MaxTokenTotal": 16384,
-      // "ChatCompletion" or "TextCompletion"
-      "APIType": "ChatCompletion",
-      "MaxRetries": 10
-    },
-    "AzureOpenAIEmbedding": {
-      // "ApiKey" or "AzureIdentity"
-      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-      "Auth": "AzureIdentity",
-      "Endpoint": "https://<...>.openai.azure.com/",
-      "APIKey": "",
-      "Deployment": "",
-      // The max number of tokens supported by model deployed
-      // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-      "MaxTokenTotal": 8191,
-    },
-    "OpenAI": {
-      // Name of the model used to generate text (text completion or chat completion)
-      "TextModel": "gpt-3.5-turbo-16k",
-      // The max number of tokens supported by the text model.
-      "TextModelMaxTokenTotal": 16384,
-      // Name of the model used to generate text embeddings
-      "EmbeddingModel": "text-embedding-ada-002",
-      // The max number of tokens supported by the embedding model
-      // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
-      "EmbeddingModelMaxTokenTotal": 8191,
-      // OpenAI API Key
-      "APIKey": "",
-      // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
-      "OrgId": "",
-      // How many times to retry in case of throttling
-      "MaxRetries": 10
-    },
+  "KernelMemory": {
+    "Services": {
+      "Postgres": {
+        // Postgres instance connection string
+        "ConnectionString": "Host=localhost;Port=5432;Username=public;Password=",
+        // Mandatory prefix to add to the name of table managed by KM,
+        // e.g. to exclude other tables in the same schema.
+        "TableNamePrefix": "tests-"
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
+        "MaxRetries": 10
+      },
+      "AzureOpenAIEmbedding": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 8191
+      },
+      "OpenAI": {
+        // Name of the model used to generate text (text completion or chat completion)
+        "TextModel": "gpt-3.5-turbo-16k",
+        // The max number of tokens supported by the text model.
+        "TextModelMaxTokenTotal": 16384,
+        // Name of the model used to generate text embeddings
+        "EmbeddingModel": "text-embedding-ada-002",
+        // The max number of tokens supported by the embedding model
+        // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
+        "EmbeddingModelMaxTokenTotal": 8191,
+        // OpenAI API Key
+        "APIKey": "",
+        // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
+        "OrgId": "",
+        // How many times to retry in case of throttling
+        "MaxRetries": 10
+      }
+    }
   }
 }

--- a/extensions/Qdrant/Qdrant.FunctionalTests/appsettings.json
+++ b/extensions/Qdrant/Qdrant.FunctionalTests/appsettings.json
@@ -1,30 +1,32 @@
 {
-  "ServiceAuthorization": {
-    "Endpoint": "http://127.0.0.1:9001/",
-    "AccessKey": "",
-  },
-  "Services": {
-    "Qdrant": {
-      "Endpoint": "http://127.0.0.1:6333",
-      "APIKey": "",
+  "KernelMemory": {
+    "ServiceAuthorization": {
+      "Endpoint": "http://127.0.0.1:9001/",
+      "AccessKey": ""
     },
-    "OpenAI": {
-      // Name of the model used to generate text (text completion or chat completion)
-      "TextModel": "gpt-3.5-turbo-16k",
-      // The max number of tokens supported by the text model.
-      "TextModelMaxTokenTotal": 16384,
-      // Name of the model used to generate text embeddings
-      "EmbeddingModel": "text-embedding-ada-002",
-      // The max number of tokens supported by the embedding model
-      // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
-      "EmbeddingModelMaxTokenTotal": 8191,
-      // OpenAI API Key
-      "APIKey": "",
-      // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
-      "OrgId": "",
-      // How many times to retry in case of throttling
-      "MaxRetries": 10
-    },
+    "Services": {
+      "Qdrant": {
+        "Endpoint": "http://127.0.0.1:6333",
+        "APIKey": ""
+      },
+      "OpenAI": {
+        // Name of the model used to generate text (text completion or chat completion)
+        "TextModel": "gpt-3.5-turbo-16k",
+        // The max number of tokens supported by the text model.
+        "TextModelMaxTokenTotal": 16384,
+        // Name of the model used to generate text embeddings
+        "EmbeddingModel": "text-embedding-ada-002",
+        // The max number of tokens supported by the embedding model
+        // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
+        "EmbeddingModelMaxTokenTotal": 8191,
+        // OpenAI API Key
+        "APIKey": "",
+        // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
+        "OrgId": "",
+        // How many times to retry in case of throttling
+        "MaxRetries": 10
+      }
+    }
   },
   "Logging": {
     "LogLevel": {

--- a/extensions/Redis/Redis.FunctionalTests/RedisSpecificTests.cs
+++ b/extensions/Redis/Redis.FunctionalTests/RedisSpecificTests.cs
@@ -31,7 +31,7 @@ public class RedisSpecificTests : BaseFunctionalTestCase
             tags: new TagCollection { { "non-configuredTag", "foobarbaz" } }));
 
         Assert.Equal(
-            "Attempt to insert un-indexed tag field: non-configuredTag, will not be able to filter on it, please adjust the tag settings in your Redis Configuration",
+            "Attempt to insert un-indexed tag field: 'non-configuredTag', will not be able to filter on it, please adjust the tag settings in your Redis Configuration",
             res.Message);
     }
 
@@ -44,7 +44,7 @@ public class RedisSpecificTests : BaseFunctionalTestCase
             documentId: "1",
             tags: new TagCollection { { "user", "foo|bar|baz" } }));
         Assert.Equal(
-            $"Attempted to insert record with tag field: user containing the separator: '|'. Update your {nameof(Microsoft.KernelMemory.RedisConfig)} to use a different separator, or remove the separator from the field.",
+            $"Attempted to insert record with tag field: 'user' containing the separator: '|'. Update your {nameof(Microsoft.KernelMemory.RedisConfig)} to use a different separator, or remove the separator from the field.",
             res.Message);
     }
 

--- a/extensions/Redis/Redis.FunctionalTests/appsettings.json
+++ b/extensions/Redis/Redis.FunctionalTests/appsettings.json
@@ -4,64 +4,67 @@
       "Default": "Information"
     }
   },
-  "Services": {
-    "Redis": {
-      "ConnectionString": "localhost",
-      "AppPrefix": "tests-",
-      "Tags": {
-        "__document_id": "|",
-        "__file_id": "|",
-        "__file_part": "|",
-        "__file_type": "|",
-        "__synth": "|",
-        "user": "|",
-        "type": "|",
-        "ext": "|"
+  "KernelMemory": {
+    "Services": {
+      "Redis": {
+        "ConnectionString": "localhost",
+        "AppPrefix": "tests-",
+        "Tags": {
+          "__document_id": "|",
+          "__file_id": "|",
+          "__file_part": "|",
+          "__file_type": "|",
+          "__synth": "|",
+          "__part_n": "|",
+          "user": "|",
+          "type": "|",
+          "ext": "|"
+        }
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
+        "MaxRetries": 10
+      },
+      "AzureOpenAIEmbedding": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 8191
+      },
+      "OpenAI": {
+        // Name of the model used to generate text (text completion or chat completion)
+        "TextModel": "gpt-3.5-turbo-16k",
+        // The max number of tokens supported by the text model.
+        "TextModelMaxTokenTotal": 16384,
+        // Name of the model used to generate text embeddings
+        "EmbeddingModel": "text-embedding-ada-002",
+        // The max number of tokens supported by the embedding model
+        // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
+        "EmbeddingModelMaxTokenTotal": 8191,
+        // OpenAI API Key
+        "APIKey": "",
+        // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
+        "OrgId": "",
+        // How many times to retry in case of throttling
+        "MaxRetries": 10
       }
-    },
-    "AzureOpenAIText": {
-      // "ApiKey" or "AzureIdentity"
-      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-      "Auth": "AzureIdentity",
-      "Endpoint": "https://<...>.openai.azure.com/",
-      "APIKey": "",
-      "Deployment": "",
-      // The max number of tokens supported by model deployed
-      // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-      "MaxTokenTotal": 16384,
-      // "ChatCompletion" or "TextCompletion"
-      "APIType": "ChatCompletion",
-      "MaxRetries": 10
-    },
-    "AzureOpenAIEmbedding": {
-      // "ApiKey" or "AzureIdentity"
-      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-      "Auth": "AzureIdentity",
-      "Endpoint": "https://<...>.openai.azure.com/",
-      "APIKey": "",
-      "Deployment": "",
-      // The max number of tokens supported by model deployed
-      // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-      "MaxTokenTotal": 8191,
-    },
-    "OpenAI": {
-      // Name of the model used to generate text (text completion or chat completion)
-      "TextModel": "gpt-3.5-turbo-16k",
-      // The max number of tokens supported by the text model.
-      "TextModelMaxTokenTotal": 16384,
-      // Name of the model used to generate text embeddings
-      "EmbeddingModel": "text-embedding-ada-002",
-      // The max number of tokens supported by the embedding model
-      // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
-      "EmbeddingModelMaxTokenTotal": 8191,
-      // OpenAI API Key
-      "APIKey": "",
-      // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
-      "OrgId": "",
-      // How many times to retry in case of throttling
-      "MaxRetries": 10
-    },
+    }
   }
 }

--- a/extensions/Redis/Redis/RedisConfig.cs
+++ b/extensions/Redis/Redis/RedisConfig.cs
@@ -43,6 +43,9 @@ public class RedisConfig
         { Constants.ReservedDocumentIdTag, '|' },
         { Constants.ReservedFileIdTag, '|' },
         { Constants.ReservedFilePartitionTag, '|' },
+#if KernelMemoryDev
+        { Constants.ReservedFileSectionNumberTag, '|' },
+#endif
         { Constants.ReservedFileTypeTag, '|' },
     };
 

--- a/extensions/SQLServer/SQLServer.FunctionalTests/DefaultTests.cs
+++ b/extensions/SQLServer/SQLServer.FunctionalTests/DefaultTests.cs
@@ -16,20 +16,19 @@ namespace SQLServer.FunctionalTests;
 public class DefaultTests : BaseFunctionalTestCase
 {
     private readonly MemoryServerless _memory;
-    private SqlServerConfig _sqlServerConfig;
 
     public DefaultTests(IConfiguration cfg, ITestOutputHelper output) : base(cfg, output)
     {
         Assert.False(string.IsNullOrEmpty(this.OpenAiConfig.APIKey));
 
-        this._sqlServerConfig = cfg.GetSection("Services:SqlServer").Get<SqlServerConfig>()!;
+        SqlServerConfig sqlServerConfig = cfg.GetSection("KernelMemory:Services:SqlServer").Get<SqlServerConfig>()!;
 
         this._memory = new KernelMemoryBuilder()
             .WithSearchClientConfig(new SearchClientConfig { EmptyAnswer = NotFound })
             .WithOpenAI(this.OpenAiConfig)
             // .WithAzureOpenAITextGeneration(this.AzureOpenAITextConfiguration)
             // .WithAzureOpenAITextEmbeddingGeneration(this.AzureOpenAIEmbeddingConfiguration)
-            .WithSqlServerMemoryDb(this._sqlServerConfig)
+            .WithSqlServerMemoryDb(sqlServerConfig)
             .Build<MemoryServerless>();
     }
 

--- a/extensions/SQLServer/SQLServer.FunctionalTests/appsettings.json
+++ b/extensions/SQLServer/SQLServer.FunctionalTests/appsettings.json
@@ -4,58 +4,60 @@
       "Default": "Information"
     }
   },
-  "Services": {
-    "SqlServer": {
-      // If you're using a test instance via Docker, this connection string should work (remember to set the password)
-      // "Server=tcp:127.0.0.1,1433;Initial Catalog=master;Persist Security Info=False;User ID=sa;Password=...;MultipleActiveResultSets=False;TrustServerCertificate=True;Connection Timeout=30;"
-      // See:
-      // - https://learn.microsoft.com/sql/linux/quickstart-install-connect-docker
-      // - https://devblogs.microsoft.com/azure-sql/development-with-sql-in-containers-on-macos
-      "ConnectionString": "",
-    },
-    "AzureOpenAIText": {
-      // "ApiKey" or "AzureIdentity"
-      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-      "Auth": "AzureIdentity",
-      "Endpoint": "https://<...>.openai.azure.com/",
-      "APIKey": "",
-      "Deployment": "",
-      // The max number of tokens supported by model deployed
-      // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-      "MaxTokenTotal": 16384,
-      // "ChatCompletion" or "TextCompletion"
-      "APIType": "ChatCompletion",
-      "MaxRetries": 10
-    },
-    "AzureOpenAIEmbedding": {
-      // "ApiKey" or "AzureIdentity"
-      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-      "Auth": "AzureIdentity",
-      "Endpoint": "https://<...>.openai.azure.com/",
-      "APIKey": "",
-      "Deployment": "",
-      // The max number of tokens supported by model deployed
-      // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-      "MaxTokenTotal": 8191,
-    },
-    "OpenAI": {
-      // Name of the model used to generate text (text completion or chat completion)
-      "TextModel": "gpt-3.5-turbo-16k",
-      // The max number of tokens supported by the text model.
-      "TextModelMaxTokenTotal": 16384,
-      // Name of the model used to generate text embeddings
-      "EmbeddingModel": "text-embedding-ada-002",
-      // The max number of tokens supported by the embedding model
-      // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
-      "EmbeddingModelMaxTokenTotal": 8191,
-      // OpenAI API Key
-      "APIKey": "",
-      // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
-      "OrgId": "",
-      // How many times to retry in case of throttling
-      "MaxRetries": 10
-    },
+  "KernelMemory": {
+    "Services": {
+      "SqlServer": {
+        // If you're using a test instance via Docker, this connection string should work (remember to set the password)
+        // "Server=tcp:127.0.0.1,1433;Initial Catalog=master;Persist Security Info=False;User ID=sa;Password=...;MultipleActiveResultSets=False;TrustServerCertificate=True;Connection Timeout=30;"
+        // See:
+        // - https://learn.microsoft.com/sql/linux/quickstart-install-connect-docker
+        // - https://devblogs.microsoft.com/azure-sql/development-with-sql-in-containers-on-macos
+        "ConnectionString": ""
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
+        "MaxRetries": 10
+      },
+      "AzureOpenAIEmbedding": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 8191
+      },
+      "OpenAI": {
+        // Name of the model used to generate text (text completion or chat completion)
+        "TextModel": "gpt-3.5-turbo-16k",
+        // The max number of tokens supported by the text model.
+        "TextModelMaxTokenTotal": 16384,
+        // Name of the model used to generate text embeddings
+        "EmbeddingModel": "text-embedding-ada-002",
+        // The max number of tokens supported by the embedding model
+        // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
+        "EmbeddingModelMaxTokenTotal": 8191,
+        // OpenAI API Key
+        "APIKey": "",
+        // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
+        "OrgId": "",
+        // How many times to retry in case of throttling
+        "MaxRetries": 10
+      }
+    }
   }
 }

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -226,6 +226,19 @@
           "ext": ","
         }
       },
+      "Elasticsearch": {
+        // SHA-256 fingerprint. When running the docker image this is printed after starting the server
+        // See https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-stack-security.html#_use_the_ca_fingerprint_5
+        "CertificateFingerPrint": "",
+        // e.g. https://localhost:9200
+        "Endpoint": "",
+        // e.g. "elastic"
+        "UserName": "",
+        "Password": "",
+        "IndexPrefix": "",
+        "ShardCount": 1,
+        "Replicas": 0
+      },
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"
         // AzureIdentity: use automatic AAD authentication mechanism. You can test locally

--- a/service/tests/Core.FunctionalTests/appsettings.json
+++ b/service/tests/Core.FunctionalTests/appsettings.json
@@ -1,70 +1,72 @@
 {
-  "ServiceAuthorization": {
-    "Endpoint": "http://127.0.0.1:9001/",
-    "AccessKey": ""
-  },
-  "Services": {
-    "SimpleVectorDb": {
-      // Options: "Disk" or "Volatile". Volatile data is lost after each execution.
-      "StorageType": "Volatile",
-      // Directory where files are stored.
-      "Directory": "_vectors"
+  "KernelMemory": {
+    "ServiceAuthorization": {
+      "Endpoint": "http://127.0.0.1:9001/",
+      "AccessKey": ""
     },
-    "AzureAISearch": {
-      // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-      "Auth": "AzureIdentity",
-      "Endpoint": "https://<...>",
-      "APIKey": ""
-    },
-    "Postgres": {
-      // Postgres instance connection string
-      "ConnectionString": "Host=localhost;Port=5432;Username=public;Password=",
-      // Mandatory prefix to add to the name of table managed by KM,
-      // e.g. to exclude other tables in the same schema.
-      "TableNamePrefix": "tests-"
-    },
-    "Qdrant": {
-      "Endpoint": "http://127.0.0.1:6333",
-      "APIKey": ""
-    },
-    "Redis": {
-      // Redis connection string, e.g. "localhost:6379,password=..."
-      "ConnectionString": "localhost:6379",
-      // List of tags that clients will use to filter memories. When using Redis,
-      // the list of tags must be configured, for data to be saved correctly.
-      "Tags": {
-        "type": ",",
-        "user": ",",
-        "ext": ","
+    "Services": {
+      "SimpleVectorDb": {
+        // Options: "Disk" or "Volatile". Volatile data is lost after each execution.
+        "StorageType": "Volatile",
+        // Directory where files are stored.
+        "Directory": "_vectors"
+      },
+      "AzureAISearch": {
+        // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>",
+        "APIKey": ""
+      },
+      "Postgres": {
+        // Postgres instance connection string
+        "ConnectionString": "Host=localhost;Port=5432;Username=public;Password=",
+        // Mandatory prefix to add to the name of table managed by KM,
+        // e.g. to exclude other tables in the same schema.
+        "TableNamePrefix": "tests-"
+      },
+      "Qdrant": {
+        "Endpoint": "http://127.0.0.1:6333",
+        "APIKey": ""
+      },
+      "Redis": {
+        // Redis connection string, e.g. "localhost:6379,password=..."
+        "ConnectionString": "localhost:6379",
+        // List of tags that clients will use to filter memories. When using Redis,
+        // the list of tags must be configured, for data to be saved correctly.
+        "Tags": {
+          "type": ",",
+          "user": ",",
+          "ext": ","
+        }
+      },
+      "OpenAI": {
+        // Name of the model used to generate text (text completion or chat completion)
+        "TextModel": "gpt-3.5-turbo-16k",
+        // The max number of tokens supported by the text model.
+        "TextModelMaxTokenTotal": 16384,
+        // Name of the model used to generate text embeddings
+        "EmbeddingModel": "text-embedding-ada-002",
+        // The max number of tokens supported by the embedding model
+        // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
+        "EmbeddingModelMaxTokenTotal": 8191,
+        // OpenAI API Key
+        "APIKey": "",
+        // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
+        "OrgId": "",
+        // How many times to retry in case of throttling
+        "MaxRetries": 10
+      },
+      "LlamaSharp": {
+        // path to file, e.g. "llama-2-7b-chat.Q6_K.gguf"
+        "ModelPath": "",
+        // Max number of tokens supported by the model
+        "MaxTokenTotal": 4096
+        // Optional parameters
+        // "GpuLayerCount": 32,
+        // "Seed": 1337,
       }
-    },
-    "OpenAI": {
-      // Name of the model used to generate text (text completion or chat completion)
-      "TextModel": "gpt-3.5-turbo-16k",
-      // The max number of tokens supported by the text model.
-      "TextModelMaxTokenTotal": 16384,
-      // Name of the model used to generate text embeddings
-      "EmbeddingModel": "text-embedding-ada-002",
-      // The max number of tokens supported by the embedding model
-      // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
-      "EmbeddingModelMaxTokenTotal": 8191,
-      // OpenAI API Key
-      "APIKey": "",
-      // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
-      "OrgId": "",
-      // How many times to retry in case of throttling
-      "MaxRetries": 10
-    },
-    "LlamaSharp": {
-      // path to file, e.g. "llama-2-7b-chat.Q6_K.gguf"
-      "ModelPath": "",
-      // Max number of tokens supported by the model
-      "MaxTokenTotal": 4096
-      // Optional parameters
-      // "GpuLayerCount": 32,
-      // "Seed": 1337,
     }
   },
   "Logging": {

--- a/service/tests/Service.FunctionalTests/appsettings.json
+++ b/service/tests/Service.FunctionalTests/appsettings.json
@@ -1,52 +1,54 @@
 {
-  "ServiceAuthorization": {
-    "Endpoint": "http://127.0.0.1:9001/",
-    "AccessKey": ""
-  },
-  "Services": {
-    "SimpleVectorDb": {
-      // Options: "Disk", "Volatile"
-      "StorageType": "Volatile",
-      "Directory": "tmp-vectors"
+  "KernelMemory": {
+    "ServiceAuthorization": {
+      "Endpoint": "http://127.0.0.1:9001/",
+      "AccessKey": ""
     },
-    "AzureAISearch": {
-      // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-      "Auth": "AzureIdentity",
-      "Endpoint": "https://<...>",
-      "APIKey": ""
-    },
-    "Qdrant": {
-      "Endpoint": "http://127.0.0.1:6333",
-      "APIKey": ""
-    },
-    "AzureOpenAIText": {
-      // "ApiKey" or "AzureIdentity"
-      // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-      //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-      "Auth": "AzureIdentity",
-      "Endpoint": "https://<...>.openai.azure.com/",
-      "APIKey": "",
-      "Deployment": "",
-      // The max number of tokens supported by model deployed
-      // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-      "MaxTokenTotal": 16384,
-      // "ChatCompletion" or "TextCompletion"
-      "APIType": "ChatCompletion",
-      "MaxRetries": 10
-    },
-    "OpenAI": {
-      "APIKey": ""
-    },
-    "LlamaSharp": {
-      // path to file, e.g. "llama-2-7b-chat.Q6_K.gguf"
-      "ModelPath": "",
-      // Max number of tokens supported by the model
-      "MaxTokenTotal": 4096
-      // Optional parameters
-      // "GpuLayerCount": 32,
-      // "Seed": 1337,
+    "Services": {
+      "SimpleVectorDb": {
+        // Options: "Disk", "Volatile"
+        "StorageType": "Volatile",
+        "Directory": "tmp-vectors"
+      },
+      "AzureAISearch": {
+        // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>",
+        "APIKey": ""
+      },
+      "Qdrant": {
+        "Endpoint": "http://127.0.0.1:6333",
+        "APIKey": ""
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
+        "MaxRetries": 10
+      },
+      "OpenAI": {
+        "APIKey": ""
+      },
+      "LlamaSharp": {
+        // path to file, e.g. "llama-2-7b-chat.Q6_K.gguf"
+        "ModelPath": "",
+        // Max number of tokens supported by the model
+        "MaxTokenTotal": 4096
+        // Optional parameters
+        // "GpuLayerCount": 32,
+        // "Seed": 1337,
+      }
     }
   },
   "Logging": {

--- a/service/tests/TestHelpers/BaseFunctionalTestCase.cs
+++ b/service/tests/TestHelpers/BaseFunctionalTestCase.cs
@@ -34,21 +34,21 @@ public abstract class BaseFunctionalTestCase : IDisposable
         this._output = new RedirectConsole(output);
         Console.SetOut(this._output);
 
-        this.OpenAiConfig = cfg.GetSection("Services:OpenAI").Get<OpenAIConfig>() ?? new();
-        this.AzureOpenAITextConfiguration = cfg.GetSection("Services:AzureOpenAIText").Get<AzureOpenAIConfig>() ?? new();
-        this.AzureOpenAIEmbeddingConfiguration = cfg.GetSection("Services:AzureOpenAIEmbedding").Get<AzureOpenAIConfig>() ?? new();
-        this.AzureAiSearchConfig = cfg.GetSection("Services:AzureAISearch").Get<AzureAISearchConfig>() ?? new();
-        this.QdrantConfig = cfg.GetSection("Services:Qdrant").Get<QdrantConfig>() ?? new();
-        this.PostgresConfig = cfg.GetSection("Services:Postgres").Get<PostgresConfig>() ?? new();
-        this.RedisConfig = cfg.GetSection("Services:Redis").Get<RedisConfig>() ?? new();
-        this.SimpleVectorDbConfig = cfg.GetSection("Services:SimpleVectorDb").Get<SimpleVectorDbConfig>() ?? new();
-        this.LlamaSharpConfig = cfg.GetSection("Services:LlamaSharp").Get<LlamaSharpConfig>() ?? new();
+        this.OpenAiConfig = cfg.GetSection("KernelMemory:Services:OpenAI").Get<OpenAIConfig>() ?? new();
+        this.AzureOpenAITextConfiguration = cfg.GetSection("KernelMemory:Services:AzureOpenAIText").Get<AzureOpenAIConfig>() ?? new();
+        this.AzureOpenAIEmbeddingConfiguration = cfg.GetSection("KernelMemory:Services:AzureOpenAIEmbedding").Get<AzureOpenAIConfig>() ?? new();
+        this.AzureAiSearchConfig = cfg.GetSection("KernelMemory:Services:AzureAISearch").Get<AzureAISearchConfig>() ?? new();
+        this.QdrantConfig = cfg.GetSection("KernelMemory:Services:Qdrant").Get<QdrantConfig>() ?? new();
+        this.PostgresConfig = cfg.GetSection("KernelMemory:Services:Postgres").Get<PostgresConfig>() ?? new();
+        this.RedisConfig = cfg.GetSection("KernelMemory:Services:Redis").Get<RedisConfig>() ?? new();
+        this.SimpleVectorDbConfig = cfg.GetSection("KernelMemory:Services:SimpleVectorDb").Get<SimpleVectorDbConfig>() ?? new();
+        this.LlamaSharpConfig = cfg.GetSection("KernelMemory:Services:LlamaSharp").Get<LlamaSharpConfig>() ?? new();
     }
 
     protected IKernelMemory GetMemoryWebClient()
     {
-        string endpoint = this._cfg.GetSection("ServiceAuthorization").GetValue<string>("Endpoint", "http://127.0.0.1:9001/")!;
-        string? apiKey = this._cfg.GetSection("ServiceAuthorization").GetValue<string>("AccessKey");
+        string endpoint = this._cfg.GetSection("KernelMemory:ServiceAuthorization").GetValue<string>("Endpoint", "http://127.0.0.1:9001/")!;
+        string? apiKey = this._cfg.GetSection("KernelMemory:ServiceAuthorization").GetValue<string>("AccessKey");
         return new MemoryWebClient(endpoint, apiKey: apiKey);
     }
 


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

Some functional tests config used a different schema, making it harder to copy settings from service to examples to tests.
Redis config needs an update given the new tag for partition number.
Redis functional tests checking for error message were not aligned with latest code.
ElasticSearch config settings were missing in Service appsettings.json

## High level description (Approach, Design)

* Add "KernelMemory" config prefix where missing.
* Update Redis config and Redis settings.
* Add ES default settings.