### PR TITLE
Export/Download document support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,7 +43,7 @@
   </ItemGroup>
   <!-- Kernel Memory -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.KernelMemory.Abstractions" Version="0.39.240426.1" />
+    <PackageVersion Include="Microsoft.KernelMemory.Abstractions" Version="0.40.240430.1" />
     <PackageVersion Include="Microsoft.KernelMemory.Core" Version="0.39.240427.1" />
     <PackageVersion Include="KernelMemory.MemoryStorage.SqlServer" Version="1.6.3" />
     <PackageVersion Include="FreeMindLabs.KernelMemory.Elasticsearch" Version="0.9.5" />

--- a/extensions/AzureAISearch/AzureAISearch.FunctionalTests/DefaultTests.cs
+++ b/extensions/AzureAISearch/AzureAISearch.FunctionalTests/DefaultTests.cs
@@ -101,4 +101,11 @@ public class DefaultTests : BaseFunctionalTestCase
     {
         await DocumentUploadTest.ItSupportsTags(this._memory, this.Log, true);
     }
+
+    [Fact]
+    [Trait("Category", "AzAISearch")]
+    public async Task ItDownloadsPDFDocs()
+    {
+        await DocumentUploadTest.ItDownloadsPDFDocs(this._memory, this.Log);
+    }
 }

--- a/extensions/AzureBlobs/AzureBlobsStorage.cs
+++ b/extensions/AzureBlobs/AzureBlobsStorage.cs
@@ -12,6 +12,7 @@ using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.Diagnostics;
+using Microsoft.KernelMemory.Pipeline;
 
 namespace Microsoft.KernelMemory.ContentStorage.AzureBlobs;
 
@@ -24,11 +25,14 @@ public class AzureBlobsStorage : IContentStorage
     private readonly BlobContainerClient _containerClient;
     private readonly string _containerName;
     private readonly ILogger<AzureBlobsStorage> _log;
+    private readonly IMimeTypeDetection _mimeTypeDetection;
 
     public AzureBlobsStorage(
         AzureBlobsConfig config,
+        IMimeTypeDetection? mimeTypeDetection = null,
         ILogger<AzureBlobsStorage>? log = null)
     {
+        this._mimeTypeDetection = mimeTypeDetection ?? new MimeTypesDetection();
         this._log = log ?? DefaultLogger<AzureBlobsStorage>.Instance;
 
         BlobServiceClient client;
@@ -186,40 +190,43 @@ public class AzureBlobsStorage : IContentStorage
         CancellationToken cancellationToken = default)
     {
         var directoryName = JoinPaths(index, documentId);
-        return this.InternalWriteAsync(directoryName, fileName, streamContent, cancellationToken);
+        var fileType = this._mimeTypeDetection.GetFileType(fileName);
+        return this.InternalWriteAsync(
+            directoryName: directoryName,
+            fileName: fileName,
+            fileType: fileType,
+            content: streamContent,
+            cancellationToken);
     }
 
-#if KernelMemoryDev
     /// <inheritdoc />
-    public Task<StreamableFileContent> ReadFileAsync(
+    public async Task<StreamableFileContent> ReadFileAsync(
         string index,
         string documentId,
         string fileName,
         bool logErrIfNotFound = true,
         CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
-    }
-#else
-    /// <inheritdoc />
-    public async Task<BinaryData> ReadFileAsync(
-        string index,
-        string documentId,
-        string fileName,
-        bool logErrIfNotFound = true,
-        CancellationToken cancellationToken = default)
-    {
+        ArgumentNullExceptionEx.ThrowIfNullOrEmpty(index, nameof(index), "Index name is empty");
+        ArgumentNullExceptionEx.ThrowIfNullOrEmpty(documentId, nameof(documentId), "Document Id is empty");
+        ArgumentNullExceptionEx.ThrowIfNullOrEmpty(fileName, nameof(fileName), "Filename is empty");
+
         var directoryName = JoinPaths(index, documentId);
         var blobName = $"{directoryName}/{fileName}";
         BlobClient blobClient = this.GetBlobClient(blobName);
 
         try
         {
-            Response<BlobDownloadResult>? content = await blobClient.DownloadContentAsync(cancellationToken).ConfigureAwait(false);
-
-            if (content != null && content.HasValue)
+            bool exists = await blobClient.ExistsAsync(cancellationToken).ConfigureAwait(false);
+            if (exists)
             {
-                return content.Value.Content;
+                var properties = (await blobClient.GetPropertiesAsync(null, cancellationToken).ConfigureAwait(false)).Value;
+                return new StreamableFileContent(
+                    blobClient.Name,
+                    properties.ContentLength,
+                    properties.ContentType,
+                    properties.LastModified,
+                    async () => (await blobClient.DownloadStreamingAsync(null, cancellationToken).ConfigureAwait(false)).Value.Content);
             }
 
             if (logErrIfNotFound) { this._log.LogError("Unable to download file {0}", blobName); }
@@ -232,7 +239,6 @@ public class AzureBlobsStorage : IContentStorage
             throw new ContentStorageFileNotFoundException("File not found", e);
         }
     }
-#endif
 
     #region private
 
@@ -247,7 +253,12 @@ public class AzureBlobsStorage : IContentStorage
         return $"{index}/{documentId}";
     }
 
