### PR TITLE
Possible fix for 303 - Ignoring legacy Word 97-2003 files

### DIFF
--- a/service/Abstractions/Pipeline/MimeTypes.cs
+++ b/service/Abstractions/Pipeline/MimeTypes.cs
@@ -11,9 +11,9 @@ public static class MimeTypes
     public const string PlainText = "text/plain";
     public const string MarkDown = "text/plain-markdown";
     public const string Html = "text/html";
-    public const string MsWord = "application/msword";
-    public const string MsPowerPoint = "application/mspowerpoint";
-    public const string MsExcel = "application/msexcel";
+    public const string MsWord = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    public const string MsPowerPoint = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+    public const string MsExcel = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
     public const string Pdf = "application/pdf";
     public const string Json = "application/json";
     public const string WebPageUrl = "text/x-uri";
@@ -30,8 +30,7 @@ public static class FileExtensions
     public const string PlainText = ".txt";
     public const string Json = ".json";
     public const string MarkDown = ".md";
-    public const string MsWord = ".doc";
-    public const string MsWordX = ".docx";
+    public const string MsWord = ".docx";
     public const string MsPowerPoint = ".pptx";
     public const string MsExcel = ".xlsx";
     public const string Pdf = ".pdf";
@@ -69,7 +68,6 @@ public class MimeTypesDetection : IMimeTypeDetection
             { FileExtensions.Html, MimeTypes.Html },
             { FileExtensions.WebPageUrl, MimeTypes.WebPageUrl },
             { FileExtensions.MsWord, MimeTypes.MsWord },
-            { FileExtensions.MsWordX, MimeTypes.MsWord },
             { FileExtensions.MsPowerPoint, MimeTypes.MsPowerPoint },
             { FileExtensions.MsExcel, MimeTypes.MsExcel },
             { FileExtensions.PlainText, MimeTypes.PlainText },

--- a/service/Abstractions/Pipeline/MimeTypes.cs
+++ b/service/Abstractions/Pipeline/MimeTypes.cs
@@ -11,9 +11,12 @@ public static class MimeTypes
     public const string PlainText = "text/plain";
     public const string MarkDown = "text/plain-markdown";
     public const string Html = "text/html";
-    public const string MsWord = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-    public const string MsPowerPoint = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
-    public const string MsExcel = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    public const string MsWord = "application/msword";
+    public const string MsWordX = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    public const string MsPowerPoint = "application/vnd.ms-powerpoint";
+    public const string MsPowerPointX = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+    public const string MsExcel = "application/vnd.ms-excel";
+    public const string MsExcelX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
     public const string Pdf = "application/pdf";
     public const string Json = "application/json";
     public const string WebPageUrl = "text/x-uri";
@@ -30,9 +33,12 @@ public static class FileExtensions
     public const string PlainText = ".txt";
     public const string Json = ".json";
     public const string MarkDown = ".md";
-    public const string MsWord = ".docx";
-    public const string MsPowerPoint = ".pptx";
-    public const string MsExcel = ".xlsx";
+    public const string MsWord = ".doc";
+    public const string MsWordX = ".docx";
+    public const string MsPowerPoint = ".ppt";
+    public const string MsPowerPointX = ".pptx";
+    public const string MsExcel = ".xls";
+    public const string MsExcelX = ".xlsx";
     public const string Pdf = ".pdf";
     public const string Htm = ".htm";
     public const string Html = ".html";
@@ -67,9 +73,12 @@ public class MimeTypesDetection : IMimeTypeDetection
             { FileExtensions.Htm, MimeTypes.Html },
             { FileExtensions.Html, MimeTypes.Html },
             { FileExtensions.WebPageUrl, MimeTypes.WebPageUrl },
-            { FileExtensions.MsWord, MimeTypes.MsWord },
-            { FileExtensions.MsPowerPoint, MimeTypes.MsPowerPoint },
-            { FileExtensions.MsExcel, MimeTypes.MsExcel },
+            // { FileExtensions.MsWord, MimeTypes.MsWord }, // TODO: add support for legacy doc files
+            { FileExtensions.MsWordX, MimeTypes.MsWordX },
+            // { FileExtensions.MsPowerPoint, MimeTypes.MsPowerPoint }, // TODO: add support for legacy ppt files
+            { FileExtensions.MsPowerPointX, MimeTypes.MsPowerPointX },
+            // { FileExtensions.MsExcel, MimeTypes.MsExcel }, // TODO: add support for legacy xls files
+            { FileExtensions.MsExcelX, MimeTypes.MsExcelX },
             { FileExtensions.PlainText, MimeTypes.PlainText },
             { FileExtensions.Pdf, MimeTypes.Pdf },
             { FileExtensions.TextEmbeddingVector, MimeTypes.TextEmbeddingVector },

--- a/service/Abstractions/Pipeline/MimeTypes.cs
+++ b/service/Abstractions/Pipeline/MimeTypes.cs
@@ -73,11 +73,11 @@ public class MimeTypesDetection : IMimeTypeDetection
             { FileExtensions.Htm, MimeTypes.Html },
             { FileExtensions.Html, MimeTypes.Html },
             { FileExtensions.WebPageUrl, MimeTypes.WebPageUrl },
-            // { FileExtensions.MsWord, MimeTypes.MsWord }, // TODO: add support for legacy doc files
+            { FileExtensions.MsWord, MimeTypes.MsWord }, // TODO: add support for legacy doc files
             { FileExtensions.MsWordX, MimeTypes.MsWordX },
