### PR TITLE
Change style of csproj files

### DIFF
--- a/.github/workflows/github-pages-jekyll.yml
+++ b/.github/workflows/github-pages-jekyll.yml
@@ -4,7 +4,7 @@ name: GitHub Pages Deploy
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/spell-check-with-typos.yml
+++ b/.github/workflows/spell-check-with-typos.yml
@@ -12,7 +12,7 @@ name: Spell Check
 on:
   workflow_dispatch:
   pull_request:
-    branches: ["main", "feature*"]
+    branches: [ "main", "feature*" ]
 
 jobs:
   run:

--- a/clients/dotnet/SemanticKernelPlugin/SemanticKernelPlugin.csproj
+++ b/clients/dotnet/SemanticKernelPlugin/SemanticKernelPlugin.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>Microsoft.KernelMemory.SemanticKernelPlugin</AssemblyName>
         <RootNamespace>Microsoft.KernelMemory.SemanticKernelPlugin</RootNamespace>
-        <NoWarn>$(NoWarn);CS1591,NU5104</NoWarn>
+        <NoWarn>$(NoWarn);CS1591;NU5104;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -12,12 +12,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SemanticKernel.Abstractions"/>
+        <PackageReference Include="Microsoft.SemanticKernel.Abstractions" />
     </ItemGroup>
 
-    <Import Project="../../../code-analysis.props"/>
+    <Import Project="../../../code-analysis.props" />
 
-    <Import Project="../../../nuget-package.props"/>
+    <Import Project="../../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -28,7 +28,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="../../../README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="../../../README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/clients/dotnet/WebClient/WebClient.csproj
+++ b/clients/dotnet/WebClient/WebClient.csproj
@@ -4,17 +4,17 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>Microsoft.KernelMemory.WebClient</AssemblyName>
         <RootNamespace>Microsoft.KernelMemory</RootNamespace>
-        <NoWarn>$(NoWarn);CS1591,NU5104</NoWarn>
+        <NoWarn>$(NoWarn);CS1591;NU5104;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
-    <Import Project="../../../code-analysis.props"/>
+    <Import Project="../../../code-analysis.props" />
 
-    <Import Project="../../../nuget-package.props"/>
+    <Import Project="../../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -25,7 +25,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="../../../README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="../../../README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/examples/001-dotnet-WebClient/001-dotnet-WebClient.csproj
+++ b/examples/001-dotnet-WebClient/001-dotnet-WebClient.csproj
@@ -5,8 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA1050,CA2000,CA1707,CA1303,CA2007,CA1861</NoWarn>
+        <NoWarn>$(NoWarn);CA1050;CA2000;CA1707;CA1303;CA2007;CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -14,35 +13,35 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="file1-Wikipedia-Carbon.txt"/>
+        <None Remove="file1-Wikipedia-Carbon.txt" />
         <Content Include="file1-Wikipedia-Carbon.txt">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file2-Wikipedia-Moon.txt"/>
+        <None Remove="file2-Wikipedia-Moon.txt" />
         <Content Include="file2-Wikipedia-Moon.txt">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file3-lorem-ipsum.docx"/>
+        <None Remove="file3-lorem-ipsum.docx" />
         <Content Include="file3-lorem-ipsum.docx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file4-KM-Readme.pdf"/>
+        <None Remove="file4-KM-Readme.pdf" />
         <Content Include="file4-KM-Readme.pdf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file5-NASA-news.pdf"/>
+        <None Remove="file5-NASA-news.pdf" />
         <Content Include="file5-NASA-news.pdf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file6-ANWC-image.jpg"/>
+        <None Remove="file6-ANWC-image.jpg" />
         <Content Include="file6-ANWC-image.jpg">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file7-submarine.html"/>
+        <None Remove="file7-submarine.html" />
         <Content Include="file7-submarine.html">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file8-data.xlsx"/>
+        <None Remove="file8-data.xlsx" />
         <Content Include="file8-data.xlsx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>

--- a/examples/002-dotnet-SemanticKernel-plugin/002-dotnet-SemanticKernel-plugin.csproj
+++ b/examples/002-dotnet-SemanticKernel-plugin/002-dotnet-SemanticKernel-plugin.csproj
@@ -5,7 +5,6 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
         <NoWarn>$(NoWarn);CA1050;CA1859;CA2000;</NoWarn>
     </PropertyGroup>
 
@@ -15,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="mydocs-NASA-news.pdf"/>
+        <None Remove="mydocs-NASA-news.pdf" />
         <Content Include="mydocs-NASA-news.pdf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>

--- a/examples/003-dotnet-Serverless/003-dotnet-Serverless.csproj
+++ b/examples/003-dotnet-Serverless/003-dotnet-Serverless.csproj
@@ -5,49 +5,48 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA1050,CA2000,CA1707,CA1303,CA2007,CA1724,CA1861</NoWarn>
+        <NoWarn>$(NoWarn);CA1050;CA2000;CA1707;CA1303;CA2007;CA1724;CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
         <ProjectReference Include="..\..\extensions\LlamaSharp\LlamaSharp\LlamaSharp.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Memory.Data" Version="8.0.0"/>
+        <PackageReference Include="System.Memory.Data" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="file1-Wikipedia-Carbon.txt"/>
+        <None Remove="file1-Wikipedia-Carbon.txt" />
         <Content Include="file1-Wikipedia-Carbon.txt">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file2-Wikipedia-Moon.txt"/>
+        <None Remove="file2-Wikipedia-Moon.txt" />
         <Content Include="file2-Wikipedia-Moon.txt">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file3-lorem-ipsum.docx"/>
+        <None Remove="file3-lorem-ipsum.docx" />
         <Content Include="file3-lorem-ipsum.docx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file4-KM-Readme.pdf"/>
+        <None Remove="file4-KM-Readme.pdf" />
         <Content Include="file4-KM-Readme.pdf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file5-NASA-news.pdf"/>
+        <None Remove="file5-NASA-news.pdf" />
         <Content Include="file5-NASA-news.pdf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file6-ANWC-image.jpg"/>
