### PR TITLE
Add extension methods to easily add Kernel Memory to Service Collection

### DIFF
--- a/service/Core/ServiceCollectionExtensions.cs
+++ b/service/Core/ServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.KernelMemory;
+
+/// <summary>
+/// Service Collection extensions for Kernel Memory.
+/// </summary>
+public static partial class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds Kernel Memory services to the specified <see cref="IServiceCollection"/> and registers a singleton <see cref="IKernelMemory"/> service.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+    /// <param name="setupAction">An optional action to configure the <see cref="IKernelMemory">Kernel Memory builder</see>.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static IServiceCollection AddKernelMemory(this IServiceCollection services, Action<IKernelMemoryBuilder>? setupAction = null)
+    {
+        var kernelMemoryBuilder = new KernelMemoryBuilder(services);
+        setupAction?.Invoke(kernelMemoryBuilder);
+
+        var kernelMemory = kernelMemoryBuilder.Build();
+        services.AddSingleton<IKernelMemory>(kernelMemory);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds Kernel Memory services to the specified <see cref="IServiceCollection"/> and registers both a singleton <see cref="IKernelMemory"/> service and the implementation of <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+    /// <param name="setupAction">An optional action to configure the <see cref="IKernelMemory">Kernel Memory builder</see>.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static IServiceCollection AddKernelMemory<T>(this IServiceCollection services, Action<IKernelMemoryBuilder>? setupAction = null)
+        where T : class, IKernelMemory
+    {
+        var kernelMemoryBuilder = new KernelMemoryBuilder(services);
+        setupAction?.Invoke(kernelMemoryBuilder);
+
+        var kernelMemory = kernelMemoryBuilder.Build<T>();
+
+        services.AddSingleton(kernelMemory);
+        services.AddSingleton<IKernelMemory>(provider => provider.GetRequiredService<T>());
+
+        return services;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
See https://github.com/microsoft/kernel-memory/issues/393

## High level description (Approach, Design)
This PR introduces two extensions method that allow to add Kernel Memory to an existing Service Collection (in a typical DI context) and automatically registers it as a singleton `IKernelMemory` service.