-            // { FileExtensions.MsPowerPoint, MimeTypes.MsPowerPoint }, // TODO: add support for legacy ppt files
+            { FileExtensions.MsPowerPoint, MimeTypes.MsPowerPoint }, // TODO: add support for legacy ppt files
             { FileExtensions.MsPowerPointX, MimeTypes.MsPowerPointX },
-            // { FileExtensions.MsExcel, MimeTypes.MsExcel }, // TODO: add support for legacy xls files
+            { FileExtensions.MsExcel, MimeTypes.MsExcel }, // TODO: add support for legacy xls files
             { FileExtensions.MsExcelX, MimeTypes.MsExcelX },
             { FileExtensions.PlainText, MimeTypes.PlainText },
             { FileExtensions.Pdf, MimeTypes.Pdf },

--- a/service/Core/Handlers/TextExtractionHandler.cs
+++ b/service/Core/Handlers/TextExtractionHandler.cs
@@ -152,6 +152,7 @@ public class TextExtractionHandler : IPipelineStepHandler
                 content.Sections.Add(new(1, fileContent.ToString().Trim(), true));
                 break;
 
+#if KernelMemoryDev
             case MimeTypes.MsWordX:
                 this._log.LogDebug("Extracting text from MS Word file {0}", uploadedFile.Name);
                 content = new MsWordDecoder().ExtractContent(fileContent);
@@ -180,6 +181,30 @@ public class TextExtractionHandler : IPipelineStepHandler
                 );
                 this._log.LogWarning("Office 97-2003 file MIME type not supported: {0} - ignoring the file", uploadedFile.MimeType);
                 break;
+#else
+            case MimeTypes.MsWord:
+            case "application/vnd.openxmlformats-officedocument.wordprocessingml.document": // TODO: remove this constant after upgrades
+                this._log.LogDebug("Extracting text from MS Word file {0}", uploadedFile.Name);
+                content = new MsWordDecoder().ExtractContent(fileContent);
+                break;
+
+            case MimeTypes.MsPowerPoint:
+            case "application/vnd.ms-powerpoint": // TODO: remove this constant after upgrades
+            case "application/vnd.openxmlformats-officedocument.presentationml.presentation": // TODO: remove this constant after upgrades
+                this._log.LogDebug("Extracting text from MS PowerPoint file {0}", uploadedFile.Name);
+                content = new MsPowerPointDecoder().ExtractContent(fileContent,
+                    withSlideNumber: true,
+                    withEndOfSlideMarker: false,
+                    skipHiddenSlides: true);
+                break;
+
+            case MimeTypes.MsExcel:
+            case "application/vnd.ms-excel": // TODO: remove this constant after upgrades
+            case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": // TODO: remove this constant after upgrades
+                this._log.LogDebug("Extracting text from MS Excel file {0}", uploadedFile.Name);
+                content = new MsExcelDecoder().ExtractContent(fileContent);
+                break;
+#endif
 
             case MimeTypes.Pdf:
                 this._log.LogDebug("Extracting text from PDF file {0}", uploadedFile.Name);

--- a/service/Core/Handlers/TextExtractionHandler.cs
+++ b/service/Core/Handlers/TextExtractionHandler.cs
@@ -152,12 +152,12 @@ public class TextExtractionHandler : IPipelineStepHandler
                 content.Sections.Add(new(1, fileContent.ToString().Trim(), true));
                 break;
 
-            case MimeTypes.MsWord:
+            case MimeTypes.MsWordX:
                 this._log.LogDebug("Extracting text from MS Word file {0}", uploadedFile.Name);
                 content = new MsWordDecoder().ExtractContent(fileContent);
                 break;
 
-            case MimeTypes.MsPowerPoint:
+            case MimeTypes.MsPowerPointX:
                 this._log.LogDebug("Extracting text from MS PowerPoint file {0}", uploadedFile.Name);
                 content = new MsPowerPointDecoder().ExtractContent(fileContent,
                     withSlideNumber: true,
@@ -165,7 +165,7 @@ public class TextExtractionHandler : IPipelineStepHandler
                     skipHiddenSlides: true);
                 break;
 
-            case MimeTypes.MsExcel:
+            case MimeTypes.MsExcelX:
                 this._log.LogDebug("Extracting text from MS Excel file {0}", uploadedFile.Name);
                 content = new MsExcelDecoder().ExtractContent(fileContent);
                 break;

--- a/service/Core/Handlers/TextExtractionHandler.cs
+++ b/service/Core/Handlers/TextExtractionHandler.cs
@@ -170,6 +170,17 @@ public class TextExtractionHandler : IPipelineStepHandler
                 content = new MsExcelDecoder().ExtractContent(fileContent);
                 break;
 
+            case MimeTypes.MsWord:
+            case MimeTypes.MsPowerPoint:
+            case MimeTypes.MsExcel:
+                skipFile = true;
+                uploadedFile.Log(
+                    this,
+                    "Office 97-2003 format not supported. It is recommended to migrate to the newer OpenXML format (docx, xlsx or pptx). Ignoring the file."
+                );
+                this._log.LogWarning("Office 97-2003 file MIME type not supported: {0} - ignoring the file", uploadedFile.MimeType);
+                break;
+
             case MimeTypes.Pdf:
                 this._log.LogDebug("Extracting text from PDF file {0}", uploadedFile.Name);
                 content = new PdfDecoder().ExtractContent(fileContent);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

Proposal for fix #303 

## High level description (Approach, Design)

Like described in the issue, the legacy Word 97-2003 files will be ignored. Also the MIME types for the XML formats are changed to reflect the actual content type for those files.