-    private async Task InternalWriteAsync(string directoryName, string fileName, object content, CancellationToken cancellationToken)
+    private async Task InternalWriteAsync(
+        string directoryName,
+        string fileName,
+        string fileType,
+        object content,
+        CancellationToken cancellationToken)
     {
         var blobName = $"{directoryName}/{fileName}";
 
@@ -262,6 +273,8 @@ public class AzureBlobsStorage : IContentStorage
             lease = await this.LeaseBlobAsync(blobLeaseClient, cancellationToken).ConfigureAwait(false);
             options = new BlobUploadOptions { Conditions = new BlobRequestConditions { LeaseId = lease.LeaseId } };
         }
+
+        options.HttpHeaders = new BlobHttpHeaders { ContentType = fileType };
 
         this._log.LogTrace("Writing blob {0} ...", blobName);
 

--- a/extensions/MongoDbAtlas/MongoDbAtlas.FunctionalTests/DefaultTests.cs
+++ b/extensions/MongoDbAtlas/MongoDbAtlas.FunctionalTests/DefaultTests.cs
@@ -140,4 +140,11 @@ public abstract class DefaultTests : BaseFunctionalTestCase
     {
         await DocumentUploadTest.ItSupportsTags(this._memory, this.Log);
     }
+
+    [Fact]
+    [Trait("Category", "MongoDbAtlas")]
+    public async Task ItDownloadsPDFDocs()
+    {
+        await DocumentUploadTest.ItDownloadsPDFDocs(this._memory, this.Log);
+    }
 }

--- a/extensions/Postgres/Postgres.FunctionalTests/DefaultTests.cs
+++ b/extensions/Postgres/Postgres.FunctionalTests/DefaultTests.cs
@@ -100,4 +100,11 @@ public class DefaultTests : BaseFunctionalTestCase
     {
         await DocumentUploadTest.ItSupportsTags(this._memory, this.Log);
     }
+
+    [Fact]
+    [Trait("Category", "Postgres")]
+    public async Task ItDownloadsPDFDocs()
+    {
+        await DocumentUploadTest.ItDownloadsPDFDocs(this._memory, this.Log);
+    }
 }

--- a/extensions/Qdrant/Qdrant.FunctionalTests/DefaultTests.cs
+++ b/extensions/Qdrant/Qdrant.FunctionalTests/DefaultTests.cs
@@ -99,4 +99,11 @@ public class DefaultTests : BaseFunctionalTestCase
     {
         await DocumentUploadTest.ItSupportsTags(this._memory, this.Log);
     }
+
+    [Fact]
+    [Trait("Category", "Qdrant")]
+    public async Task ItDownloadsPDFDocs()
+    {
+        await DocumentUploadTest.ItDownloadsPDFDocs(this._memory, this.Log);
+    }
 }

--- a/extensions/Redis/Redis.FunctionalTests/DefaultTests.cs
+++ b/extensions/Redis/Redis.FunctionalTests/DefaultTests.cs
@@ -99,4 +99,11 @@ public class DefaultTests : BaseFunctionalTestCase
     {
         await DocumentUploadTest.ItSupportsTags(this._memory, this.Log);
     }
+
+    [Fact]
+    [Trait("Category", "Redis")]
+    public async Task ItDownloadsPDFDocs()
+    {
+        await DocumentUploadTest.ItDownloadsPDFDocs(this._memory, this.Log);
+    }
 }