+        <None Remove="file6-ANWC-image.jpg" />
         <Content Include="file6-ANWC-image.jpg">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file7-submarine.html"/>
+        <None Remove="file7-submarine.html" />
         <Content Include="file7-submarine.html">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file8-data.xlsx"/>
+        <None Remove="file8-data.xlsx" />
         <Content Include="file8-data.xlsx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>

--- a/examples/004-dotnet-serverless-custom-pipeline/004-dotnet-serverless-custom-pipeline.csproj
+++ b/examples/004-dotnet-serverless-custom-pipeline/004-dotnet-serverless-custom-pipeline.csproj
@@ -5,36 +5,35 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
         <NoWarn>$(NoWarn);CA1050;CA2000;CA1707;CA1303;CA2007;CA1724;CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Memory.Data" Version="8.0.0"/>
+        <PackageReference Include="System.Memory.Data" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="file1-Wikipedia-Carbon.txt"/>
+        <None Remove="file1-Wikipedia-Carbon.txt" />
         <Content Include="file1-Wikipedia-Carbon.txt">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file2-Wikipedia-Moon.txt"/>
+        <None Remove="file2-Wikipedia-Moon.txt" />
         <Content Include="file2-Wikipedia-Moon.txt">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file3-lorem-ipsum.docx"/>
+        <None Remove="file3-lorem-ipsum.docx" />
         <Content Include="file3-lorem-ipsum.docx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file4-KM-Readme.pdf"/>
+        <None Remove="file4-KM-Readme.pdf" />
         <Content Include="file4-KM-Readme.pdf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file5-NASA-news.pdf"/>
+        <None Remove="file5-NASA-news.pdf" />
         <Content Include="file5-NASA-news.pdf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>

--- a/examples/005-dotnet-async-memory-custom-pipeline/005-dotnet-async-memory-custom-pipeline.csproj
+++ b/examples/005-dotnet-async-memory-custom-pipeline/005-dotnet-async-memory-custom-pipeline.csproj
@@ -5,36 +5,35 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
         <NoWarn>$(NoWarn);CA1050;CA2000;CA1707;CA1303;CA2007;CA1724;CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Memory.Data" Version="8.0.0"/>
+        <PackageReference Include="System.Memory.Data" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="file1-Wikipedia-Carbon.txt"/>
+        <None Remove="file1-Wikipedia-Carbon.txt" />
         <Content Include="file1-Wikipedia-Carbon.txt">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file2-Wikipedia-Moon.txt"/>
+        <None Remove="file2-Wikipedia-Moon.txt" />
         <Content Include="file2-Wikipedia-Moon.txt">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file3-lorem-ipsum.docx"/>
+        <None Remove="file3-lorem-ipsum.docx" />
         <Content Include="file3-lorem-ipsum.docx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file4-KM-Readme.pdf"/>
+        <None Remove="file4-KM-Readme.pdf" />
         <Content Include="file4-KM-Readme.pdf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file5-NASA-news.pdf"/>
+        <None Remove="file5-NASA-news.pdf" />
         <Content Include="file5-NASA-news.pdf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>

--- a/examples/101-dotnet-custom-Prompts/101-dotnet-custom-Prompts.csproj
+++ b/examples/101-dotnet-custom-Prompts/101-dotnet-custom-Prompts.csproj
@@ -5,12 +5,11 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA1050</NoWarn>
+        <NoWarn>$(NoWarn);CA1050;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/examples/102-dotnet-custom-partitioning-options/102-dotnet-custom-partitioning-options.csproj
+++ b/examples/102-dotnet-custom-partitioning-options/102-dotnet-custom-partitioning-options.csproj
@@ -6,16 +6,15 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA1861</NoWarn>
+        <NoWarn>$(NoWarn);CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="mswordfile.docx"/>
+        <None Remove="mswordfile.docx" />
         <Content Include="mswordfile.docx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>

--- a/examples/103-dotnet-custom-EmbeddingGenerator/103-dotnet-custom-EmbeddingGenerator.csproj
+++ b/examples/103-dotnet-custom-EmbeddingGenerator/103-dotnet-custom-EmbeddingGenerator.csproj
@@ -5,12 +5,11 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA1050,SKEXP0001</NoWarn>
+        <NoWarn>$(NoWarn);CA1050;SKEXP0001;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/examples/104-dotnet-custom-LLM/104-dotnet-custom-LLM.csproj
+++ b/examples/104-dotnet-custom-LLM/104-dotnet-custom-LLM.csproj
@@ -5,12 +5,11 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA1050</NoWarn>
+        <NoWarn>$(NoWarn);CA1050;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/examples/105-dotnet-serverless-llamasharp/105-dotnet-serverless-llamasharp.csproj
+++ b/examples/105-dotnet-serverless-llamasharp/105-dotnet-serverless-llamasharp.csproj
@@ -5,11 +5,10 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
         <ProjectReference Include="..\..\extensions\LlamaSharp\LlamaSharp\LlamaSharp.csproj" />
     </ItemGroup>
 

--- a/examples/106-dotnet-retrieve-synthetics/106-dotnet-retrieve-synthetics.csproj
+++ b/examples/106-dotnet-retrieve-synthetics/106-dotnet-retrieve-synthetics.csproj
@@ -5,12 +5,11 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\clients\dotnet\WebClient\WebClient.csproj" />
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/107-dotnet-SemanticKernel-TextCompletion/107-dotnet-SemanticKernel-TextCompletion.csproj
+++ b/examples/107-dotnet-SemanticKernel-TextCompletion/107-dotnet-SemanticKernel-TextCompletion.csproj
@@ -6,7 +6,6 @@
         <RootNamespace>_107_dotnet_SemanticKernel_TextCompletion</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
         <NoWarn>$(NoWarn);SKEXP0001;SKEXP0010;</NoWarn>
     </PropertyGroup>
 

