### PR TITLE
Allow to override OpenAI endpoint

### DIFF
--- a/KernelMemory.sln
+++ b/KernelMemory.sln
@@ -232,6 +232,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoDbAtlas.FunctionalTest
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "107-dotnet-SemanticKernel-TextCompletion", "examples\107-dotnet-SemanticKernel-TextCompletion\107-dotnet-SemanticKernel-TextCompletion.csproj", "{494B8590-F0B2-4D40-A895-F9D7BDF26250}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "208-dotnet-lmstudio", "examples\208-dotnet-lmstudio\208-dotnet-lmstudio.csproj", "{BC8057DA-CB40-4308-96FB-EF0100822BAD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -301,6 +303,7 @@ Global
 		{4A539320-EB49-4688-82E1-4FA0ADBB3810} = {155DA079-E267-49AF-973A-D1D44681970F}
 		{8A602227-B291-4F1B-ACB8-237F49501B6A} = {3C17F42B-CFC8-4900-8CFB-88936311E919}
 		{494B8590-F0B2-4D40-A895-F9D7BDF26250} = {0A43C65C-6007-4BB4-B3FE-8D439FC91841}
+		{BC8057DA-CB40-4308-96FB-EF0100822BAD} = {0A43C65C-6007-4BB4-B3FE-8D439FC91841}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8A9FA587-7EBA-4D43-BE47-38D798B1C74C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -492,5 +495,8 @@ Global
 		{494B8590-F0B2-4D40-A895-F9D7BDF26250}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{494B8590-F0B2-4D40-A895-F9D7BDF26250}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{494B8590-F0B2-4D40-A895-F9D7BDF26250}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC8057DA-CB40-4308-96FB-EF0100822BAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC8057DA-CB40-4308-96FB-EF0100822BAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC8057DA-CB40-4308-96FB-EF0100822BAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/KernelMemory.sln.DotSettings
+++ b/KernelMemory.sln.DotSettings
@@ -250,6 +250,7 @@ public void It$SOMENAME$()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mergeresults/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Milvus/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mirostat/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mixtral/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=msword/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=myfile/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mypipelinestep/@EntryIndexedValue">True</s:Boolean>

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ or platform, e.g. browser extensions and ChatGPT assistants.**
 
 Here's a few notable differences:
 
-| Feature          | Semantic Memory                                                                                              | Kernel Memory                                                                                           |
-|------------------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
-| Data formats     | Text only                                                                                                    | Web pages, PDF, Images, Word, PowerPoint, Excel, Markdown, Text, JSON, more being added                 |
-| Search           | Cosine similarity                                                                                            | Cosine similarity, Hybrid search with filters, AND/OR conditions                                        |
-| Language support | C#, Python, Java                                                                                             | Any language, command line tools, browser extensions, low-code/no-code apps, chatbots, assistants, etc. |
-| Storage engines  | Azure AI Search, Chroma, DuckDB, Kusto, Milvus, MongoDB, Pinecone, Postgres, Qdrant, Redis, SQLite, Weaviate | Azure AI Search, Elasticsearch, Postgres, Qdrant, Redis, SQL Server, In memory KNN, On disk KNN. In progress: Chroma |
+| Feature          | Semantic Memory                                                                                              | Kernel Memory                                                                                                                                                          |
+|------------------|--------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Data formats     | Text only                                                                                                    | Web pages, PDF, Images, Word, PowerPoint, Excel, Markdown, Text, JSON, more being added                                                                                |
+| Search           | Cosine similarity                                                                                            | Cosine similarity, Hybrid search with filters, AND/OR conditions                                                                                                       |
+| Language support | C#, Python, Java                                                                                             | Any language, command line tools, browser extensions, low-code/no-code apps, chatbots, assistants, etc.                                                                |
+| Storage engines  | Azure AI Search, Chroma, DuckDB, Kusto, Milvus, MongoDB, Pinecone, Postgres, Qdrant, Redis, SQLite, Weaviate | Azure AI Search, Elasticsearch, MongoDB Atlas, Postgres, Qdrant, Redis, SQL Server, In memory KNN, On disk KNN. In progress: Azure Cosmos DB for MongoDB vCore, Chroma |
 
 and **features available only in Kernel Memory**:
 
@@ -86,6 +86,7 @@ and **features available only in Kernel Memory**:
   [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/concepts/models),
   [OpenAI](https://platform.openai.com/docs/models),
   LLama - thanks to [llama.cpp](https://github.com/ggerganov/llama.cpp) and [LLamaSharp](https://github.com/SciSharp/LLamaSharp),
+  [LM Studio](https://lmstudio.ai/),
   [Azure Document Intelligence](https://azure.microsoft.com/products/ai-services/ai-document-intelligence)
 * 🧠 Vector storage:
   [Azure AI Search](https://azure.microsoft.com/products/ai-services/ai-search),
@@ -347,7 +348,9 @@ running the service locally with OpenAPI enabled.
 16. [Test project using KM package from nuget.org](examples/203-dotnet-using-core-nuget)
 17. [Integrating Memory with ASP.NET applications and controllers](examples/204-dotnet-ASP.NET-MVC-integration)
 18. [Sample code showing how to extract text from files](examples/205-dotnet-extract-text-from-docs)
-19. [Expanding chunks retrieving adjacent partitions](examples/206-dotnet-configuration-and-logging)
+19. [.NET configuration and logging](examples/206-dotnet-configuration-and-logging)
+20. [Expanding chunks retrieving adjacent partitions](examples/207-dotnet-expanding-chunks-on-retrieval)
+21. [Using local models via LM Studio](examples/208-dotnet-lmstudio)
 
 ## Tools
 
@@ -360,6 +363,7 @@ running the service locally with OpenAPI enabled.
 7. [Script to start MS SQL Server for development tasks](tools/run-mssql.sh)
 8. [Script to start Redis for development tasks](tools/run-redis.sh)
 9. [Script to start RabbitMQ for development tasks](tools/run-rabbitmq.sh)
+10. [Script to start MongoDB Atlas for development tasks](tools/run-mongodb-atlas.sh)
 
 ### .NET packages
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ title: Overview
 permalink: /
 layout: default
 ---
+
 # Kernel Memory
 
 [![License: MIT](https://img.shields.io/github/license/microsoft/kernel-memory)](https://github.com/microsoft/kernel-memory/blob/main/LICENSE)
@@ -52,12 +53,12 @@ or platform, e.g. browser extensions and ChatGPT assistants.**
 
 Here's a few notable differences:
 
-| Feature          | Semantic Memory                                                                                              | Kernel Memory                                                                                           |
-|------------------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
-| Data formats     | Text only                                                                                                    | Web pages, PDF, Images, Word, PowerPoint, Excel, Markdown, Text, JSON, more being added                 |
-| Search           | Cosine similarity                                                                                            | Cosine similarity, Hybrid search with filters, AND/OR conditions                                        |
-| Language support | C#, Python, Java                                                                                             | Any language, command line tools, browser extensions, low-code/no-code apps, chatbots, assistants, etc. |
-| Storage engines  | Azure AI Search, Chroma, DuckDB, Kusto, Milvus, MongoDB, Pinecone, Postgres, Qdrant, Redis, SQLite, Weaviate | Azure AI Search, Elasticsearch, Postgres, Qdrant, Redis, SQL Server, In memory KNN, On disk KNN. In progress: Chroma |
+| Feature          | Semantic Memory                                                                                              | Kernel Memory                                                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Data formats     | Text only                                                                                                    | Web pages, PDF, Images, Word, PowerPoint, Excel, Markdown, Text, JSON, more being added                                                                                |
+| Search           | Cosine similarity                                                                                            | Cosine similarity, Hybrid search with filters, AND/OR conditions                                                                                                       |
+| Language support | C#, Python, Java                                                                                             | Any language, command line tools, browser extensions, low-code/no-code apps, chatbots, assistants, etc.                                                                |
+| Storage engines  | Azure AI Search, Chroma, DuckDB, Kusto, Milvus, MongoDB, Pinecone, Postgres, Qdrant, Redis, SQLite, Weaviate | Azure AI Search, Elasticsearch, MongoDB Atlas, Postgres, Qdrant, Redis, SQL Server, In memory KNN, On disk KNN. In progress: Azure Cosmos DB for MongoDB vCore, Chroma |
 
 and **features available only in Kernel Memory**:
 

--- a/examples/003-dotnet-Serverless/appsettings.json
+++ b/examples/003-dotnet-Serverless/appsettings.json
@@ -46,6 +46,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -55,6 +58,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       },

--- a/examples/101-dotnet-custom-Prompts/appsettings.json
+++ b/examples/101-dotnet-custom-Prompts/appsettings.json
@@ -46,6 +46,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -55,6 +58,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       }

--- a/examples/103-dotnet-custom-EmbeddingGenerator/appsettings.json
+++ b/examples/103-dotnet-custom-EmbeddingGenerator/appsettings.json
@@ -34,6 +34,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -43,6 +46,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       }

--- a/examples/105-dotnet-serverless-llamasharp/appsettings.json
+++ b/examples/105-dotnet-serverless-llamasharp/appsettings.json
@@ -40,6 +40,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -49,9 +52,12 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
-      },
+      }
     }
   }
 }