--- a/service/Abstractions/Constants.cs
+++ b/service/Abstractions/Constants.cs
@@ -61,8 +61,10 @@ public static class Constants
     public const string HttpDeleteDocumentEndpointWithParams = $"{HttpDocumentsEndpoint}?{WebServiceIndexField}={HttpIndexPlaceholder}&{WebServiceDocumentIdField}={HttpDocumentIdPlaceholder}";
     public const string HttpDeleteIndexEndpointWithParams = $"{HttpIndexesEndpoint}?{WebServiceIndexField}={HttpIndexPlaceholder}";
     public const string HttpUploadStatusEndpointWithParams = $"{HttpUploadStatusEndpoint}?{WebServiceIndexField}={HttpIndexPlaceholder}&{WebServiceDocumentIdField}={HttpDocumentIdPlaceholder}";
+    public const string HttpDownloadEndpointWithParams = $"{HttpDownloadEndpoint}?{WebServiceIndexField}={HttpIndexPlaceholder}&{WebServiceDocumentIdField}={HttpDocumentIdPlaceholder}&{WebServiceFilenameField}={HttpFilenamePlaceholder}";
     public const string HttpIndexPlaceholder = "{index}";
     public const string HttpDocumentIdPlaceholder = "{documentId}";
+    public const string HttpFilenamePlaceholder = "{filename}";
 
     // Pipeline Handlers, Step names
     public const string PipelineStepsExtract = "extract";

--- a/service/Core/FileSystem/DevTools/IFileSystem.cs
+++ b/service/Core/FileSystem/DevTools/IFileSystem.cs
@@ -34,6 +34,7 @@ internal interface IFileSystem
     Task<bool> FileExistsAsync(string volume, string relPath, string fileName, CancellationToken cancellationToken = default);
 
     Task<BinaryData> ReadFileAsBinaryAsync(string volume, string relPath, string fileName, CancellationToken cancellationToken = default);
+    Task<StreamableFileContent> ReadFileInfoAsync(string volume, string relPath, string fileName, CancellationToken cancellationToken = default);
     Task<string> ReadFileAsTextAsync(string volume, string relPath, string fileName, CancellationToken cancellationToken = default);
     Task<IDictionary<string, string>> ReadAllFilesAsTextAsync(string volume, string relPath, CancellationToken cancellationToken = default);
     Task<IEnumerable<string>> GetAllFileNamesAsync(string volume, string relPath, CancellationToken cancellationToken = default);

--- a/service/Core/MemoryServerless.cs
+++ b/service/Core/MemoryServerless.cs
@@ -44,7 +44,6 @@ public class MemoryServerless : IKernelMemory
     {
         this._orchestrator = orchestrator ?? throw new ConfigurationException("The orchestrator is NULL");
         this._searchClient = searchClient ?? throw new ConfigurationException("The search client is NULL");
-        // this._exportValidationService = exportValidationService ?? throw new ConfigurationException("The export validation service is NULL");
 
         // A non-null config object is required in order to get a non-empty default index name
         config ??= new KernelMemoryConfig();

--- a/service/Core/MemoryService.cs
+++ b/service/Core/MemoryService.cs
@@ -168,13 +168,20 @@ public class MemoryService : IKernelMemory
         return this._orchestrator.ReadPipelineSummaryAsync(index: index, documentId, cancellationToken);
     }
 
-#if KernelMemoryDev
     /// <inheritdoc />
-    public Task<StreamableFileContent> ExportFileAsync(string documentId, string fileName, string? index = null, CancellationToken cancellationToken = default)
+    public Task<StreamableFileContent> ExportFileAsync(
+        string documentId,
+        string fileName,
+        string? index = null,
+        CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        var pipeline = new DataPipeline
+        {
+            Index = IndexName.CleanName(index, this._defaultIndexName),
+            DocumentId = documentId,
+        };
+        return this._orchestrator.ReadFileAsStreamAsync(pipeline, fileName, cancellationToken);
     }
-#endif
 
     /// <inheritdoc />
     public Task<SearchResult> SearchAsync(

--- a/service/Core/MemoryStorage/DevTools/SimpleTextDb.cs
+++ b/service/Core/MemoryStorage/DevTools/SimpleTextDb.cs
@@ -33,11 +33,11 @@ public class SimpleTextDb : IMemoryDb
         switch (config.StorageType)
         {
             case FileSystemTypes.Disk:
-                this._fileSystem = new DiskFileSystem(config.Directory, this._log);
+                this._fileSystem = new DiskFileSystem(config.Directory, null, this._log);
                 break;
 
             case FileSystemTypes.Volatile:
-                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, this._log);
+                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, null, this._log);
                 break;
 
             default:

--- a/service/Core/MemoryStorage/DevTools/SimpleVectorDb.cs
+++ b/service/Core/MemoryStorage/DevTools/SimpleVectorDb.cs
@@ -49,11 +49,11 @@ public class SimpleVectorDb : IMemoryDb
         switch (config.StorageType)
         {
             case FileSystemTypes.Disk:
-                this._fileSystem = new DiskFileSystem(config.Directory, this._log);
+                this._fileSystem = new DiskFileSystem(config.Directory, null, this._log);
                 break;
 
             case FileSystemTypes.Volatile:
-                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, this._log);
+                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, null, this._log);
                 break;
 
             default:

--- a/service/Core/MemoryStorage/MemoryRecordExtensions.cs
+++ b/service/Core/MemoryStorage/MemoryRecordExtensions.cs
@@ -68,10 +68,24 @@ public static class MemoryRecordExtensions
     /// <summary>
     /// Get web page URL, if the document was a web page
     /// </summary>
-    public static string? GetWebPageUrl(this MemoryRecord record, ILogger? log = null)
+    public static string GetWebPageUrl(this MemoryRecord record, string indexName, ILogger? log = null)
     {
-        var result = record.GetPayloadValue(Constants.ReservedPayloadUrlField, log)?.ToString();
-        return string.IsNullOrWhiteSpace(result) ? null : result;
+        // TODO: remove on next Abstractions release and use Constants
+        // TODO: support custom API path prefix
+        const string HttpFilenamePlaceholder = "{filename}";
+        const string HTTPDownloadEndpointWithParams = $"{Constants.HttpDownloadEndpoint}" +
+                                                      $"?{Constants.WebServiceIndexField}={Constants.HttpIndexPlaceholder}" +
+                                                      $"&{Constants.WebServiceDocumentIdField}={Constants.HttpDocumentIdPlaceholder}" +
+                                                      $"&{Constants.WebServiceFilenameField}={HttpFilenamePlaceholder}";
+
+        var fileDownloadUrl = HTTPDownloadEndpointWithParams
+            .Replace(Constants.HttpIndexPlaceholder, indexName, StringComparison.Ordinal)
+            .Replace(Constants.HttpDocumentIdPlaceholder, record.GetDocumentId(), StringComparison.Ordinal)
+            .Replace(Constants.HttpFilenamePlaceholder, record.GetFileName(), StringComparison.Ordinal);
+
+        var webPageUrl = record.GetPayloadValue(Constants.ReservedPayloadUrlField, log)?.ToString();
+
+        return string.IsNullOrWhiteSpace(webPageUrl) ? fileDownloadUrl : webPageUrl;
     }
 
     /// <summary>