--- a/examples/108-dotnet-custom-content-decoders/108-dotnet-custom-content-decoders.csproj
+++ b/examples/108-dotnet-custom-content-decoders/108-dotnet-custom-content-decoders.csproj
@@ -6,8 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>6ee042b0-aba3-4f08-8d32-33d1a6f8fed1</UserSecretsId>
-        <NoWarn>$(NoWarn);CA1050</NoWarn>
+        <NoWarn>$(NoWarn);CA1050;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/examples/109-dotnet-custom-webscraper/109-dotnet-custom-webscraper.csproj
+++ b/examples/109-dotnet-custom-webscraper/109-dotnet-custom-webscraper.csproj
@@ -5,12 +5,11 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA1050,CA2000,CA1707,CA1303,CA2007,CA1724,CA1861</NoWarn>
+        <NoWarn>$(NoWarn);CA1050;CA2000;CA1707;CA1303;CA2007;CA1724;CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/examples/201-dotnet-serverless-custom-handler/201-dotnet-serverless-custom-handler.csproj
+++ b/examples/201-dotnet-serverless-custom-handler/201-dotnet-serverless-custom-handler.csproj
@@ -5,8 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA1050,CA1303,CA1861</NoWarn>
+        <NoWarn>$(NoWarn);CA1050;CA1303;CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/examples/202-dotnet-custom-handler-as-a-service/202-dotnet-custom-handler-as-a-service.csproj
+++ b/examples/202-dotnet-custom-handler-as-a-service/202-dotnet-custom-handler-as-a-service.csproj
@@ -5,12 +5,11 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA1050,CA1303;CS4014;CA1861</NoWarn>
+        <NoWarn>$(NoWarn);CA1050;CA1303;CS4014;CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/examples/203-dotnet-using-core-nuget/203-dotnet-using-core-nuget.csproj
+++ b/examples/203-dotnet-using-core-nuget/203-dotnet-using-core-nuget.csproj
@@ -5,7 +5,6 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
@@ -13,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="sample-KM-Readme.pdf"/>
+        <None Remove="sample-KM-Readme.pdf" />
         <Content Include="sample-KM-Readme.pdf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>

--- a/examples/204-dotnet-ASP.NET-MVC-integration/204-dotnet-ASP.NET-MVC-integration.csproj
+++ b/examples/204-dotnet-ASP.NET-MVC-integration/204-dotnet-ASP.NET-MVC-integration.csproj
@@ -5,15 +5,15 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <NoWarn>$(NoWarn);CS8625,CA1050</NoWarn>
+        <NoWarn>$(NoWarn);CS8625;CA1050;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>
 
 </Project>

--- a/examples/205-dotnet-extract-text-from-docs/205-dotnet-extract-text-from-docs.csproj
+++ b/examples/205-dotnet-extract-text-from-docs/205-dotnet-extract-text-from-docs.csproj
@@ -5,32 +5,31 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA1303</NoWarn>
+        <NoWarn>$(NoWarn);CA1303;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="msexcelfile.xlsx"/>
+        <None Remove="msexcelfile.xlsx" />
         <Content Include="msexcelfile.xlsx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="mspowerpointfile.pptx"/>
+        <None Remove="mspowerpointfile.pptx" />
         <Content Include="mspowerpointfile.pptx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="mswordfile.docx"/>
+        <None Remove="mswordfile.docx" />
         <Content Include="mswordfile.docx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file1.pdf"/>
+        <None Remove="file1.pdf" />
         <Content Include="file1.pdf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="file2.pdf"/>
+        <None Remove="file2.pdf" />
         <Content Include="file2.pdf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>

--- a/examples/206-dotnet-configuration-and-logging/206-dotnet-configuration-and-logging.csproj
+++ b/examples/206-dotnet-configuration-and-logging/206-dotnet-configuration-and-logging.csproj
@@ -5,12 +5,11 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
         <NoWarn>$(NoWarn);CA1050;CA2000;CA1707;CA1303;CA2007;CA1724;CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
     <ItemGroup>
@@ -27,9 +26,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.1.0"/>
+        <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.1.0" />
     </ItemGroup>
 
 </Project>

--- a/examples/207-dotnet-expanding-chunks-on-retrieval/207-dotnet-expanding-chunks-on-retrieval.csproj
+++ b/examples/207-dotnet-expanding-chunks-on-retrieval/207-dotnet-expanding-chunks-on-retrieval.csproj
@@ -5,17 +5,16 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
         <NoWarn>$(NoWarn);CA1050;CA2000;CA1707;CA1303;CA2007;CA1724;CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\extensions\OpenAI\OpenAI.csproj"/>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\extensions\OpenAI\OpenAI.csproj" />
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="story.docx"/>
+        <None Remove="story.docx" />
         <Content Include="story.docx">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>

--- a/examples/208-dotnet-lmstudio/208-dotnet-lmstudio.csproj
+++ b/examples/208-dotnet-lmstudio/208-dotnet-lmstudio.csproj
@@ -5,12 +5,11 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
         <NoWarn>$(NoWarn);CA1050;CA2000;CA1707;CA1303;CA2007;CA1724;CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\service\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/extensions/AzureAIDocIntel/AzureAIDocIntel.csproj
+++ b/extensions/AzureAIDocIntel/AzureAIDocIntel.csproj
@@ -10,21 +10,21 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <ProjectReference Include="..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <ProjectReference Include="..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity"/>
-        <PackageReference Include="Azure.AI.FormRecognizer"/>
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="Azure.AI.FormRecognizer" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Microsoft.UnitTests"/>
+        <InternalsVisibleTo Include="Microsoft.UnitTests" />
     </ItemGroup>
 
-    <Import Project="../../code-analysis.props"/>
+    <Import Project="../../code-analysis.props" />
 
-    <Import Project="../../nuget-package.props"/>
+    <Import Project="../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -35,7 +35,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/extensions/AzureAISearch/AzureAISearch.FunctionalTests/AzureAISearch.FunctionalTests.csproj
+++ b/extensions/AzureAISearch/AzureAISearch.FunctionalTests/AzureAISearch.FunctionalTests.csproj
@@ -3,13 +3,13 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
+        <RootNamespace>Microsoft.AzureAISearch.FunctionalTests</RootNamespace>
         <IsTestProject>true</IsTestProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);IDE1006,CA1303,CA1307,CA1859,CA2007,CA2201,CS1591,CA1861,SKEXP0001</NoWarn>
