### PR TITLE
Add IKernelMemoryBuilder generic oveloads

### DIFF
--- a/service/Abstractions/KernelMemoryBuilderExtensions.cs
+++ b/service/Abstractions/KernelMemoryBuilderExtensions.cs
@@ -79,6 +79,14 @@ public static partial class KernelMemoryBuilderExtensions
         return builder;
     }
 
+    public static IKernelMemoryBuilder WithCustomIngestionQueueClientFactory<T>(
+        this IKernelMemoryBuilder builder, T service) where T : QueueClientFactory
+    {
+        service = service ?? throw new ConfigurationException("The ingestion queue client factory instance is NULL");
+        builder.AddSingleton<QueueClientFactory, T>();
+        return builder;
+    }
+
     public static IKernelMemoryBuilder WithCustomStorage(
         this IKernelMemoryBuilder builder, IContentStorage service)
     {
@@ -87,11 +95,27 @@ public static partial class KernelMemoryBuilderExtensions
         return builder;
     }
 
+    public static IKernelMemoryBuilder WithCustomStorage<T>(
+        this IKernelMemoryBuilder builder, T service) where T : class, IContentStorage
+    {
+        service = service ?? throw new ConfigurationException("The content storage instance is NULL");
+        builder.AddSingleton<IContentStorage, T>();
+        return builder;
+    }
+
     public static IKernelMemoryBuilder WithCustomMimeTypeDetection(
         this IKernelMemoryBuilder builder, IMimeTypeDetection service)
     {
         service = service ?? throw new ConfigurationException("The MIME type detection instance is NULL");
         builder.AddSingleton<IMimeTypeDetection>(service);
+        return builder;
+    }
+
+    public static IKernelMemoryBuilder WithCustomMimeTypeDetection<T>(
+        this IKernelMemoryBuilder builder, T service) where T : class, IMimeTypeDetection
+    {
+        service = service ?? throw new ConfigurationException("The MIME type detection instance is NULL");
+        builder.AddSingleton<IMimeTypeDetection, T>();
         return builder;
     }
 
@@ -146,6 +170,15 @@ public static partial class KernelMemoryBuilderExtensions
         return builder;
     }
 
+    public static IKernelMemoryBuilder WithCustomTextGenerator<T>(
+        this IKernelMemoryBuilder builder,
+        T service) where T : class, ITextGenerator
+    {
+        service = service ?? throw new ConfigurationException("The text generator instance is NULL");
+        builder.AddSingleton<ITextGenerator, T>();
+        return builder;
+    }
+
     public static IKernelMemoryBuilder WithCustomImageOcr(
         this IKernelMemoryBuilder builder,
         IOcrEngine service)
@@ -155,11 +188,28 @@ public static partial class KernelMemoryBuilderExtensions
         return builder;
     }
 
+    public static IKernelMemoryBuilder WithCustomImageOcr<T>(
+        this IKernelMemoryBuilder builder,
+        T service) where T : class, IOcrEngine
+    {
+        service = service ?? throw new ConfigurationException("The OCR engine instance is NULL");
+        builder.AddSingleton<IOcrEngine, T>();
+        return builder;
+    }
+
     public static IKernelMemoryBuilder WithCustomPromptProvider(
         this IKernelMemoryBuilder builder, IPromptProvider service)
     {
         service = service ?? throw new ConfigurationException("The prompt provider instance is NULL");
         builder.AddSingleton<IPromptProvider>(service);
+        return builder;
+    }
+
+    public static IKernelMemoryBuilder WithCustomPromptProvider<T>(
+        this IKernelMemoryBuilder builder, T service) where T : class, IPromptProvider
+    {
+        service = service ?? throw new ConfigurationException("The prompt provider instance is NULL");
+        builder.AddSingleton<IPromptProvider, T>();
         return builder;
     }
 

--- a/service/Core/Search/DependencyInjection.cs
+++ b/service/Core/Search/DependencyInjection.cs
@@ -30,6 +30,13 @@ public static partial class KernelMemoryBuilderExtensions
         builder.Services.AddCustomSearchClient(instance);
         return builder;
     }
+
+    public static IKernelMemoryBuilder WithCustomSearchClient<T>(
+        this IKernelMemoryBuilder builder) where T : class, ISearchClient
+    {
+        builder.Services.AddCustomSearchClient<T>();
+        return builder;
+    }
 }
 
 public static partial class DependencyInjection
@@ -45,6 +52,12 @@ public static partial class DependencyInjection
         this IServiceCollection services, ISearchClient instance)
     {
         return services.AddSingleton<ISearchClient>(instance);
+    }
+
+    public static IServiceCollection AddCustomSearchClient<T>(
+        this IServiceCollection services) where T : class, ISearchClient
+    {
+        return services.AddSingleton<ISearchClient, T>();
     }
 
     public static IServiceCollection AddSearchClientConfig(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
This PR adds generic overloads to the following `IKernelMemoryBuilder` extension methods, allowing to fully leverage dependency injection:

- `WithCustomIngestionQueueClientFactory`
- `WithCustomStorage`
- `WithCustomMimeTypeDetection`
- `WithCustomTextGenerator`
- `WithCustomImageOcr`
- `WithCustomPromptProvider`
- `WithCustomSearchClient`

From this list, `WithCustomEmbeddingGenerator` and `WithCustomMemoryDb` methods are missing, because providing a generic implementation of them requires a little refactoring, so it will be added later.