--- a/service/Core/Pipeline/BaseOrchestrator.cs
+++ b/service/Core/Pipeline/BaseOrchestrator.cs
@@ -1,10 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-// ReSharper disable RedundantUsingDirective
-#pragma warning disable CS0162 // temp
-#pragma warning disable CS1998 // temp
-#pragma warning disable IDE0005 // temp
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -152,15 +147,20 @@ public abstract class BaseOrchestrator : IPipelineOrchestrator, IDisposable
     ///<inheritdoc />
     public async Task<DataPipeline?> ReadPipelineStatusAsync(string index, string documentId, CancellationToken cancellationToken = default)
     {
-#if KernelMemoryDev
-        throw new NotImplementedException();
-#else
         index = IndexName.CleanName(index, this._defaultIndexName);
 
         try
         {
-            BinaryData? content = await (this._contentStorage.ReadFileAsync(index, documentId, Constants.PipelineStatusFilename, false, cancellationToken)
-                .ConfigureAwait(false));
+            StreamableFileContent? streamableContent = await this._contentStorage.ReadFileAsync(index, documentId, Constants.PipelineStatusFilename, false, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (streamableContent == null)
+            {
+                throw new InvalidPipelineDataException("The pipeline data is not found");
+            }
+
+            BinaryData? content = await BinaryData.FromStreamAsync(await streamableContent.StreamAsync().ConfigureAwait(false), cancellationToken)
+                .ConfigureAwait(false);
 
             if (content == null)
             {
@@ -180,7 +180,6 @@ public abstract class BaseOrchestrator : IPipelineOrchestrator, IDisposable
         {
             throw new PipelineNotFoundException("Pipeline/Document not found");
         }
-#endif
     }
 
     ///<inheritdoc />
@@ -221,12 +220,13 @@ public abstract class BaseOrchestrator : IPipelineOrchestrator, IDisposable
         return this.CancellationTokenSource.CancelAsync();
     }
 
-#if KernelMemoryDev
-    public Task<StreamableFileContent> ReadFileAsStreamAsync(DataPipeline pipeline, string fileName, CancellationToken cancellationToken = default)
+    ///<inheritdoc />
+    public async Task<StreamableFileContent> ReadFileAsStreamAsync(DataPipeline pipeline, string fileName, CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        pipeline.Index = IndexName.CleanName(pipeline.Index, this._defaultIndexName);
+        return await this._contentStorage.ReadFileAsync(pipeline.Index, pipeline.DocumentId, fileName, true, cancellationToken)
+            .ConfigureAwait(false);
     }
-#endif
 
     ///<inheritdoc />
     public async Task<string> ReadTextFileAsync(DataPipeline pipeline, string fileName, CancellationToken cancellationToken = default)
@@ -236,14 +236,11 @@ public abstract class BaseOrchestrator : IPipelineOrchestrator, IDisposable
     }
 
     ///<inheritdoc />
-    public Task<BinaryData> ReadFileAsync(DataPipeline pipeline, string fileName, CancellationToken cancellationToken = default)
+    public async Task<BinaryData> ReadFileAsync(DataPipeline pipeline, string fileName, CancellationToken cancellationToken = default)
     {
-        pipeline.Index = IndexName.CleanName(pipeline.Index, this._defaultIndexName);
-#if KernelMemoryDev
-        throw new NotImplementedException();
-#else
-        return this._contentStorage.ReadFileAsync(pipeline.Index, pipeline.DocumentId, fileName, true, cancellationToken);
-#endif
+        StreamableFileContent streamableContent = await this.ReadFileAsStreamAsync(pipeline, fileName, cancellationToken).ConfigureAwait(false);
+        return await BinaryData.FromStreamAsync(await streamableContent.StreamAsync().ConfigureAwait(false), cancellationToken)
+            .ConfigureAwait(false);
     }
 
     ///<inheritdoc />

--- a/service/Core/Pipeline/Queue/DevTools/SimpleQueues.cs
+++ b/service/Core/Pipeline/Queue/DevTools/SimpleQueues.cs
@@ -82,11 +82,11 @@ public sealed class SimpleQueues : IQueue
         switch (config.StorageType)
         {
             case FileSystemTypes.Disk:
-                this._fileSystem = new DiskFileSystem(config.Directory, this._log);
+                this._fileSystem = new DiskFileSystem(config.Directory, null, this._log);
                 break;
 
             case FileSystemTypes.Volatile:
-                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, this._log);
+                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, null, this._log);
                 break;
 
             default:

--- a/service/Core/Search/SearchClient.cs
+++ b/service/Core/Search/SearchClient.cs
@@ -152,7 +152,7 @@ public class SearchClient : ISearchClient
             citation.Link = linkToFile;
             citation.SourceContentType = memory.GetFileContentType(this._log);
             citation.SourceName = memory.GetFileName(this._log);
-            citation.SourceUrl = memory.GetWebPageUrl();
+            citation.SourceUrl = memory.GetWebPageUrl(index);
 
             citation.Partitions.Add(new Citation.Partition
             {
@@ -279,7 +279,7 @@ public class SearchClient : ISearchClient
             citation.Link = linkToFile;
             citation.SourceContentType = memory.GetFileContentType(this._log);
             citation.SourceName = fileName;
-            citation.SourceUrl = memory.GetWebPageUrl();
+            citation.SourceUrl = memory.GetWebPageUrl(index);
 
             citation.Partitions.Add(new Citation.Partition
             {

--- a/service/Service.AspNetCore/Service.AspNetCore.csproj
+++ b/service/Service.AspNetCore/Service.AspNetCore.csproj
@@ -7,6 +7,7 @@
         <AssemblyName>Microsoft.KernelMemory.Service.AspNetCore</AssemblyName>
         <RootNamespace>Microsoft.KernelMemory.Service.AspNetCore</RootNamespace>
         <NoWarn>$(NoWarn);CA1031;CA2254;CS1591;</NoWarn>
+        <DefineConstants Condition="'$(SolutionName)' == 'KernelMemoryDev'">$(DefineConstants);KernelMemoryDev</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>

--- a/service/tests/Abstractions.UnitTests/Abstractions.UnitTests.csproj
+++ b/service/tests/Abstractions.UnitTests/Abstractions.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -10,6 +10,9 @@
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);CS1591;CA1861;</NoWarn>
+    </PropertyGroup>
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+        <DefineConstants>OS_WINDOWS</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>

--- a/service/tests/Abstractions.UnitTests/Models/FileCollectionTest.cs
+++ b/service/tests/Abstractions.UnitTests/Models/FileCollectionTest.cs
@@ -31,6 +31,7 @@ public class FileCollectionTest
         Assert.Equal(2, target.GetStreams().ToList().Count);
     }
 
+#if !OS_WINDOWS // does not allow 2 open streams to the same file
     [Fact]
     [Trait("Category", "UnitTest")]
     public void ItDoesntDeDupeStreams()
@@ -67,4 +68,5 @@ public class FileCollectionTest
         // Assert
         Assert.Equal(9, target.GetStreams().ToList().Count);
     }
+#endif
 }

