### PR TITLE
Check index once per unique index name during save embeddings.

### DIFF
--- a/examples/003-dotnet-Serverless/003-dotnet-Serverless.csproj
+++ b/examples/003-dotnet-Serverless/003-dotnet-Serverless.csproj
@@ -11,6 +11,9 @@
     <ItemGroup>
         <ProjectReference Include="..\..\service\Core\Core.csproj" />
         <ProjectReference Include="..\..\extensions\LlamaSharp\LlamaSharp\LlamaSharp.csproj" />
+
+        <PackageReference Include="Microsoft.KernelMemory.MemoryDb.Postgres" Version="0.38.240423.1" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
+        <ProjectReference Include="..\..\extensions\Postgres\Postgres\Postgres.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/003-dotnet-Serverless/Program.cs
+++ b/examples/003-dotnet-Serverless/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.KernelMemory;
 using Microsoft.KernelMemory.AI.OpenAI;
 using Microsoft.KernelMemory.ContentStorage.DevTools;
 using Microsoft.KernelMemory.MemoryStorage.DevTools;
+using Microsoft.KernelMemory.Postgres;
 
 /* Use MemoryServerlessClient to run the default import pipeline
  * in the same process, without distributed queues.
@@ -36,6 +37,7 @@ public static class Program
         var searchClientConfig = new SearchClientConfig();
         var azDocIntelConfig = new AzureAIDocIntelConfig();
         var azureAISearchConfig = new AzureAISearchConfig();
+        var postgresConfig = new PostgresConfig();
 
         new ConfigurationBuilder()
             .AddJsonFile("appsettings.json")
@@ -47,6 +49,7 @@ public static class Program
             .BindSection("KernelMemory:Services:LlamaSharp", llamaConfig)
             .BindSection("KernelMemory:Services:AzureAIDocIntel", azDocIntelConfig)
             .BindSection("KernelMemory:Services:AzureAISearch", azureAISearchConfig)
+            .BindSection("KernelMemory:Services:Postgres", postgresConfig)
             .BindSection("KernelMemory:Retrieval:SearchClient", searchClientConfig);
 
         s_memory = new KernelMemoryBuilder()
@@ -60,6 +63,7 @@ public static class Program
             // .WithAzureBlobsStorage(new AzureBlobsConfig {...})           // Store files in Azure Blobs
             // .WithSimpleVectorDb(SimpleVectorDbConfig.Persistent)         // Store memories on disk
             // .WithAzureAISearchMemoryDb(azureAISearchConfig)              // Store memories in Azure AI Search
+            // .WithPostgresMemoryDb(postgresConfig)                        // Store memories in Postgres
             // .WithQdrantMemoryDb("http://127.0.0.1:6333")                 // Store memories in Qdrant
             .Build<MemoryServerless>();
 

--- a/extensions/AzureAISearch/AzureAISearch/AzureAISearchMemory.cs
+++ b/extensions/AzureAISearch/AzureAISearch/AzureAISearchMemory.cs
@@ -136,10 +136,7 @@ public class AzureAISearchMemory : IMemoryDb
                 new IndexDocumentsOptions { ThrowOnAnyError = true },
                 cancellationToken: cancellationToken).ConfigureAwait(false);
         }
-        catch (RequestFailedException e)
-            when (e.Status == 404
-                  && e.Message.Contains("index", StringComparison.OrdinalIgnoreCase)
-                  && e.Message.Contains("not found", StringComparison.OrdinalIgnoreCase))
+        catch (RequestFailedException e) when (IsIndexNotFoundException(e))
         {
             throw new IndexNotFound(e.Message, e);
         }
@@ -408,6 +405,13 @@ public class AzureAISearchMemory : IMemoryDb
         }
 
         return client;
+    }
+
+    private static bool IsIndexNotFoundException(RequestFailedException e)
+    {
+        return e.Status == 404
+               && e.Message.Contains("index", StringComparison.OrdinalIgnoreCase)
+               && e.Message.Contains("not found", StringComparison.OrdinalIgnoreCase);
     }
 
     private static void ValidateSchema(MemoryDbSchema schema)

--- a/service/Abstractions/MemoryStorage/IMemoryDb.cs
+++ b/service/Abstractions/MemoryStorage/IMemoryDb.cs
@@ -45,6 +45,7 @@ public interface IMemoryDb
     /// <param name="record">Vector + payload to save</param>
     /// <param name="cancellationToken">Task cancellation token</param>
     /// <returns>Record ID</returns>
+    /// <exception cref="IndexNotFound">Error returned if the index where to write doesn't exist</exception>
     Task<string> UpsertAsync(
         string index,
         MemoryRecord record,

--- a/service/Core/Handlers/SaveRecordsHandler.cs
+++ b/service/Core/Handlers/SaveRecordsHandler.cs
@@ -143,7 +143,9 @@ public class SaveRecordsHandler : IPipelineStepHandler
 
             foreach (IMemoryDb client in this._memoryDbs)
             {
-                if (!createdIndexes.Contains(pipeline.Index))
+                var key = GetPipelineKeyForSave(client, pipeline.Index);
+
+                if (!createdIndexes.Contains(key))
                 {
                     this._log.LogTrace("Creating index '{0}'", pipeline.Index);
                     await client.CreateIndexAsync(pipeline.Index, record.Vector.Length, cancellationToken).ConfigureAwait(false);
@@ -212,7 +214,9 @@ public class SaveRecordsHandler : IPipelineStepHandler
 
                     foreach (IMemoryDb client in this._memoryDbs)
                     {
-                        if (!createdIndexes.Contains(pipeline.Index))
+                        var key = GetPipelineKeyForSave(client, pipeline.Index);
+
+                        if (!createdIndexes.Contains(key))
                         {
                             this._log.LogTrace("Creating index '{0}'", pipeline.Index);
                             await client.CreateIndexAsync(pipeline.Index, record.Vector.Length, cancellationToken).ConfigureAwait(false);
@@ -281,6 +285,11 @@ public class SaveRecordsHandler : IPipelineStepHandler
         return pipeline.Files.SelectMany(f1 => f1.GeneratedFiles.Where(
                 f2 => f2.Value.ArtifactType == DataPipeline.ArtifactTypes.TextPartition || f2.Value.ArtifactType == DataPipeline.ArtifactTypes.SyntheticData)
             .Select(x => new FileDetailsWithRecordId(pipeline, x.Value)));
+    }
+
+    private static string GetPipelineKeyForSave(IMemoryDb client, string index)
+    {
+        return $"{client.GetType().Name}::{index}";
     }
 
     private async Task<string> GetSourceUrlAsync(

--- a/service/Core/Handlers/SaveRecordsHandler.cs
+++ b/service/Core/Handlers/SaveRecordsHandler.cs
@@ -149,7 +149,7 @@ public class SaveRecordsHandler : IPipelineStepHandler
                 {
                     this._log.LogTrace("Creating index '{0}'", pipeline.Index);
                     await client.CreateIndexAsync(pipeline.Index, record.Vector.Length, cancellationToken).ConfigureAwait(false);
-                    createdIndexes.Add(pipeline.Index);
+                    createdIndexes.Add(key);
                 }
 
                 this._log.LogTrace("Saving record {0} in index '{1}'", record.Id, pipeline.Index);
@@ -220,7 +220,7 @@ public class SaveRecordsHandler : IPipelineStepHandler
                         {
                             this._log.LogTrace("Creating index '{0}'", pipeline.Index);
                             await client.CreateIndexAsync(pipeline.Index, record.Vector.Length, cancellationToken).ConfigureAwait(false);
-                            createdIndexes.Add(pipeline.Index);
+                            createdIndexes.Add(key);
                         }
 
                         this._log.LogTrace("Saving record {0} in index '{1}'", record.Id, pipeline.Index);

--- a/service/Core/Handlers/SaveRecordsHandler.cs
+++ b/service/Core/Handlers/SaveRecordsHandler.cs
@@ -101,6 +101,8 @@ public class SaveRecordsHandler : IPipelineStepHandler
         DataPipeline pipeline, CancellationToken cancellationToken = default)
     {
         var embeddingsFound = false;
+
+        // TODO: replace with ConditionalWeakTable indexing on this._memoryDbs
         var createdIndexes = new HashSet<string>();
 
         // For each embedding file => For each Memory DB => Upsert record
@@ -178,6 +180,8 @@ public class SaveRecordsHandler : IPipelineStepHandler
         DataPipeline pipeline, CancellationToken cancellationToken = default)
     {
         var partitionsFound = false;
+
+        // TODO: replace with ConditionalWeakTable indexing on this._memoryDbs
         var createdIndexes = new HashSet<string>();
 
         // Create records only for partitions (text chunks) and synthetic data

--- a/service/Core/MemoryStorage/DevTools/SimpleVectorDb.cs
+++ b/service/Core/MemoryStorage/DevTools/SimpleVectorDb.cs
@@ -84,6 +84,7 @@ public class SimpleVectorDb : IMemoryDb
     /// <inheritdoc />
     public async Task<string> UpsertAsync(string index, MemoryRecord record, CancellationToken cancellationToken = default)
     {
+        // Note: if the index doesn't exist, it's automatically created (the index is just a folder)
         index = NormalizeIndexName(index);
         await this._fileSystem.WriteFileAsync(index, "", EncodeId(record.Id), JsonSerializer.Serialize(record), cancellationToken).ConfigureAwait(false);
         return record.Id;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

I had the same problem as the submitter of this issue: https://github.com/microsoft/kernel-memory/issues/289. For every embedding during the save process, a call is made to list indexes. Using Azure AI Search, I was getting rate limit errors, i.e. `Azure.RequestFailedException with the message "You are sending too many requests. Please try again later."`

## High level description (Approach, Design)

Made an adjustment to simply cache indexes that were already checked/created during the save embeddings process. This skips the unnecessary call to ListIndexes for every single embedding.