### PR TITLE
Cache embeddings by content hash

### DIFF
--- a/examples/002-dotnet-SemanticKernel-plugin/Program.cs
+++ b/examples/002-dotnet-SemanticKernel-plugin/Program.cs
@@ -170,7 +170,7 @@ public static class Program
         return null;
 
         // return new KernelMemoryBuilder()
-        //     .WithAzureOpenAIEmbeddingGeneration(new AzureOpenAIConfig
+        //     .WithAzureOpenAITextEmbeddingGeneration(new AzureOpenAIConfig
         //     {
         //         APIType = AzureOpenAIConfig.APITypes.EmbeddingGeneration,
         //         Endpoint = EnvVar("AOAI_ENDPOINT"),

--- a/examples/203-dotnet-using-core-nuget/Program.cs
+++ b/examples/203-dotnet-using-core-nuget/Program.cs
@@ -8,7 +8,7 @@ var memory = new KernelMemoryBuilder()
     // .WithAzureAISearch(Env.Var("AZSEARCH_ENDPOINT"), Env.Var("AZSEARCH_API_KEY"))            => use Azure AI Search
     // .WithQdrant("http://127.0.0.1:6333")                                                     => use Qdrant docker
     // .WithAzureAIDocIntel(Env.Var("AZDOCINTEL_ENDPOINT"), Env.Var("AZDOCINTEL_API_KEY"))      => use Azure AI Document Intelligence OCR
-    // .WithAzureOpenAITextEmbeddingGeneration(new AzureOpenAIConfig                                => use Azure OpenAI for embedding generation
+    // .WithAzureOpenAITextEmbeddingGeneration(new AzureOpenAIConfig                            => use Azure OpenAI for embedding generation
     // {
     //     APIType = AzureOpenAIConfig.APITypes.EmbeddingGeneration,
     //     Auth = AzureOpenAIConfig.AuthTypes.AzureIdentity,

--- a/examples/203-dotnet-using-core-nuget/Program.cs
+++ b/examples/203-dotnet-using-core-nuget/Program.cs
@@ -8,7 +8,7 @@ var memory = new KernelMemoryBuilder()
     // .WithAzureAISearch(Env.Var("AZSEARCH_ENDPOINT"), Env.Var("AZSEARCH_API_KEY"))            => use Azure AI Search
     // .WithQdrant("http://127.0.0.1:6333")                                                     => use Qdrant docker
     // .WithAzureAIDocIntel(Env.Var("AZDOCINTEL_ENDPOINT"), Env.Var("AZDOCINTEL_API_KEY"))      => use Azure AI Document Intelligence OCR
-    // .WithAzureOpenAIEmbeddingGeneration(new AzureOpenAIConfig                                => use Azure OpenAI for embedding generation
+    // .WithAzureOpenAITextEmbeddingGeneration(new AzureOpenAIConfig                                => use Azure OpenAI for embedding generation
     // {
     //     APIType = AzureOpenAIConfig.APITypes.EmbeddingGeneration,
     //     Auth = AzureOpenAIConfig.AuthTypes.AzureIdentity,

--- a/service/Core/Handlers/GenerateEmbeddingsHandler.cs
+++ b/service/Core/Handlers/GenerateEmbeddingsHandler.cs
@@ -105,7 +105,6 @@ public class GenerateEmbeddingsHandler : IPipelineStepHandler
 
                 partitionsFound = true;
 
-                // TODO: cost/perf: if the partition SHA256 is the same and the embedding exists, avoid generating it again
                 switch (partitionFile.MimeType)
                 {
                     case MimeTypes.PlainText:


### PR DESCRIPTION
Caching the embeddings by content hash of the partitioned file content to avoid/reduce potential cost of invoking the embedding API.

<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
It is very costly (both time and money wise) to call and invoke the embedding API. So we want to reduce the chance of hitting it by caching the embeddings as much as possible.

## High level description (Approach, Design)
Cache the embeddings of a given partitioned content by its content hash to determine if content embedding can be re-used.