--- a/examples/106-dotnet-retrieve-synthetics/appsettings.json
+++ b/examples/106-dotnet-retrieve-synthetics/appsettings.json
@@ -19,6 +19,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -28,6 +31,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       },

--- a/examples/206-dotnet-configuration-and-logging/appsettings.json
+++ b/examples/206-dotnet-configuration-and-logging/appsettings.json
@@ -19,6 +19,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -28,6 +31,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       }

--- a/examples/207-dotnet-expanding-chunks-on-retrieval/appsettings.json
+++ b/examples/207-dotnet-expanding-chunks-on-retrieval/appsettings.json
@@ -19,6 +19,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -28,6 +31,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       }

--- a/examples/208-dotnet-lmstudio/208-dotnet-lmstudio.csproj
+++ b/examples/208-dotnet-lmstudio/208-dotnet-lmstudio.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <AssemblyName/>
+        <RootNamespace/>
+        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
+        <NoWarn>$(NoWarn);CA1050;CA2000;CA1707;CA1303;CA2007;CA1724;CA1861;</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/examples/208-dotnet-lmstudio/Program.cs
+++ b/examples/208-dotnet-lmstudio/Program.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.KernelMemory;
+
+public static class Program
+{
+    // ReSharper disable once InconsistentNaming
+    public static async Task Main()
+    {
+        // Using OpenAI for embeddings
+        var openAIEmbeddingConfig = new OpenAIConfig
+        {
+            EmbeddingModel = "text-embedding-ada-002",
+            EmbeddingModelMaxTokenTotal = 8191,
+            APIKey = Env.Var("OPENAI_API_KEY")
+        };
+
+        // Using LM Studio for text generation
+        var lmStudioConfig = new OpenAIConfig
+        {
+            Endpoint = "http://localhost:1234/v1/",
+            TextModel = "local-model",
+            TextModelMaxTokenTotal = 4096,
+            APIKey = "lm-studio"
+        };
+
+        var memory = new KernelMemoryBuilder()
+            .WithOpenAITextEmbeddingGeneration(openAIEmbeddingConfig) // OpenAI
+            .WithOpenAITextGeneration(lmStudioConfig) // LM Studio
+            .Build();
+
+        // Import some text - This will use OpenAI embeddings
+        await memory.ImportTextAsync("Today is October 32nd, 2476");
+
+        // Generate an answer - This uses OpenAI for embeddings and finding relevant data, and LM Studio to generate an answer
+        var answer = await memory.AskAsync("What's the current date?");
+        Console.WriteLine(answer.Question);
+        Console.WriteLine(answer.Result);
+
+        /*
+
+        -- Output using Mixtral 8x 7B Q8_0:
+
+        What's the current date?
+        The current date is October 32nd, 2476.
+
+
+        -- Server log:
+
+        [2024-03-21 19:30:22.201] [INFO] [LM STUDIO SERVER] Processing queued request...
+        [2024-03-21 19:30:22.202] [INFO] Received POST request to /v1/chat/completions with body: {
+            "messages": [
+                {
+                    "content": "Facts:\n==== [File:content.txt;Relevance:82.6%]:\nToday is October 32nd, 2476\n======\nGiven only the facts above, provide a comprehensive/detailed answer.\nYou don't know where the knowledge comes from, just answer.\nIf you don't have sufficient information, reply with 'INFO NOT FOUND'.\nQuestion: What's the current date?\nAnswer: ",
+                    "role": "system"
+                }
+            ],
+            "max_tokens": 300,
+            "temperature": 0,
+            "top_p": 0,
+            "presence_penalty": 0,
+            "frequency_penalty": 0,
+            "stream": true,
+            "model": "local-model"
+        }
+        [2024-03-21 19:30:22.203] [INFO] [LM STUDIO SERVER] Context Overflow Policy is: Rolling Window
+        [2024-03-21 19:30:22.204] [INFO] [LM STUDIO SERVER] Streaming response...
+        [2024-03-21 19:30:23.023] [INFO] [LM STUDIO SERVER] First token generated. Continuing to stream response..
+        [2024-03-21 19:30:25.907] [INFO] Finished streaming response
+
+        */
+    }
+}

