### PR TITLE
Add PartitionNumber e SectionNumber to citations

### DIFF
--- a/service/Core/Search/SearchClient.cs
+++ b/service/Core/Search/SearchClient.cs
@@ -279,6 +279,8 @@ public class SearchClient : ISearchClient
             {
                 Text = partitionText,
                 Relevance = (float)relevance,
+                PartitionNumber = memory.GetPartitionNumber(this._log),
+                SectionNumber = memory.GetSectionNumber(),
                 LastUpdate = memory.GetLastUpdate(),
                 Tags = memory.Tags,
             });


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
`PartitionNumber` and `SectionNumber` properties of `Citations` object are set only in the [SearchAsync](https://github.com/microsoft/kernel-memory/blob/main/service/Core/Search/SearchClient.cs#L161-L162) method of [SearchClient](https://github.com/microsoft/kernel-memory/blob/main/service/Core/Search/SearchClient.cs), but not in the [AskAsync](https://github.com/microsoft/kernel-memory/blob/main/service/Core/Search/SearchClient.cs#L177) method. This PR assigns the missing properties.
