### PR TITLE
Add properties to set SearchClient settings like Temperature and TopP

### DIFF
--- a/service/Abstractions/Search/SearchClientConfig.cs
+++ b/service/Abstractions/Search/SearchClientConfig.cs
@@ -41,40 +41,40 @@ public class SearchClientConfig
     /// </summary>
     public string EmptyAnswer { get; set; } = "INFO NOT FOUND";
 
-    //
-    // Summary:
-    //     Temperature controls the randomness of the completion. The higher the temperature,
-    //     the more random the completion.
-    public double Temperature { get; set; }
+    /// <summary>
+    /// Number between 0.0 and 2.0. It controls the randomness of the completion.
+    /// The higher the temperature, the more random the completion.
+    /// </summary>
+    public double Temperature { get; set; } = 0;
 
-    //
-    // Summary:
-    //     TopP controls the diversity of the completion. The higher the TopP, the more
-    //     diverse the completion.
-    public double TopP { get; set; }
+    /// <summary>
+    /// Number between 0.0 and 2.0. It controls the diversity of the completion.
+    /// The higher the TopP, the more diverse the completion.
+    /// </summary>    
+    public double TopP { get; set; } = 0;
 
-    //
-    // Summary:
-    //     Number between -2.0 and 2.0. Positive values penalize new tokens based on whether
-    //     they appear in the text so far, increasing the model's likelihood to talk about
-    //     new topics.
-    public double PresencePenalty { get; set; }
+    /// <summary>
+    /// Number between -2.0 and 2.0. Positive values penalize new tokens based on whether
+    /// they appear in the text so far, increasing the model's likelihood to talk about
+    /// new topics.
+    /// </summary>
+    public double PresencePenalty { get; set; } = 0;
 
-    //
-    // Summary:
-    //     Number between -2.0 and 2.0. Positive values penalize new tokens based on their
-    //     existing frequency in the text so far, decreasing the model's likelihood to repeat
-    //     the same line verbatim.
-    public double FrequencyPenalty { get; set; }
+    /// <summary>
+    /// Number between -2.0 and 2.0. Positive values penalize new tokens based on their
+    /// existing frequency in the text so far, decreasing the model's likelihood to repeat
+    /// the same line verbatim.
+    /// </summary> 
+    public double FrequencyPenalty { get; set; } = 0;
 
-    //
-    // Summary:
-    //     Sequences where the completion will stop generating further tokens.
+    /// <summary>
+    /// Up to 4 sequences where the completion will stop generating further tokens.
+    /// </summary>
     public IList<string> StopSequences { get; set; } = Array.Empty<string>();
 
-    //
-    // Summary:
-    //     Modify the likelihood of specified tokens appearing in the completion.
+    /// <summary>
+    /// Modify the likelihood of specified tokens appearing in the completion.
+    /// </summary>
     public Dictionary<int, float> TokenSelectionBiases { get; set; } = new Dictionary<int, float>();
 
     /// <summary>

--- a/service/Abstractions/Search/SearchClientConfig.cs
+++ b/service/Abstractions/Search/SearchClientConfig.cs
@@ -50,7 +50,7 @@ public class SearchClientConfig
     /// <summary>
     /// Number between 0.0 and 2.0. It controls the diversity of the completion.
     /// The higher the TopP, the more diverse the completion.
-    /// </summary>    
+    /// </summary>
     public double TopP { get; set; } = 0;
 
     /// <summary>
@@ -64,7 +64,7 @@ public class SearchClientConfig
     /// Number between -2.0 and 2.0. Positive values penalize new tokens based on their
     /// existing frequency in the text so far, decreasing the model's likelihood to repeat
     /// the same line verbatim.
-    /// </summary> 
+    /// </summary>
     public double FrequencyPenalty { get; set; } = 0;
 
     /// <summary>
@@ -75,7 +75,7 @@ public class SearchClientConfig
     /// <summary>
     /// Modify the likelihood of specified tokens appearing in the completion.
     /// </summary>
-    public Dictionary<int, float> TokenSelectionBiases { get; set; } = new Dictionary<int, float>();
+    public Dictionary<int, float> TokenSelectionBiases { get; set; } = new();
 
     /// <summary>
     /// Verify that the current state is valid.
@@ -121,7 +121,7 @@ public class SearchClientConfig
         if (this.PresencePenalty is < -2 or > 2)
         {
             throw new ArgumentOutOfRangeException(nameof(this.PresencePenalty),
-                               $"{nameof(this.PresencePenalty)} must be between -2 and 2");
+                $"{nameof(this.PresencePenalty)} must be between -2 and 2");
         }
 
         if (this.FrequencyPenalty is < -2 or > 2)

--- a/service/Abstractions/Search/SearchClientConfig.cs
+++ b/service/Abstractions/Search/SearchClientConfig.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 
 #pragma warning disable IDE0130 // reduce number of "using" statements
 // ReSharper disable once CheckNamespace - reduce number of "using" statements