--- a/service/tests/Core.FunctionalTests/DefaultTestCases/DocumentUploadTest.cs
+++ b/service/tests/Core.FunctionalTests/DefaultTestCases/DocumentUploadTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.KernelMemory;
+using Microsoft.KernelMemory.FileSystem.DevTools;
 
 namespace Microsoft.Core.FunctionalTests.DefaultTestCases;
 
@@ -96,5 +100,54 @@ public static class DocumentUploadTest
         Assert.Contains("spacecraft", answer2.Result, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("spacecraft", answer3.Result, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("NOT FOUND", answer4.Result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static async Task ItDownloadsPDFDocs(IKernelMemory memory, Action<string> log)
+    {
+        // Arrange
+        const string fileName = "file1-NASA-news.pdf";
+        const string Id = "ItUploadsPDFDocsAndDeletes-file1-NASA-news.pdf";
+        log("Uploading document");
+        await memory.ImportDocumentAsync(
+            fileName,
+            documentId: Id,
+            steps: Constants.PipelineWithoutSummary);
+
+        var count = 0;
+        while (!await memory.IsDocumentReadyAsync(documentId: Id))
+        {
+            Assert.True(count++ <= 30, "Document import timed out");
+            log("Waiting for memory ingestion to complete...");
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+
+        // Act
+        var streamAbleFileInfo = await memory.ExportFileAsync(documentId: Id, fileName: fileName);
+        var pdfBytes = (await streamAbleFileInfo.StreamAsync()).ReadAllBytes();
+        log($"Export {streamAbleFileInfo.FileName}, size: {streamAbleFileInfo.FileSize}");
+
+        // Assert
+        var expected = ComputeChecksum(await File.ReadAllBytesAsync(fileName));
+        var actual = ComputeChecksum(pdfBytes);
+        Assert.Equal(expected, actual);
+
+        // Cleanup
+        log("Deleting memories extracted from the document");
+        await memory.DeleteDocumentAsync(Id);
+    }
+
+    private static string ComputeChecksum(byte[] bytes)
+    {
+        // Compute and return a checksum for the specified byte array
+        byte[] computedHash = SHA256.HashData(bytes);
+
+        // Convert byte array to a string
+        StringBuilder builder = new();
+        for (int i = 0; i < computedHash.Length; i++)
+        {
+            builder.Append(computedHash[i].ToString("x2", CultureInfo.CurrentCulture));
+        }
+
+        return builder.ToString();
     }
 }

--- a/service/tests/Core.FunctionalTests/Fixtures/Doc1.txt
+++ b/service/tests/Core.FunctionalTests/Fixtures/Doc1.txt
@@ -1,0 +1,1 @@
+Document one example

--- a/service/tests/Core.FunctionalTests/Fixtures/Documents/Doc1.txt
+++ b/service/tests/Core.FunctionalTests/Fixtures/Documents/Doc1.txt
@@ -1,0 +1,1 @@
+Document one example

--- a/service/tests/Core.FunctionalTests/Fixtures/Documents/Sales/Doc1.txt
+++ b/service/tests/Core.FunctionalTests/Fixtures/Documents/Sales/Doc1.txt
@@ -1,0 +1,1 @@
+Document one example

--- a/service/tests/Core.FunctionalTests/Fixtures/Documents/Support/Doc1.txt
+++ b/service/tests/Core.FunctionalTests/Fixtures/Documents/Support/Doc1.txt
@@ -1,0 +1,1 @@
+Document one example

--- a/service/tests/Core.FunctionalTests/ServerLess/DefaultTests.cs
+++ b/service/tests/Core.FunctionalTests/ServerLess/DefaultTests.cs
@@ -101,4 +101,14 @@ public class DefaultTests : BaseFunctionalTestCase
     {
         await DocumentUploadTest.ItSupportsTags(this.GetServerlessMemory(memoryType), this.Log);
     }
+
+    [Theory]
+    [Trait("Category", "Serverless")]
+    [InlineData("default")]
+    [InlineData("simple_on_disk")]
+    [InlineData("simple_volatile")]
+    public async Task ItDownloadsPDFDocs(string memoryType)
+    {
+        await DocumentUploadTest.ItDownloadsPDFDocs(this.GetServerlessMemory(memoryType), this.Log);
+    }
 }

--- a/service/tests/Core.FunctionalTests/ServerLess/SubDirFilesAndStreamsTest.cs
+++ b/service/tests/Core.FunctionalTests/ServerLess/SubDirFilesAndStreamsTest.cs
@@ -87,7 +87,7 @@ public class SubDirFilesAndStreamsTest : BaseFunctionalTestCase
         doc.AddFile(Path.Join(this._fixturesPath, "Doc1.txt"));
         doc.AddFile(Path.Join(this._fixturesPath, "Documents", "Doc1.txt"));
 
-        // Act - Assert no exception occurs
+        // Act
         await this._memory.ImportDocumentAsync(document: doc);
         SearchResult result = await this._memory.SearchAsync("Document one");
 

--- a/service/tests/Core.FunctionalTests/ServerLess/SubDirFilesAndStreamsTest.cs
+++ b/service/tests/Core.FunctionalTests/ServerLess/SubDirFilesAndStreamsTest.cs
@@ -78,4 +78,23 @@ public class SubDirFilesAndStreamsTest : BaseFunctionalTestCase
             steps: new[] { "extract", "partition" },
             tags: new() { { "user", "user1" } });
     }
