### PR TITLE
Bump SemanticKernel dependencies to v1.6.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,8 +43,8 @@
   </ItemGroup>
   <!-- Semantic Kernel -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.4.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.4.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.6.1" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.6.1" />
   </ItemGroup>
   <!-- Documentation -->
   <ItemGroup>

--- a/extensions/AzureOpenAI/AzureOpenAI.csproj
+++ b/extensions/AzureOpenAI/AzureOpenAI.csproj
@@ -5,7 +5,7 @@
         <RollForward>LatestMajor</RollForward>
         <AssemblyName>Microsoft.KernelMemory.AI.AzureOpenAI</AssemblyName>
         <RootNamespace>Microsoft.KernelMemory.AI.AzureOpenAI</RootNamespace>
-        <NoWarn>$(NoWarn);CA1724;CS1591;SKEXP0011;</NoWarn>
+        <NoWarn>$(NoWarn);CA1724;CS1591;SKEXP0010;SKEXP0011;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/extensions/OpenAI/OpenAI.csproj
+++ b/extensions/OpenAI/OpenAI.csproj
@@ -5,7 +5,7 @@
         <RollForward>LatestMajor</RollForward>
         <AssemblyName>Microsoft.KernelMemory.AI.OpenAI</AssemblyName>
         <RootNamespace>Microsoft.KernelMemory.AI.OpenAI</RootNamespace>
-        <NoWarn>$(NoWarn);CA1724;CS1591;CA1308;SKEXP0011;</NoWarn>
+        <NoWarn>$(NoWarn);CA1724;CS1591;CA1308;SKEXP0010;SKEXP0011;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/service/Core/Handlers/DependencyInjection.cs
+++ b/service/Core/Handlers/DependencyInjection.cs
@@ -103,11 +103,11 @@ public static partial class DependencyInjection
         // Build generic type: HandlerAsAHostedService<THandler>
         Type handlerAsAHostedServiceTHandler = typeof(HandlerAsAHostedService<>).MakeGenericType(tHandler);
 
-        IHostedService implementationFactory(IServiceProvider serviceProvider)
+        IHostedService ImplementationFactory(IServiceProvider serviceProvider)
             => (IHostedService)ActivatorUtilities.CreateInstance(serviceProvider, handlerAsAHostedServiceTHandler, stepName);
 
         // See https://github.com/dotnet/runtime/issues/38751 for troubleshooting
-        services.Add(ServiceDescriptor.Singleton<IHostedService>(implementationFactory));
+        services.Add(ServiceDescriptor.Singleton<IHostedService>((Func<IServiceProvider, IHostedService>)ImplementationFactory));
 
         return services;
     }

--- a/service/Core/Handlers/DependencyInjection.cs
+++ b/service/Core/Handlers/DependencyInjection.cs
@@ -103,8 +103,8 @@ public static partial class DependencyInjection
         // Build generic type: HandlerAsAHostedService<THandler>
         Type handlerAsAHostedServiceTHandler = typeof(HandlerAsAHostedService<>).MakeGenericType(tHandler);
 
-        Func<IServiceProvider, IHostedService> implementationFactory =
-            serviceProvider => (IHostedService)ActivatorUtilities.CreateInstance(serviceProvider, handlerAsAHostedServiceTHandler, stepName);
+        IHostedService implementationFactory(IServiceProvider serviceProvider)
+            => (IHostedService)ActivatorUtilities.CreateInstance(serviceProvider, handlerAsAHostedServiceTHandler, stepName);
 
         // See https://github.com/dotnet/runtime/issues/38751 for troubleshooting
         services.Add(ServiceDescriptor.Singleton<IHostedService>(implementationFactory));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
This PR solves a version mismatch between libraries. See https://github.com/microsoft/kernel-memory/issues/361.

## High level description (Approach, Design)
This PR updates the package dependencies to correctly support the latest version of **Azure.AI.OpenAI library**, that is required to use the right API version of the service.
