### PR TITLE
Fixed #358 - configuration on Disk from clean folder

### DIFF
--- a/tools/InteractiveSetup/AppSettings.cs
+++ b/tools/InteractiveSetup/AppSettings.cs
@@ -76,6 +76,10 @@ public static class AppSettings
 
     private static JObject GetGlobalConfig(bool includeDefaults = false)
     {
+        if (!File.Exists(DevelopmentSettingsFile))
+        {
+            CreateFileIfNotExists();
+        }
         string json = File.ReadAllText(DevelopmentSettingsFile);
         JObject? data = JsonConvert.DeserializeObject<JObject>(json);
         if (data == null)

--- a/tools/InteractiveSetup/Main.cs
+++ b/tools/InteractiveSetup/Main.cs
@@ -626,9 +626,12 @@ public static class Main
             };
         }
 
+        var queueFolderOnDisk = SetupUI.AskOpenQuestion("Directory where to store queue messages, empty to use in memory volatile queue", "", optional: true);
+
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>
         {
-            { "Directory", SetupUI.AskOpenQuestion("Directory where to store queue messages", config["Directory"].ToString()) }
+            { "StorageType", string.IsNullOrEmpty(queueFolderOnDisk) ? "Volatile" : "Disk" },
+            { "Directory", queueFolderOnDisk }
         });
     }
 
@@ -732,9 +735,12 @@ public static class Main
             };
         }
 
+        var queueFolderOnDisk = SetupUI.AskOpenQuestion("Directory where to store files, empty to use in memory volatile storage", "", optional: true);
+
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>
         {
-            { "Directory", SetupUI.AskOpenQuestion("Directory where to store files", config["Directory"].ToString()) }
+            { "StorageType", string.IsNullOrEmpty(queueFolderOnDisk) ? "Volatile" : "Disk" },
+            { "Directory", queueFolderOnDisk }
         });
     }
 
@@ -860,9 +866,12 @@ public static class Main
             };
         }
 
+        var queueFolderOnDisk = SetupUI.AskOpenQuestion("Directory where to store vectors, empty to use in memory volatile memory", "", optional: true);
+
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>
         {
-            { "Directory", SetupUI.AskOpenQuestion("Directory where to store vectors", config["Directory"].ToString()) }
+            { "StorageType", string.IsNullOrEmpty(queueFolderOnDisk) ? "Volatile" : "Disk" },
+            { "Directory", queueFolderOnDisk }
         });
     }
 

--- a/tools/InteractiveSetup/Main.cs
+++ b/tools/InteractiveSetup/Main.cs
@@ -732,8 +732,6 @@ public static class Main
             };
         }
 
-        var queueFolderOnDisk = SetupUI.AskOpenQuestion("Directory where to store files, empty to use in memory volatile storage", "", optional: true);
-
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>
         {
             { "StorageType", string.IsNullOrEmpty(queueFolderOnDisk) ? "Volatile" : "Disk" },

--- a/tools/InteractiveSetup/Main.cs
+++ b/tools/InteractiveSetup/Main.cs
@@ -628,8 +628,7 @@ public static class Main
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>
         {
-            { "StorageType", string.IsNullOrEmpty(queueFolderOnDisk) ? "Volatile" : "Disk" },
-            { "Directory", queueFolderOnDisk }
+            { "Directory", SetupUI.AskOpenQuestion("Directory where to store queue messages", config["Directory"].ToString()) }
         });
     }
 

--- a/tools/InteractiveSetup/Main.cs
+++ b/tools/InteractiveSetup/Main.cs
@@ -626,8 +626,6 @@ public static class Main
             };
         }
 
-        var queueFolderOnDisk = SetupUI.AskOpenQuestion("Directory where to store queue messages, empty to use in memory volatile queue", "", optional: true);
-
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>
         {
             { "StorageType", string.IsNullOrEmpty(queueFolderOnDisk) ? "Volatile" : "Disk" },

--- a/tools/InteractiveSetup/Main.cs
+++ b/tools/InteractiveSetup/Main.cs
@@ -734,8 +734,7 @@ public static class Main
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>
         {
-            { "StorageType", string.IsNullOrEmpty(queueFolderOnDisk) ? "Volatile" : "Disk" },
-            { "Directory", queueFolderOnDisk }
+            { "Directory", SetupUI.AskOpenQuestion("Directory where to store files", config["Directory"].ToString()) }
         });
     }
 

--- a/tools/InteractiveSetup/Main.cs
+++ b/tools/InteractiveSetup/Main.cs
@@ -860,8 +860,6 @@ public static class Main
             };
         }
 
-        var queueFolderOnDisk = SetupUI.AskOpenQuestion("Directory where to store vectors, empty to use in memory volatile memory", "", optional: true);
-
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>
         {
             { "StorageType", string.IsNullOrEmpty(queueFolderOnDisk) ? "Volatile" : "Disk" },

--- a/tools/InteractiveSetup/Main.cs
+++ b/tools/InteractiveSetup/Main.cs
@@ -862,8 +862,7 @@ public static class Main
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>
         {
-            { "StorageType", string.IsNullOrEmpty(queueFolderOnDisk) ? "Volatile" : "Disk" },
-            { "Directory", queueFolderOnDisk }
+            { "Directory", SetupUI.AskOpenQuestion("Directory where to store vectors", config["Directory"].ToString()) }
         });
     }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

When you download the project in a fresh folder, running `dotnet run setup` in the service folder throws an error because development.json file does not exists.

Also if you configure using Disk storage (not for production but useful for testing) actually it uses volatile storage and does not persist anytying on disk.

it will fix #358

## High level description (Approach, Design)

I've simply restored the generation of basic development file if not exists, also fixed configuration using "disk" storage type instead of "volatile"

