### PR TITLE
Changes to new decoders interfaces/types

### DIFF
--- a/service/Abstractions/DataFormats/FileContent.cs
+++ b/service/Abstractions/DataFormats/FileContent.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using Microsoft.KernelMemory.Pipeline;
 
 namespace Microsoft.KernelMemory.DataFormats;
 
@@ -14,5 +13,10 @@ public class FileContent
 
     [JsonPropertyOrder(1)]
     [JsonPropertyName("mimeType")]
-    public string MimeType { get; set; } = MimeTypes.PlainText;
+    public string MimeType { get; set; }
+
+    public FileContent(string mimeType)
+    {
+        this.MimeType = mimeType;
+    }
 }

--- a/service/Abstractions/DataFormats/IContentDecoder.cs
+++ b/service/Abstractions/DataFormats/IContentDecoder.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,10 +13,11 @@ namespace Microsoft.KernelMemory.DataFormats;
 public interface IContentDecoder
 {
     /// <summary>
-    /// List of types supported by the extractor.
-    /// A decoder is called only to process files of supported types.
+    /// Returns true if the decoder supports the given MIME type
     /// </summary>
-    IEnumerable<string> SupportedMimeTypes { get; }
+    /// <param name="mimeType">MIME type string (e.g. content type without encoding details)</param>
+    /// <returns>Whether the MIME type is supported</returns>
+    bool SupportsMimeType(string mimeType);
 
     /// <summary>
     /// Extract content from the given file.


### PR DESCRIPTION
Decouple FileContent from MIME constants. Allow decoders to use logic to decide if a type is supported.