--- a/extensions/AzureAISearch/AzureAISearch.FunctionalTests/appsettings.json
+++ b/extensions/AzureAISearch/AzureAISearch.FunctionalTests/appsettings.json
@@ -18,6 +18,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -27,6 +30,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       }

--- a/extensions/AzureAISearch/AzureAISearch.TestApplication/appsettings.json
+++ b/extensions/AzureAISearch/AzureAISearch.TestApplication/appsettings.json
@@ -48,6 +48,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -57,6 +60,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 3
       }

--- a/extensions/Elasticsearch/Elasticsearch.FunctionalTests/appsettings.json
+++ b/extensions/Elasticsearch/Elasticsearch.FunctionalTests/appsettings.json
@@ -51,6 +51,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -60,6 +63,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       }

--- a/extensions/LlamaSharp/LlamaSharp.FunctionalTests/appsettings.json
+++ b/extensions/LlamaSharp/LlamaSharp.FunctionalTests/appsettings.json
@@ -35,6 +35,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -44,6 +47,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       },

--- a/extensions/MongoDbAtlas/MongoDbAtlas.FunctionalTests/appsettings.json
+++ b/extensions/MongoDbAtlas/MongoDbAtlas.FunctionalTests/appsettings.json
@@ -42,6 +42,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -51,6 +54,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       }