+
+    [Fact]
+    [Trait("Category", "Serverless")]
+    public async Task ItAllowsToDownloadFilesWithTheSameName()
+    {
+        var doc = new Document { Id = "clones" };
+        doc.AddFile(Path.Join(this._fixturesPath, "Doc1.txt"));
+        doc.AddFile(Path.Join(this._fixturesPath, "Documents", "Doc1.txt"));
+
+        // Act - Assert no exception occurs
+        await this._memory.ImportDocumentAsync(document: doc);
+        SearchResult result = await this._memory.SearchAsync("Document one");
+
+        // Assert
+        Assert.Equal(2, result.Results.Count);
+        Assert.NotEqual(result.Results[0].SourceUrl, result.Results[1].SourceUrl);
+        Assert.EndsWith("Doc1.txt", result.Results[0].SourceUrl);
+        Assert.EndsWith("Doc1.txt", result.Results[1].SourceUrl);
+    }
 }

--- a/service/tests/Core.UnitTests/FileSystem/DevTools/InMemoryFileSystemTest.cs
+++ b/service/tests/Core.UnitTests/FileSystem/DevTools/InMemoryFileSystemTest.cs
@@ -188,6 +188,34 @@ public class InMemoryFileSystemTest : BaseUnitTestCase
 
     [Fact]
     [Trait("Category", "UnitTest")]