+        <NoWarn>$(NoWarn);IDE1006;CA1303;CA1307;CA1859;CA2007;CA2201;CS1591;CA1861;SKEXP0001;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -18,12 +18,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.abstractions"/>
-        <PackageReference Include="Xunit.DependencyInjection"/>
-        <PackageReference Include="Xunit.DependencyInjection.Logging"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.abstractions" />
+        <PackageReference Include="Xunit.DependencyInjection" />
+        <PackageReference Include="Xunit.DependencyInjection.Logging" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/extensions/AzureAISearch/AzureAISearch.TestApplication/AzureAISearch.TestApplication.csproj
+++ b/extensions/AzureAISearch/AzureAISearch.TestApplication/AzureAISearch.TestApplication.csproj
@@ -8,8 +8,7 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA1050,CA2007,CA1826,CA1303,CA1307,SKEXP0001</NoWarn>
+        <NoWarn>$(NoWarn);CA1050;CA2007;CA1826;CA1303;CA1307;SKEXP0001;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Search.Documents"/>
+        <PackageReference Include="Azure.Search.Documents" />
     </ItemGroup>
 
 </Project>

--- a/extensions/AzureAISearch/AzureAISearch.UnitTests/AzureAISearch.UnitTests.csproj
+++ b/extensions/AzureAISearch/AzureAISearch.UnitTests/AzureAISearch.UnitTests.csproj
@@ -13,8 +13,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -27,7 +27,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj" />
-        <ProjectReference Include="..\AzureAISearch\AzureAISearch.csproj"/>
+        <ProjectReference Include="..\AzureAISearch\AzureAISearch.csproj" />
     </ItemGroup>
 
 </Project>

--- a/extensions/AzureAISearch/AzureAISearch/AzureAISearch.csproj
+++ b/extensions/AzureAISearch/AzureAISearch/AzureAISearch.csproj
@@ -10,22 +10,22 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Linq.Async"/>
-        <PackageReference Include="Azure.Identity"/>
-        <PackageReference Include="Azure.Search.Documents"/>
+        <PackageReference Include="System.Linq.Async" />
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="Azure.Search.Documents" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Microsoft.AzureAISearch.UnitTests"/>
+        <InternalsVisibleTo Include="Microsoft.AzureAISearch.UnitTests" />
     </ItemGroup>
 
-    <Import Project="../../../code-analysis.props"/>
+    <Import Project="../../../code-analysis.props" />
 
-    <Import Project="../../../nuget-package.props"/>
+    <Import Project="../../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -36,7 +36,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/extensions/AzureBlobs/AzureBlobs.csproj
+++ b/extensions/AzureBlobs/AzureBlobs.csproj
@@ -10,21 +10,21 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <ProjectReference Include="..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <ProjectReference Include="..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity"/>
-        <PackageReference Include="Azure.Storage.Blobs"/>
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="Azure.Storage.Blobs" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Microsoft.UnitTests"/>
+        <InternalsVisibleTo Include="Microsoft.UnitTests" />
     </ItemGroup>
 
-    <Import Project="../../code-analysis.props"/>
+    <Import Project="../../code-analysis.props" />
 
-    <Import Project="../../nuget-package.props"/>
+    <Import Project="../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -35,7 +35,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/extensions/AzureOpenAI/AzureOpenAI.csproj
+++ b/extensions/AzureOpenAI/AzureOpenAI.csproj
@@ -9,26 +9,26 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\OpenAI\OpenAI.csproj"/>
+        <ProjectReference Include="..\OpenAI\OpenAI.csproj" />
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <ProjectReference Include="..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <ProjectReference Include="..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity"/>
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI"/>
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Microsoft.UnitTests"/>
+        <InternalsVisibleTo Include="Microsoft.UnitTests" />
     </ItemGroup>
 
-    <Import Project="../../code-analysis.props"/>
+    <Import Project="../../code-analysis.props" />
 
-    <Import Project="../../nuget-package.props"/>
+    <Import Project="../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -39,7 +39,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/extensions/AzureQueues/AzureQueues.csproj
+++ b/extensions/AzureQueues/AzureQueues.csproj
@@ -10,21 +10,21 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <ProjectReference Include="..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <ProjectReference Include="..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity"/>
-        <PackageReference Include="Azure.Storage.Queues"/>
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="Azure.Storage.Queues" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Microsoft.UnitTests"/>
+        <InternalsVisibleTo Include="Microsoft.UnitTests" />
     </ItemGroup>
 
-    <Import Project="../../code-analysis.props"/>
+    <Import Project="../../code-analysis.props" />
 
-    <Import Project="../../nuget-package.props"/>
+    <Import Project="../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -35,7 +35,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/extensions/Elasticsearch/Elasticsearch.FunctionalTests/Elasticsearch.FunctionalTests.csproj
+++ b/extensions/Elasticsearch/Elasticsearch.FunctionalTests/Elasticsearch.FunctionalTests.csproj
@@ -3,27 +3,27 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
+        <RootNamespace>Microsoft.Elasticsearch.FunctionalTests</RootNamespace>
         <IsTestProject>true</IsTestProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
         <NoWarn>$(NoWarn);CA1859;</NoWarn>
         <DefineConstants Condition="'$(SolutionName)' == 'KernelMemoryDev'">$(DefineConstants);KernelMemoryDev</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\service\tests\Core.FunctionalTests\Core.FunctionalTests.csproj"/>
-        <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj"/>
+        <ProjectReference Include="..\..\..\service\tests\Core.FunctionalTests\Core.FunctionalTests.csproj" />
+        <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj" />
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="FreeMindLabs.KernelMemory.Elasticsearch" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.abstractions"/>
-        <PackageReference Include="Xunit.DependencyInjection"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.abstractions" />
+        <PackageReference Include="Xunit.DependencyInjection" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/extensions/LlamaSharp/LlamaSharp.FunctionalTests/LlamaSharp.FunctionalTests.csproj
+++ b/extensions/LlamaSharp/LlamaSharp.FunctionalTests/LlamaSharp.FunctionalTests.csproj
@@ -3,21 +3,22 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
+        <RootNamespace>Microsoft.LlamaSharp.FunctionalTests</RootNamespace>
         <IsTestProject>true</IsTestProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);CS1591,CA1861</NoWarn>