@@ -40,6 +41,42 @@ public class SearchClientConfig
     /// </summary>
     public string EmptyAnswer { get; set; } = "INFO NOT FOUND";
 
+    //
+    // Summary:
+    //     Temperature controls the randomness of the completion. The higher the temperature,
+    //     the more random the completion.
+    public double Temperature { get; set; }
+
+    //
+    // Summary:
+    //     TopP controls the diversity of the completion. The higher the TopP, the more
+    //     diverse the completion.
+    public double TopP { get; set; }
+
+    //
+    // Summary:
+    //     Number between -2.0 and 2.0. Positive values penalize new tokens based on whether
+    //     they appear in the text so far, increasing the model's likelihood to talk about
+    //     new topics.
+    public double PresencePenalty { get; set; }
+
+    //
+    // Summary:
+    //     Number between -2.0 and 2.0. Positive values penalize new tokens based on their
+    //     existing frequency in the text so far, decreasing the model's likelihood to repeat
+    //     the same line verbatim.
+    public double FrequencyPenalty { get; set; }
+
+    //
+    // Summary:
+    //     Sequences where the completion will stop generating further tokens.
+    public IList<string> StopSequences { get; set; } = Array.Empty<string>();
+
+    //
+    // Summary:
+    //     Modify the likelihood of specified tokens appearing in the completion.
+    public Dictionary<int, float> TokenSelectionBiases { get; set; } = new Dictionary<int, float>();
+
     /// <summary>
     /// Verify that the current state is valid.
     /// </summary>
@@ -67,6 +104,30 @@ public class SearchClientConfig
         {
             throw new ArgumentOutOfRangeException(nameof(this.EmptyAnswer),
                 $"{nameof(this.EmptyAnswer)} is too long, consider something shorter");
+        }
+
+        if (this.Temperature is < 0 or > 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(this.Temperature),
+                $"{nameof(this.Temperature)} must be between 0 and 2");
+        }
+
+        if (this.TopP is < 0 or > 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(this.TopP),
+                $"{nameof(this.TopP)} must be between 0 and 2");
+        }
+
+        if (this.PresencePenalty is < -2 or > 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(this.PresencePenalty),
+                               $"{nameof(this.PresencePenalty)} must be between -2 and 2");
+        }
+
+        if (this.FrequencyPenalty is < -2 or > 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(this.FrequencyPenalty),
+                $"{nameof(this.FrequencyPenalty)} must be between -2 and 2");
         }
     }
 }

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -197,6 +197,7 @@
         "FrequencyPenalty": 0,
         // Sequences where the completion will stop generating further tokens.
         "StopSequences": "[]"
+        // Modify the likelihood of specified tokens appearing in the completion.
         //"TokenSelectionBiases": { }
       }
     },

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -180,7 +180,24 @@
         // prompt + question + grounding information retrieved from memory.
         "AnswerTokens": 300,
         // Text to return when the LLM cannot produce an answer.
-        "EmptyAnswer": "INFO NOT FOUND"
+        "EmptyAnswer": "INFO NOT FOUND",
+        // Number between 0 and 2 that controls the randomness of the completion.
+        // The higher the temperature, the more random the completion.
+        "Temperature": 0,
+        // Number between 0 and 2 that controls the diversity of the completion.
+        // The higher the TopP, the more diverse the completion.
+        "TopP": 0,
+        // Number between -2.0 and 2.0. Positive values penalize new tokens based on whether
+        // they appear in the text so far, increasing the model's likelihood to talk about
+        // new topics.
+        "PresencePenalty": 0,
+        // Number between -2.0 and 2.0. Positive values penalize new tokens based on their
+        // existing frequency in the text so far, decreasing the model's likelihood to repeat
+        // the same line verbatim.
+        "FrequencyPenalty": 0,
+        // Sequences where the completion will stop generating further tokens.
+        "StopSequences": "[]"
+        //"TokenSelectionBiases": { }
       }
     },
     "Services": {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
With the exception of `MaxTokens`, properties of the [TextGenerationOptions](https://github.com/microsoft/kernel-memory/blob/dacc5047e339fe4073636b3d9b54c32438073978/service/Core/Search/SearchClient.cs#L341-L350) object used by `AskAsync` are hard-coded.

## High level description (Approach, Design)
This PR addresses issues https://github.com/microsoft/kernel-memory/issues/137 and https://github.com/microsoft/kernel-memory/issues/337. It updates the [SearchClientConfig.cs](https://github.com/microsoft/kernel-memory/blob/main/service/Abstractions/Search/SearchClientConfig.cs) file in the **Abstractions** project adding the properties that allows to set **Temperature**, **TopP**, **PresencePenaltiy**, etc.

Once the **Abstractions** project is updated on NuGet, the **Core** project can be in turn modified to use these new settings in the [SearchClient.cs](https://github.com/microsoft/kernel-memory/blob/dacc5047e339fe4073636b3d9b54c32438073978/service/Core/Search/SearchClient.cs#L341-L350) file.