+    public async Task ItStreamsFilesThatExist()
+    {
+        // Arrange
+        const string Vol = "v5";
+        await this._target.CreateVolumeAsync(Vol);
+        await this._target.CreateDirectoryAsync(Vol, "sub1/sub2");
+        await this._target.WriteFileAsync(Vol, "sub1/sub2", "file.txt", "some content");
+
+        // Act
+        var contentFile = await this._target.ReadFileInfoAsync(Vol, "sub1/sub2", "file.txt");
+        BinaryData? data = null;
+        using (Stream stream = await contentFile.StreamAsync())
+        {
+            data = new BinaryData(stream.ReadAllBytes());
+            stream.Close();
+        }
+
+        var content = data.ToString();
+
+        // Assert
+        Assert.Equal("some content", content);
+
+        // Cleanup
+        await this._target.DeleteVolumeAsync(Vol);
+    }
+
+    [Fact]
+    [Trait("Category", "UnitTest")]
     public async Task ItThrowsIfAFileOrDirDoesntExist()
     {
         // Arrange

--- a/service/tests/Core.UnitTests/FileSystem/DevTools/InMemoryFileSystemTest.cs
+++ b/service/tests/Core.UnitTests/FileSystem/DevTools/InMemoryFileSystemTest.cs
@@ -198,8 +198,8 @@ public class InMemoryFileSystemTest : BaseUnitTestCase
 
         // Act
         var contentFile = await this._target.ReadFileInfoAsync(Vol, "sub1/sub2", "file.txt");
-        BinaryData? data = null;
-        using (Stream stream = await contentFile.StreamAsync())
+        BinaryData? data;
+        await using (Stream stream = await contentFile.StreamAsync())
         {
             data = new BinaryData(stream.ReadAllBytes());
             stream.Close();

--- a/service/tests/Core.UnitTests/FileSystem/DevTools/OnDiskFileSystemTest.cs
+++ b/service/tests/Core.UnitTests/FileSystem/DevTools/OnDiskFileSystemTest.cs
@@ -149,8 +149,8 @@ public class OnDiskFileSystemTest : BaseUnitTestCase
 
         // Act
         var contentFile = await this._target.ReadFileInfoAsync(Vol, "sub1/sub2", "file.txt");
-        BinaryData? data = null;
-        using (Stream stream = await contentFile.StreamAsync())
+        BinaryData? data;
+        await using (Stream stream = await contentFile.StreamAsync())
         {
             data = new BinaryData(stream.ReadAllBytes());
             stream.Close();

--- a/service/tests/Core.UnitTests/FileSystem/DevTools/OnDiskFileSystemTest.cs
+++ b/service/tests/Core.UnitTests/FileSystem/DevTools/OnDiskFileSystemTest.cs
@@ -139,6 +139,34 @@ public class OnDiskFileSystemTest : BaseUnitTestCase
 
     [Fact]
     [Trait("Category", "UnitTest")]
+    public async Task ItStreamsFilesThatExist()
+    {
+        // Arrange
+        const string Vol = "v5";
+        await this._target.CreateVolumeAsync(Vol);
+        await this._target.CreateDirectoryAsync(Vol, "sub1/sub2");
+        await this._target.WriteFileAsync(Vol, "sub1/sub2", "file.txt", "some content");
+
+        // Act
+        var contentFile = await this._target.ReadFileInfoAsync(Vol, "sub1/sub2", "file.txt");
+        BinaryData? data = null;
+        using (Stream stream = await contentFile.StreamAsync())
+        {
+            data = new BinaryData(stream.ReadAllBytes());
+            stream.Close();
+        }
+
+        var content = data.ToString();
+
+        // Assert
+        Assert.Equal("some content", content);
+
+        // Cleanup
+        await this._target.DeleteVolumeAsync(Vol);
+    }
+
+    [Fact]
+    [Trait("Category", "UnitTest")]
     public async Task ItThrowsIfAFileOrDirDoesntExist()
     {
         // Arrange

--- a/service/tests/Service.FunctionalTests/DefaultTests.cs
+++ b/service/tests/Service.FunctionalTests/DefaultTests.cs
@@ -92,4 +92,11 @@ public class DefaultTests : BaseFunctionalTestCase
     {
         await DocumentUploadTest.ItSupportsTags(this._memory, this.Log);
     }
+
+    [Fact]
+    [Trait("Category", "WebService")]
+    public async Task ItDownloadsPDFDocs()
+    {
+        await DocumentUploadTest.ItDownloadsPDFDocs(this._memory, this.Log);
+    }
 }


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

Validating AI answers requires access to the source grounding documents and data. The KM solution enables easy ingestion of grounding documents as well as the ability to remove documents. A file download feature allows consumers access to the grounding source materials and allow them to verify the answers presented by the ASK endpoint.

## High level description (Approach, Design)

* New methods to memory and storage interface, to allow access to individual files
* New web service endpoint to download files, passing index name, document ID and file name
* Include download link in RAG citations and search results:
<img width="459" alt="image" src="https://github.com/microsoft/kernel-memory/assets/371009/786549e7-6a94-4b76-b217-a6137e8a9379">
* Stream file download and support Range fetch

Since KM is a backend service not meant for multi-user direct access (ie KM security model is based on a single key, like a SQL server or any DB), the endpoint provides direct access to all files, similarly to search allows access to all memory records. For public deployments, a middleware webservice should take care of securing links, e.g. adding and validating signatures and user tokens.