+        <NoWarn>$(NoWarn);CS1591;CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="Xunit.DependencyInjection"/>
-        <PackageReference Include="Xunit.DependencyInjection.Logging"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.abstractions"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Xunit.DependencyInjection" />
+        <PackageReference Include="Xunit.DependencyInjection.Logging" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.abstractions" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -29,7 +30,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj" />
+        <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj" />
     </ItemGroup>
 
 </Project>

--- a/extensions/LlamaSharp/LlamaSharp/LlamaSharp.csproj
+++ b/extensions/LlamaSharp/LlamaSharp/LlamaSharp.csproj
@@ -10,23 +10,23 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="LLamaSharp"/>
-        <PackageReference Include="LLamaSharp.Backend.Cpu"/>
-        <PackageReference Include="LLamaSharp.Backend.Cuda12"/>
-        <PackageReference Include="System.Linq.Async"/>
+        <PackageReference Include="LLamaSharp" />
+        <PackageReference Include="LLamaSharp.Backend.Cpu" />
+        <PackageReference Include="LLamaSharp.Backend.Cuda12" />
+        <PackageReference Include="System.Linq.Async" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Microsoft.UnitTests"/>
+        <InternalsVisibleTo Include="Microsoft.UnitTests" />
     </ItemGroup>
 
-    <Import Project="../../../code-analysis.props"/>
+    <Import Project="../../../code-analysis.props" />
 
-    <Import Project="../../../nuget-package.props"/>
+    <Import Project="../../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -37,7 +37,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/extensions/MongoDbAtlas/MongoDbAtlas.FunctionalTests/MongoDbAtlas.FunctionalTests.csproj
+++ b/extensions/MongoDbAtlas/MongoDbAtlas.FunctionalTests/MongoDbAtlas.FunctionalTests.csproj
@@ -3,13 +3,13 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
+        <RootNamespace>Microsoft.MongoDbAtlas.FunctionalTests</RootNamespace>
         <IsTestProject>true</IsTestProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA2007;CA1303;IDE0005;IDE1006;IDE0130;CA1711</NoWarn>
+        <NoWarn>$(NoWarn);CA2007;CA1303;IDE0005;IDE1006;IDE0130;CA1711;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -34,9 +34,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Content Update="file1-NASA-news.pdf">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </Content>
+        <Content Update="file1-NASA-news.pdf">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/extensions/MongoDbAtlas/MongoDbAtlas/MongoDbAtlas.csproj
+++ b/extensions/MongoDbAtlas/MongoDbAtlas/MongoDbAtlas.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'"/>
-        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
+        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>
@@ -18,12 +18,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="MongoDbAtlas.FunctionalTests"/>
+        <InternalsVisibleTo Include="MongoDbAtlas.FunctionalTests" />
     </ItemGroup>
 
-    <Import Project="../../../code-analysis.props"/>
+    <Import Project="../../../code-analysis.props" />
 
-    <Import Project="../../../nuget-package.props"/>
+    <Import Project="../../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -34,7 +34,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/extensions/OpenAI/OpenAI.csproj
+++ b/extensions/OpenAI/OpenAI.csproj
@@ -10,26 +10,26 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <ProjectReference Include="..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <ProjectReference Include="..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI"/>
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" />
     </ItemGroup>
 
     <ItemGroup>
-        <EmbeddedResource Include="GPT3\encoder.json"/>
-        <EmbeddedResource Include="GPT3\vocab.bpe"/>
+        <EmbeddedResource Include="GPT3\encoder.json" />
+        <EmbeddedResource Include="GPT3\vocab.bpe" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Microsoft.UnitTests"/>
-        <InternalsVisibleTo Include="Microsoft.KernelMemory.AI.AzureOpenAI"/>
+        <InternalsVisibleTo Include="Microsoft.UnitTests" />
+        <InternalsVisibleTo Include="Microsoft.KernelMemory.AI.AzureOpenAI" />
     </ItemGroup>
 
-    <Import Project="../../code-analysis.props"/>
-    
-    <Import Project="../../nuget-package.props"/>
+    <Import Project="../../code-analysis.props" />
+
+    <Import Project="../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -40,7 +40,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/extensions/Postgres/Postgres.FunctionalTests/Postgres.FunctionalTests.csproj
+++ b/extensions/Postgres/Postgres.FunctionalTests/Postgres.FunctionalTests.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
+        <RootNamespace>Microsoft.Postres.FunctionalTests</RootNamespace>
         <IsTestProject>true</IsTestProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -12,10 +13,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.abstractions"/>
-        <PackageReference Include="Xunit.DependencyInjection"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.abstractions" />
+        <PackageReference Include="Xunit.DependencyInjection" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -27,8 +28,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\service\tests\Core.FunctionalTests\Core.FunctionalTests.csproj"/>
-        <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj"/>
+        <ProjectReference Include="..\..\..\service\tests\Core.FunctionalTests\Core.FunctionalTests.csproj" />
+        <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj" />
     </ItemGroup>
 
 </Project>

--- a/extensions/Postgres/Postgres.TestApplication/Postgres.TestApplication.csproj
+++ b/extensions/Postgres/Postgres.TestApplication/Postgres.TestApplication.csproj
@@ -8,13 +8,12 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>CA1303,CA1852</NoWarn>
+        <NoWarn>$(NoWarn);CA1303;CA1852;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\service\Core\Core.csproj"/>
-        <ProjectReference Include="..\Postgres\Postgres.csproj"/>
+        <ProjectReference Include="..\..\..\service\Core\Core.csproj" />
+        <ProjectReference Include="..\Postgres\Postgres.csproj" />
     </ItemGroup>
 
 </Project>

