### PR TITLE
Bugfix for new Qdrant Create Collection API response code

### DIFF
--- a/extensions/Qdrant/Qdrant/Client/QdrantClient.cs
+++ b/extensions/Qdrant/Qdrant/Client/QdrantClient.cs
@@ -95,7 +95,7 @@ internal sealed class QdrantClient<T> where T : DefaultQdrantPayload, new()
         var (response, content) = await this.ExecuteHttpRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
         // Creation is idempotent, ignore error (and for now ignore vector size)
-        if (response.StatusCode == HttpStatusCode.BadRequest && content.Contains("already exists", StringComparison.OrdinalIgnoreCase))
+        if (response.StatusCode is HttpStatusCode.BadRequest or HttpStatusCode.Conflict && content.Contains("already exists", StringComparison.OrdinalIgnoreCase))
         {
             this._log.LogDebug("Collection {0} already exists", collectionName);
             return;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
Qdrant v1.8.0 has changed the response code that is returned when trying to create a collection that already exists.

## High level description (Approach, Design)
Old version of Qdrant returned **400 Bad Request** when trying to create a collection that already exists. Starting from v1.8.0, this API returns **409 Conflict**. This PR addresses this breaking change (see #347).
