### PR TITLE
Configure Qdrant default collection name

### DIFF
--- a/extensions/LlamaSharp/LlamaSharp.FunctionalTests/appsettings.json
+++ b/extensions/LlamaSharp/LlamaSharp.FunctionalTests/appsettings.json
@@ -28,7 +28,8 @@
       },
       "Qdrant": {
         "Endpoint": "http://127.0.0.1:6333",
-        "APIKey": ""
+        "APIKey": "",
+        "DefaultIndex": "default"
       },
       "OpenAI": {
         // Name of the model used to generate text (text completion or chat completion)

--- a/extensions/Qdrant/Qdrant.FunctionalTests/appsettings.json
+++ b/extensions/Qdrant/Qdrant.FunctionalTests/appsettings.json
@@ -7,7 +7,8 @@
     "Services": {
       "Qdrant": {
         "Endpoint": "http://127.0.0.1:6333",
-        "APIKey": ""
+        "APIKey": "",
+        "DefaultIndex": "default"
       },
       "OpenAI": {
         // Name of the model used to generate text (text completion or chat completion)

--- a/extensions/Qdrant/Qdrant.TestApplication/appsettings.json
+++ b/extensions/Qdrant/Qdrant.TestApplication/appsettings.json
@@ -10,7 +10,8 @@
       "Qdrant": {
         "Endpoint": "http://127.0.0.1:6333",
         "APIKey": "",
-      },
+        "DefaultIndex": "default"
+      }
     }
   }
 }

--- a/extensions/Qdrant/Qdrant/QdrantConfig.cs
+++ b/extensions/Qdrant/Qdrant/QdrantConfig.cs
@@ -19,4 +19,5 @@ public class QdrantConfig
 
     public string Endpoint { get; set; } = string.Empty;
     public string APIKey { get; set; } = string.Empty;
+    public string DefaultIndex { get; set; } = Constants.DefaultIndex;
 }

--- a/extensions/Qdrant/Qdrant/QdrantMemory.cs
+++ b/extensions/Qdrant/Qdrant/QdrantMemory.cs
@@ -24,6 +24,7 @@ public class QdrantMemory : IMemoryDb
 {
     private readonly ITextEmbeddingGenerator _embeddingGenerator;
     private readonly QdrantClient<DefaultQdrantPayload> _qdrantClient;
+    private readonly string _defaultIndex;
     private readonly ILogger<QdrantMemory> _log;
 
     /// <summary>
@@ -46,6 +47,7 @@ public class QdrantMemory : IMemoryDb
 
         this._log = log ?? DefaultLogger<QdrantMemory>.Instance;
         this._qdrantClient = new QdrantClient<DefaultQdrantPayload>(endpoint: config.Endpoint, apiKey: config.APIKey);
+        this._defaultIndex = !string.IsNullOrWhiteSpace(config.DefaultIndex) ? config.DefaultIndex : Constants.DefaultIndex;
     }
 
     /// <inheritdoc />
@@ -225,7 +227,7 @@ public class QdrantMemory : IMemoryDb
     {
         if (string.IsNullOrWhiteSpace(index))
         {
-            index = Constants.DefaultIndex;
+            index = this._defaultIndex;
         }
 
         index = s_replaceIndexNameCharsRegex.Replace(index.Trim().ToLowerInvariant(), ValidSeparator);

--- a/extensions/Qdrant/Qdrant/QdrantMemory.cs
+++ b/extensions/Qdrant/Qdrant/QdrantMemory.cs
@@ -24,8 +24,8 @@ public class QdrantMemory : IMemoryDb
 {
     private readonly ITextEmbeddingGenerator _embeddingGenerator;
     private readonly QdrantClient<DefaultQdrantPayload> _qdrantClient;
-    private readonly string _defaultIndex;
     private readonly ILogger<QdrantMemory> _log;
+    private readonly string _defaultIndex;
 
     /// <summary>
     /// Create new instance

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -256,7 +256,8 @@
       },
       "Qdrant": {
         "Endpoint": "http://127.0.0.1:6333",
-        "APIKey": ""
+        "APIKey": "",
+        "DefaultIndex": "default"
       },
       "Redis": {
         // Redis connection string, e.g. "localhost:6379,password=..."

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -125,7 +125,7 @@
       "EmbeddingGeneratorTypes": [
       ],
       // Vectors can be written to multiple storages, e.g. for data migration, A/B testing, etc.
-      // "AzureAISearch", "Qdrant", "Postgres", "SimpleVectorDb"
+      // "AzureAISearch", "Qdrant", "Postgres", "Redis", "SimpleVectorDb"
       "MemoryDbTypes": [
         "SimpleVectorDb"
       ],
@@ -160,7 +160,7 @@
       // "AzureOpenAIEmbedding" or "OpenAI"
       // This is the generator registered for `ITextEmbeddingGeneration` dependency injection.
       "EmbeddingGeneratorType": "",
-      // "AzureAISearch", "Qdrant", "Postgres", "SimpleVectorDb"
+      // "AzureAISearch", "Qdrant", "Postgres", "Redis", "SimpleVectorDb"
       "MemoryDbType": "SimpleVectorDb",
       // Search client settings
       "SearchClient": {
@@ -255,8 +255,11 @@
         "TableNamePrefix": "km-"
       },
       "Qdrant": {
+        // Qdrant endpoint
         "Endpoint": "http://127.0.0.1:6333",
+        // Qdrant API key, e.g. when using Qdrant cloud
         "APIKey": "",
+        // Name of the default KM index/Qdrant collection, when none is specified
         "DefaultIndex": "default"
       },
       "Redis": {

--- a/service/tests/Core.FunctionalTests/appsettings.json
+++ b/service/tests/Core.FunctionalTests/appsettings.json
@@ -28,7 +28,8 @@
       },
       "Qdrant": {
         "Endpoint": "http://127.0.0.1:6333",
-        "APIKey": ""
+        "APIKey": "",
+        "DefaultIndex": "default"
       },
       "Redis": {
         // Redis connection string, e.g. "localhost:6379,password=..."

--- a/service/tests/Service.FunctionalTests/appsettings.json
+++ b/service/tests/Service.FunctionalTests/appsettings.json
@@ -20,7 +20,8 @@
       },
       "Qdrant": {
         "Endpoint": "http://127.0.0.1:6333",
-        "APIKey": ""
+        "APIKey": "",
+        "DefaultIndex": "default"
       },
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

As described in the issue https://github.com/microsoft/kernel-memory/issues/285, it is useful to have the ability to specify the default collection used by Qdrant, so we don't need to specify it for every invocation of methos that work with index.

## High level description (Approach, Design)

This PR adds a new configuration property, `DefaultIndex`, to `QdrantConfig` class. This value is used to set the default index name in the `QdrantMemory` client. If no value is provided, that the old `Constants.DefaultIndex` field is used, so backward compatibility is guaranted.