--- a/extensions/Postgres/Postgres.UnitTests/Postgres.UnitTests.csproj
+++ b/extensions/Postgres/Postgres.UnitTests/Postgres.UnitTests.csproj
@@ -9,12 +9,12 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);CS1591</NoWarn>
+        <NoWarn>$(NoWarn);CS1591;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/extensions/Postgres/Postgres/Postgres.csproj
+++ b/extensions/Postgres/Postgres/Postgres.csproj
@@ -3,24 +3,24 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
-        <NoWarn>CA1724,NU5104,CA1308</NoWarn>
         <AssemblyName>Microsoft.KernelMemory.Postgres</AssemblyName>
         <RootNamespace>Microsoft.KernelMemory.Postgres</RootNamespace>
+        <NoWarn>$(NoWarn);CA1724;NU5104;CA1308;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Pgvector" />
     </ItemGroup>
 
-    <Import Project="../../../code-analysis.props"/>
+    <Import Project="../../../code-analysis.props" />
 
-    <Import Project="../../../nuget-package.props"/>
+    <Import Project="../../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -31,7 +31,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/extensions/Qdrant/Qdrant.FunctionalTests/Qdrant.FunctionalTests.csproj
+++ b/extensions/Qdrant/Qdrant.FunctionalTests/Qdrant.FunctionalTests.csproj
@@ -3,13 +3,13 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
+        <RootNamespace>Microsoft.Qdrant.FunctionalTests</RootNamespace>
         <IsTestProject>true</IsTestProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);IDE1006,CA1303,CA1307,CA1859,CA2007,CA2201,CS1591,CA1861,SKEXP0001</NoWarn>
+        <NoWarn>$(NoWarn);IDE1006;CA1303;CA1307;CA1859;CA2007;CA2201;CS1591;CA1861;SKEXP0001;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -18,12 +18,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.abstractions"/>
-        <PackageReference Include="Xunit.DependencyInjection"/>
-        <PackageReference Include="Xunit.DependencyInjection.Logging"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.abstractions" />
+        <PackageReference Include="Xunit.DependencyInjection" />
+        <PackageReference Include="Xunit.DependencyInjection.Logging" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/extensions/Qdrant/Qdrant.TestApplication/Qdrant.TestApplication.csproj
+++ b/extensions/Qdrant/Qdrant.TestApplication/Qdrant.TestApplication.csproj
@@ -8,13 +8,12 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>CA1303,CA1852</NoWarn>
+        <NoWarn>$(NoWarn);CA1303;CA1852;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj" />
-        <ProjectReference Include="..\Qdrant\Qdrant.csproj"/>
+        <ProjectReference Include="..\Qdrant\Qdrant.csproj" />
     </ItemGroup>
 
 </Project>

--- a/extensions/Qdrant/Qdrant.UnitTests/Qdrant.UnitTests.csproj
+++ b/extensions/Qdrant/Qdrant.UnitTests/Qdrant.UnitTests.csproj
@@ -9,12 +9,12 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);CS1591,CA1861</NoWarn>
+        <NoWarn>$(NoWarn);CS1591;CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj" />
-        <ProjectReference Include="..\Qdrant\Qdrant.csproj"/>
+        <ProjectReference Include="..\Qdrant\Qdrant.csproj" />
     </ItemGroup>
 
     <ItemGroup>
@@ -22,12 +22,12 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="Xunit.DependencyInjection"/>
-        <PackageReference Include="Xunit.DependencyInjection.Logging"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.abstractions"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Xunit.DependencyInjection" />
+        <PackageReference Include="Xunit.DependencyInjection.Logging" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.abstractions" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/extensions/Qdrant/Qdrant/Qdrant.csproj
+++ b/extensions/Qdrant/Qdrant/Qdrant.csproj
@@ -10,20 +10,20 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Linq.Async"/>
+        <PackageReference Include="System.Linq.Async" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Microsoft.Qdrant.UnitTests"/>
+        <InternalsVisibleTo Include="Microsoft.Qdrant.UnitTests" />
     </ItemGroup>
 
-    <Import Project="../../../code-analysis.props"/>
+    <Import Project="../../../code-analysis.props" />
 
-    <Import Project="../../../nuget-package.props"/>
+    <Import Project="../../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -34,7 +34,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/extensions/RabbitMQ/RabbitMQ.csproj
+++ b/extensions/RabbitMQ/RabbitMQ.csproj
@@ -10,20 +10,20 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <ProjectReference Include="..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <ProjectReference Include="..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="RabbitMQ.Client"/>
+        <PackageReference Include="RabbitMQ.Client" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Microsoft.UnitTests"/>
+        <InternalsVisibleTo Include="Microsoft.UnitTests" />
     </ItemGroup>
 
-    <Import Project="../../code-analysis.props"/>
+    <Import Project="../../code-analysis.props" />
 
-    <Import Project="../../nuget-package.props"/>
+    <Import Project="../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -34,7 +34,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/extensions/Redis/Redis.FunctionalTests/Redis.FunctionalTests.csproj
+++ b/extensions/Redis/Redis.FunctionalTests/Redis.FunctionalTests.csproj
@@ -3,27 +3,27 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
+        <RootNamespace>Microsoft.Redis.FunctionalTests</RootNamespace>
         <IsTestProject>true</IsTestProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA2007;CA1303;IDE0005;IDE1006;IDE0130</NoWarn>
+        <NoWarn>$(NoWarn);CA2007;CA1303;IDE0005;IDE1006;IDE0130;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\service\tests\Core.FunctionalTests\Core.FunctionalTests.csproj"/>
-        <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj"/>
-        <ProjectReference Include="..\Redis\Redis.csproj"/>
+        <ProjectReference Include="..\..\..\service\tests\Core.FunctionalTests\Core.FunctionalTests.csproj" />
+        <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj" />
+        <ProjectReference Include="..\Redis\Redis.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.abstractions"/>
-        <PackageReference Include="Xunit.DependencyInjection"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.abstractions" />
+        <PackageReference Include="Xunit.DependencyInjection" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -35,9 +35,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Content Update="file1-NASA-news.pdf">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </Content>
+        <Content Update="file1-NASA-news.pdf">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/extensions/Redis/Redis.TestApplication/Redis.TestApplication.csproj
+++ b/extensions/Redis/Redis.TestApplication/Redis.TestApplication.csproj
@@ -8,13 +8,12 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
         <NoWarn>$(NoWarn);CA1050;CA2007;CA1826;CA1307;SKEXP0001;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\OpenAI\OpenAI.csproj"/>