--- a/extensions/OpenAI/ChangeEndpointPolicy.cs
+++ b/extensions/OpenAI/ChangeEndpointPolicy.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Microsoft.KernelMemory.AI.OpenAI;
+
+internal class ChangeEndpointPolicy : HttpPipelinePolicy
+{
+    internal const string DefaultEndpoint = "https://api.openai.com/v1";
+    private readonly string _endpoint;
+
+    public ChangeEndpointPolicy(string endpoint)
+    {
+        this._endpoint = endpoint.TrimEnd('/');
+    }
+
+    public override ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+    {
+        var uri = message.Request.Uri.ToString().Replace(DefaultEndpoint, this._endpoint, StringComparison.OrdinalIgnoreCase);
+        message.Request.Uri.Reset(new Uri(uri));
+        return ProcessNextAsync(message, pipeline);
+    }
+
+    public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+    {
+        ProcessNext(message, pipeline);
+    }
+}

--- a/extensions/OpenAI/OpenAI.csproj
+++ b/extensions/OpenAI/OpenAI.csproj
@@ -5,7 +5,7 @@
         <RollForward>LatestMajor</RollForward>
         <AssemblyName>Microsoft.KernelMemory.AI.OpenAI</AssemblyName>
         <RootNamespace>Microsoft.KernelMemory.AI.OpenAI</RootNamespace>
-        <NoWarn>$(NoWarn);CA1724;CS1591;CA1308;SKEXP0010;SKEXP0011;</NoWarn>
+        <NoWarn>$(NoWarn);CA1724;CS1591;CA1308;SKEXP0010;SKEXP0011;SKEXP0001;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/extensions/OpenAI/OpenAIClientBuilder.cs
+++ b/extensions/OpenAI/OpenAIClientBuilder.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Net.Http;
+using Azure.AI.OpenAI;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Microsoft.KernelMemory.Diagnostics;
+
+namespace Microsoft.KernelMemory.AI.OpenAI;
+
+internal static class OpenAIClientBuilder
+{
+    internal static OpenAIClient BuildOpenAIClient(
+        OpenAIConfig config,
+        HttpClient? httpClient = null)
+    {
+        OpenAIClientOptions options = new()
+        {
+            RetryPolicy = new RetryPolicy(maxRetries: Math.Max(0, config.MaxRetries), new SequentialDelayStrategy()),
+            Diagnostics =
+            {
+                IsTelemetryEnabled = Telemetry.IsTelemetryEnabled,
+                ApplicationId = Telemetry.HttpUserAgent,
+            }
+        };
+
+        // Point the client to a non-OpenAI endpoint, e.g. LM Studio web service
+        if (!string.IsNullOrWhiteSpace(config.Endpoint)
+            && !config.Endpoint.StartsWith(ChangeEndpointPolicy.DefaultEndpoint, StringComparison.OrdinalIgnoreCase))
+        {
+            options.AddPolicy(new ChangeEndpointPolicy(config.Endpoint), HttpPipelinePosition.PerRetry);
+        }
+
+        if (httpClient is not null)
+        {
+            options.Transport = new HttpClientTransport(httpClient);
+        }
+
+        return new OpenAIClient(config.APIKey, options);
+    }
+}