-        <ProjectReference Include="..\Redis\Redis.csproj"/>
+        <ProjectReference Include="..\..\OpenAI\OpenAI.csproj" />
+        <ProjectReference Include="..\Redis\Redis.csproj" />
     </ItemGroup>
 
 </Project>

--- a/extensions/Redis/Redis/Redis.csproj
+++ b/extensions/Redis/Redis/Redis.csproj
@@ -12,17 +12,17 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.KernelMemory.Abstractions" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <ProjectReference Include="..\..\..\service\Abstractions\Abstractions.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Linq.Async"/>
-        <PackageReference Include="NRedisStack"/>
+        <PackageReference Include="System.Linq.Async" />
+        <PackageReference Include="NRedisStack" />
     </ItemGroup>
 
-    <Import Project="../../../code-analysis.props"/>
+    <Import Project="../../../code-analysis.props" />
 
-    <Import Project="../../../nuget-package.props"/>
+    <Import Project="../../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -33,7 +33,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
-    
+
 </Project>

--- a/extensions/SQLServer/SQLServer.FunctionalTests/SQLServer.FunctionalTests.csproj
+++ b/extensions/SQLServer/SQLServer.FunctionalTests/SQLServer.FunctionalTests.csproj
@@ -3,27 +3,27 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
+        <RootNamespace>Microsoft.SQLServer.FunctionalTests</RootNamespace>
         <IsTestProject>true</IsTestProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
         <NoWarn>$(NoWarn);CA1859;</NoWarn>
         <DefineConstants Condition="'$(SolutionName)' == 'KernelMemoryDev'">$(DefineConstants);KernelMemoryDev</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\service\tests\Core.FunctionalTests\Core.FunctionalTests.csproj"/>
-        <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj"/>
+        <ProjectReference Include="..\..\..\service\tests\Core.FunctionalTests\Core.FunctionalTests.csproj" />
+        <ProjectReference Include="..\..\..\service\tests\TestHelpers\TestHelpers.csproj" />
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="KernelMemory.MemoryStorage.SqlServer" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.abstractions"/>
-        <PackageReference Include="Xunit.DependencyInjection"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.abstractions" />
+        <PackageReference Include="Xunit.DependencyInjection" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/nuget-package.props
+++ b/nuget-package.props
@@ -39,11 +39,11 @@
     <ItemGroup>
         <!-- SourceLink allows step-through debugging for source hosted on GitHub. -->
         <!-- https://github.com/dotnet/sourcelink -->
-        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="$(RepoRoot)/packages/icon.png" Link="icon.png" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="$(RepoRoot)/packages/icon.png" Link="icon.png" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/nuget.config
+++ b/nuget.config
@@ -3,17 +3,17 @@
 <configuration>
 
   <packageSources>
-    <clear/>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json"/>
-    <add key="Local" value="packages"/>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="Local" value="packages" />
   </packageSources>
 
   <packageSourceMapping>
     <packageSource key="nuget.org">
-      <package pattern="*"/>
+      <package pattern="*" />
     </packageSource>
     <packageSource key="Local">
-      <package pattern="*"/>
+      <package pattern="*" />
     </packageSource>
   </packageSourceMapping>
 

--- a/service/Abstractions/Abstractions.csproj
+++ b/service/Abstractions/Abstractions.csproj
@@ -4,28 +4,28 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>Microsoft.KernelMemory.Abstractions</AssemblyName>
         <RootNamespace>Microsoft.KernelMemory</RootNamespace>
-        <NoWarn>$(NoWarn);CA1711,CS1591,CS1574,NU5104,SKEXP0001</NoWarn>
+        <NoWarn>$(NoWarn);CA1711;CS1591;CS1574;NU5104;SKEXP0001;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
-        <PackageReference Include="Microsoft.SemanticKernel.Abstractions"/>
-        <PackageReference Include="System.Memory.Data"/>
-        <PackageReference Include="System.Numerics.Tensors"/>
-        <PackageReference Include="System.Text.Json"/>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.SemanticKernel.Abstractions" />
+        <PackageReference Include="System.Memory.Data" />
+        <PackageReference Include="System.Numerics.Tensors" />
+        <PackageReference Include="System.Text.Json" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Microsoft.Abstractions.UnitTests"/>
+        <InternalsVisibleTo Include="Microsoft.Abstractions.UnitTests" />
     </ItemGroup>
 
-    <Import Project="../../code-analysis.props"/>
+    <Import Project="../../code-analysis.props" />
 
-    <Import Project="../../nuget-package.props"/>
+    <Import Project="../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -36,7 +36,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="../../README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="../../README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/service/Core/Core.csproj
+++ b/service/Core/Core.csproj
@@ -58,7 +58,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="../../README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="../../README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/service/Service.AspNetCore/Service.AspNetCore.csproj
+++ b/service/Service.AspNetCore/Service.AspNetCore.csproj
@@ -10,13 +10,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.KernelMemory.Core" Condition="'$(SolutionName)' != 'KernelMemoryDev'"/>
-        <ProjectReference Include="..\Core\Core.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <PackageReference Include="Microsoft.KernelMemory.Core" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
+        <ProjectReference Include="..\Core\Core.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
-    <Import Project="../../code-analysis.props"/>
+    <Import Project="../../code-analysis.props" />
 
-    <Import Project="../../nuget-package.props"/>
+    <Import Project="../../nuget-package.props" />
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -27,7 +27,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="../../README.md" Link="README.md" Pack="true" PackagePath="." Visible="false"/>
+        <None Include="../../README.md" Link="README.md" Pack="true" PackagePath="." Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/service/Service/Service.csproj
+++ b/service/Service/Service.csproj
@@ -7,8 +7,7 @@
         <AssemblyName>Microsoft.KernelMemory.ServiceAssembly</AssemblyName>
         <RootNamespace>Microsoft.KernelMemory.Service</RootNamespace>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);CA2007,CA1724,CA2254,CA1031,CS1591,CA1861,CA1303,SKEXP0001</NoWarn>
+        <NoWarn>$(NoWarn);CA2007;CA1724;CA2254;CA1031;CS1591;CA1861;CA1303;SKEXP0001;</NoWarn>
         <DefineConstants Condition="'$(SolutionName)' == 'KernelMemoryDev'">$(DefineConstants);KernelMemoryDev</DefineConstants>
     </PropertyGroup>
 

--- a/service/tests/Abstractions.UnitTests/Abstractions.UnitTests.csproj
+++ b/service/tests/Abstractions.UnitTests/Abstractions.UnitTests.csproj
@@ -9,7 +9,7 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);CS1591,CA1861</NoWarn>
+        <NoWarn>$(NoWarn);CS1591;CA1861;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -21,12 +21,12 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="Xunit.DependencyInjection"/>
-        <PackageReference Include="Xunit.DependencyInjection.Logging"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.abstractions"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Xunit.DependencyInjection" />
+        <PackageReference Include="Xunit.DependencyInjection.Logging" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.abstractions" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -34,11 +34,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="Fixtures\Doc1.txt"/>
+        <None Remove="Fixtures\Doc1.txt" />
         <Content Include="Fixtures\Doc1.txt">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
-        <None Remove="Fixtures\Documents\Doc1.txt"/>
+        <None Remove="Fixtures\Documents\Doc1.txt" />
         <Content Include="Fixtures\Documents\Doc1.txt">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>

--- a/service/tests/Core.FunctionalTests/Core.FunctionalTests.csproj
+++ b/service/tests/Core.FunctionalTests/Core.FunctionalTests.csproj
@@ -3,14 +3,13 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
+        <RootNamespace>Microsoft.Core.FunctionalTests</RootNamespace>
         <IsTestProject>true</IsTestProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);IDE1006,CA1303,CA1307,CA1859,CA2007,CA2201,CS1591,CA1861,CA2000,SKEXP0001</NoWarn>
-        <RootNamespace>FunctionalTests</RootNamespace>
+        <NoWarn>$(NoWarn);IDE1006;CA1303;CA1307;CA1859;CA2007;CA2201;CS1591;CA1861;CA2000;SKEXP0001;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -38,7 +37,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="file1-NASA-news.pdf"/>
+        <None Remove="file1-NASA-news.pdf" />
         <Content Include="file1-NASA-news.pdf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>

--- a/service/tests/Core.UnitTests/Core.UnitTests.csproj
+++ b/service/tests/Core.UnitTests/Core.UnitTests.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Core\Core.csproj"/>
+        <ProjectReference Include="..\..\Core\Core.csproj" />
         <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
     </ItemGroup>
 
@@ -22,13 +22,13 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Moq" />
-        <PackageReference Include="Xunit.DependencyInjection"/>
-        <PackageReference Include="Xunit.DependencyInjection.Logging"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.abstractions"/>
+        <PackageReference Include="Xunit.DependencyInjection" />
+        <PackageReference Include="Xunit.DependencyInjection.Logging" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.abstractions" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/service/tests/Service.FunctionalTests/Service.FunctionalTests.csproj
+++ b/service/tests/Service.FunctionalTests/Service.FunctionalTests.csproj
@@ -3,14 +3,13 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
+        <RootNamespace>Microsoft.Service.FunctionalTests</RootNamespace>
         <IsTestProject>true</IsTestProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-        <NoWarn>$(NoWarn);IDE1006,CA1303,CA1307,CA1859,CA2007,CA2201,CS1591,CA1861,SKEXP0001</NoWarn>
-        <RootNamespace>ServiceFunctionalTests</RootNamespace>
+        <NoWarn>$(NoWarn);IDE1006;CA1303;CA1307;CA1859;CA2007;CA2201;CS1591;CA1861;SKEXP0001;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -24,12 +23,12 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="Xunit.DependencyInjection"/>
-        <PackageReference Include="Xunit.DependencyInjection.Logging"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.abstractions"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Xunit.DependencyInjection" />
+        <PackageReference Include="Xunit.DependencyInjection.Logging" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.abstractions" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/service/tests/TestHelpers/TestHelpers.csproj
+++ b/service/tests/TestHelpers/TestHelpers.csproj
@@ -17,7 +17,7 @@
         <ProjectReference Include="..\..\..\extensions\LlamaSharp\LlamaSharp\LlamaSharp.csproj" />
         <ProjectReference Include="..\..\..\extensions\Postgres\Postgres\Postgres.csproj" />
         <ProjectReference Include="..\..\..\extensions\Redis\Redis\Redis.csproj" />
-        <ProjectReference Include="..\..\..\extensions\MongoDbAtlas\MongoDbAtlas\MongoDbAtlas.csproj"/>
+        <ProjectReference Include="..\..\..\extensions\MongoDbAtlas\MongoDbAtlas\MongoDbAtlas.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tools/InteractiveSetup/InteractiveSetup.csproj
+++ b/tools/InteractiveSetup/InteractiveSetup.csproj
@@ -10,12 +10,12 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.KernelMemory.Core" Version="0.37.240420.2" Condition="'$(SolutionName)' != 'KernelMemoryDev'" />
-        <ProjectReference Include="..\..\service\Core\Core.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'"/>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" Condition="'$(SolutionName)' == 'KernelMemoryDev'" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageReference Include="ReadLine" Version="2.0.1"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="ReadLine" Version="2.0.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

* Several PRs include unnecessary noise and require back and forth file changes due to continuous changes automatically introduced by VisualStudio
* All projects historically used `<UserSecretsId>` which over time has caused some problems debugging unexpected behavior 

## High level description (Approach, Design)

* Change XML spacing to match VS behavior, hopefully this will stop VS from introducing unnecessary file changes
* Remove `<UserSecretsId>` from all projects
* Add some missing namespaces in test projects
* Align syntax of `<NoWarn>` across all projects, also adding `$(NoWarn)` where missing