--- a/extensions/OpenAI/OpenAIConfig.cs
+++ b/extensions/OpenAI/OpenAIConfig.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Text.Json.Serialization;
 
 #pragma warning disable IDE0130 // reduce number of "using" statements
 // ReSharper disable once CheckNamespace - reduce number of "using" statements
@@ -11,6 +12,14 @@ namespace Microsoft.KernelMemory;
 /// </summary>
 public class OpenAIConfig
 {
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum TextGenerationTypes
+    {
+        Auto = 0,
+        TextCompletion,
+        Chat,
+    }
+
     /// <summary>
     /// Model used for text generation. Chat models can be used too.
     /// </summary>
@@ -22,6 +31,13 @@ public class OpenAIConfig
     public int TextModelMaxTokenTotal { get; set; } = 8192;
 
     /// <summary>
+    /// The type of OpenAI completion to use, either Text (legacy) or Chat.
+    /// When using Auto, the client uses OpenAI model names to detect the correct protocol.
+    /// Most OpenAI models use Chat. If you're using a non-OpenAI model, you might want to set this manually.
+    /// </summary>
+    public TextGenerationTypes TextGenerationType { get; set; } = TextGenerationTypes.Auto;
+
+    /// <summary>
     /// Model used to embedding generation/
     /// </summary>
     public string EmbeddingModel { get; set; } = string.Empty;
@@ -31,6 +47,12 @@ public class OpenAIConfig
     /// Default to OpenAI ADA2 settings.
     /// </summary>
     public int EmbeddingModelMaxTokenTotal { get; set; } = 8191;
+
+    /// <summary>
+    /// OpenAI HTTP endpoint. You may need to override this to work with
+    /// OpenAI compatible services like LM Studio.
+    /// </summary>
+    public string Endpoint { get; set; } = "https://api.openai.com/v1";
 
     /// <summary>
     /// OpenAI API key.

--- a/extensions/OpenAI/OpenAITextGenerator.cs
+++ b/extensions/OpenAI/OpenAITextGenerator.cs
@@ -7,104 +7,121 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.OpenAI;
-using Azure.Core.Pipeline;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.Configuration;
 using Microsoft.KernelMemory.Diagnostics;
 
 namespace Microsoft.KernelMemory.AI.OpenAI;
 
+/// <summary>
+/// Text generator, supporting OpenAI text and chat completion. The class can be used with any service
+/// supporting OpenAI HTTP schema, such as LM Studio HTTP API.
+/// </summary>
 public class OpenAITextGenerator : ITextGenerator
 {
-    private readonly ILogger<OpenAITextGenerator> _log;
-    private readonly ITextTokenizer _textTokenizer;
     private readonly OpenAIClient _client;
-    private readonly bool _isTextModel;
-    private readonly string _model;
+    private readonly ILogger<OpenAITextGenerator> _log;
+    private ITextTokenizer? _textTokenizer;
+    private bool _useTextCompletionProtocol;
+    private string? _model;
+
+    /// <summary>
+    /// Legacy OpenAI models using the old text generation protocol.
+    /// </summary>
+    private static readonly List<string> s_textModels = new()
+    {
+        "text-ada-001",
+        "text-babbage-001",
+        "text-curie-001",
+        "text-davinci-001",
+        "text-davinci-002",
+        "text-davinci-003",
+        "gpt-3.5-turbo-instruct"
+    };
 
     /// <inheritdoc/>
     public int MaxTokenTotal { get; }
 
+    /// <summary>
+    /// Create a new instance, using the given OpenAI pre-configured client
+    /// </summary>
+    /// <param name="config">Model configuration</param>
+    /// <param name="openAIClient">Custom OpenAI client, already configured</param>
+    /// <param name="textTokenizer">Text tokenizer, possibly matching the model used</param>
+    /// <param name="loggerFactory">App logger factory</param>
+    public OpenAITextGenerator(
+        OpenAIConfig config,
+        OpenAIClient openAIClient,
+        ITextTokenizer? textTokenizer = null,
+        ILoggerFactory? loggerFactory = null)
+    {
+        this._log = loggerFactory?.CreateLogger<OpenAITextGenerator>() ?? DefaultLogger<OpenAITextGenerator>.Instance;
+
+        this.MaxTokenTotal = config.TextModelMaxTokenTotal;
+        this.SetCompletionType(config);
+        this.SetTokenizer(textTokenizer);
+        this._client = openAIClient;
+    }
+
+    /// <summary>
+    /// Create a new instance.
+    /// </summary>
+    /// <param name="config">Client and model configuration</param>
+    /// <param name="textTokenizer">Text tokenizer, possibly matching the model used</param>
+    /// <param name="loggerFactory">App logger factory</param>
+    /// <param name="httpClient">Optional HTTP client with custom settings</param>
     public OpenAITextGenerator(
         OpenAIConfig config,
         ITextTokenizer? textTokenizer = null,
         ILoggerFactory? loggerFactory = null,
         HttpClient? httpClient = null)
-        : this(config, textTokenizer, loggerFactory?.CreateLogger<OpenAITextGenerator>(), httpClient)
     {
+        this._log = loggerFactory?.CreateLogger<OpenAITextGenerator>() ?? DefaultLogger<OpenAITextGenerator>.Instance;
+
+        this.MaxTokenTotal = config.TextModelMaxTokenTotal;
+        this.SetCompletionType(config);
+        this.SetTokenizer(textTokenizer);
+        this._client = OpenAIClientBuilder.BuildOpenAIClient(config, httpClient);
     }
 
+    /// <summary>
+    /// Create a new instance.
+    /// </summary>
+    /// <param name="config">Client and model configuration</param>
+    /// <param name="textTokenizer">Text tokenizer, possibly matching the model used</param>
+    /// <param name="log">Application logger</param>
+    /// <param name="httpClient">Optional HTTP client with custom settings</param>
     public OpenAITextGenerator(
         OpenAIConfig config,
         ITextTokenizer? textTokenizer = null,
         ILogger<OpenAITextGenerator>? log = null,
         HttpClient? httpClient = null)
     {
-        var textModels = new List<string>
-        {
-            "text-ada-001",
-            "text-babbage-001",
-            "text-curie-001",
-            "text-davinci-001",
-            "text-davinci-002",
-            "text-davinci-003",
-            "gpt-3.5-turbo-instruct"
-        };
-
         this._log = log ?? DefaultLogger<OpenAITextGenerator>.Instance;
 
-        if (textTokenizer == null)
-        {
-            this._log.LogWarning(
-                "Tokenizer not specified, will use {0}. The token count might be incorrect, causing unexpected errors",
-                nameof(DefaultGPTTokenizer));
-            textTokenizer = new DefaultGPTTokenizer();
-        }
-
-        this._textTokenizer = textTokenizer;
-
-        if (string.IsNullOrEmpty(config.TextModel))
-        {
-            throw new ConfigurationException("The OpenAI model name is empty");
-        }
-
-        this._isTextModel = (textModels.Contains(config.TextModel.ToLowerInvariant()));
-        this._model = config.TextModel;
         this.MaxTokenTotal = config.TextModelMaxTokenTotal;
-
-        OpenAIClientOptions options = new()
-        {
-            RetryPolicy = new RetryPolicy(maxRetries: Math.Max(0, config.MaxRetries), new SequentialDelayStrategy()),
-            Diagnostics =
-            {
-                IsTelemetryEnabled = Telemetry.IsTelemetryEnabled,
-                ApplicationId = Telemetry.HttpUserAgent,
-            }
-        };
-
-        if (httpClient is not null)
-        {
-            options.Transport = new HttpClientTransport(httpClient);
-        }
-
-        this._client = new OpenAIClient(config.APIKey, options);
+        this.SetCompletionType(config);
+        this.SetTokenizer(textTokenizer);
+        this._client = OpenAIClientBuilder.BuildOpenAIClient(config, httpClient);
     }
 
     /// <inheritdoc/>
     public int CountTokens(string text)
     {
-        return this._textTokenizer.CountTokens(text);
+        return this._textTokenizer!.CountTokens(text);
     }
 
+    /// <inheritdoc/>
     public async IAsyncEnumerable<string> GenerateTextAsync(
         string prompt,
         TextGenerationOptions options,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        if (this._isTextModel)
+        if (this._useTextCompletionProtocol)
         {
             var openaiOptions = new CompletionsOptions
             {
+                Prompts = { prompt },
                 DeploymentName = this._model,
                 MaxTokens = options.MaxTokens,
                 Temperature = (float)options.Temperature,
@@ -164,5 +181,43 @@ public class OpenAITextGenerator : ITextGenerator
                 yield return update.ContentUpdate;
             }
         }
+    }
+
+    private void SetCompletionType(OpenAIConfig config)
+    {
+        if (string.IsNullOrEmpty(config.TextModel))
+        {
+            throw new ConfigurationException("The OpenAI model name is empty");
+        }
+
+        this._model = config.TextModel;
+
+        switch (config.TextGenerationType)
+        {
+            case OpenAIConfig.TextGenerationTypes.Auto:
+                this._useTextCompletionProtocol = (s_textModels.Contains(config.TextModel.ToLowerInvariant()));
+                break;
+            case OpenAIConfig.TextGenerationTypes.TextCompletion:
+                this._useTextCompletionProtocol = true;
+                break;
+            case OpenAIConfig.TextGenerationTypes.Chat:
+                this._useTextCompletionProtocol = false;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException($"Unsupported text completion type '{config.TextGenerationType:G}'");
+        }
+    }
+
+    private void SetTokenizer(ITextTokenizer? textTokenizer = null)
+    {
+        if (textTokenizer == null)
+        {
+            this._log.LogWarning(
+                "Tokenizer not specified, will use {0}. The token count might be incorrect, causing unexpected errors",
+                nameof(DefaultGPTTokenizer));
+            textTokenizer = new DefaultGPTTokenizer();
+        }
+
+        this._textTokenizer = textTokenizer;
     }
 }

--- a/extensions/Postgres/Postgres.FunctionalTests/appsettings.json
+++ b/extensions/Postgres/Postgres.FunctionalTests/appsettings.json
@@ -45,6 +45,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -54,6 +57,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       }

--- a/extensions/Postgres/Postgres.TestApplication/appsettings.json
+++ b/extensions/Postgres/Postgres.TestApplication/appsettings.json
@@ -45,6 +45,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -54,6 +57,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 3
       }

--- a/extensions/Qdrant/Qdrant.FunctionalTests/appsettings.json
+++ b/extensions/Qdrant/Qdrant.FunctionalTests/appsettings.json
@@ -14,6 +14,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -23,6 +26,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       }

--- a/extensions/Redis/Redis.FunctionalTests/appsettings.json
+++ b/extensions/Redis/Redis.FunctionalTests/appsettings.json
@@ -53,6 +53,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -62,6 +65,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       }

--- a/extensions/SQLServer/SQLServer.FunctionalTests/appsettings.json
+++ b/extensions/SQLServer/SQLServer.FunctionalTests/appsettings.json
@@ -46,6 +46,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -55,6 +58,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       }

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -336,6 +336,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -345,6 +348,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       },

--- a/service/tests/Core.FunctionalTests/appsettings.json
+++ b/service/tests/Core.FunctionalTests/appsettings.json
@@ -50,6 +50,9 @@
         "TextModel": "gpt-3.5-turbo-16k",
         // The max number of tokens supported by the text model.
         "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
         // Name of the model used to generate text embeddings
         "EmbeddingModel": "text-embedding-ada-002",
         // The max number of tokens supported by the embedding model
@@ -59,6 +62,9 @@
         "APIKey": "",
         // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
         "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10
       },


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

In multiple scenarios one might want to send OpenAI-like requests to a custom endpoint, for instance when using a proxy, when using LM Studio HTTP service.

## High level description (Approach, Design)

Add new OpenAI config options:
* `Endpoint`: can be empty to use default, or a custom value like `http://localhost:1234/v1/` for LM Studio, or anything else
* `TextGenerationType`: allows to choose the text generation protocol, either text or chat. The valu "Auto" checks the model name against a list of OpenAI legacy models that would generate text.
* Add example 208 showing how to use LM Studio
* Add more ctor options for `OpenAITextEmbeddingGenerator` and `OpenAITextGenerator` to allow further scenarios where one might want to control the OpenAIClient used (see https://github.com/microsoft/kernel-memory/issues/320 for example)