### PR TITLE
Azure AI Search: Add support for batching save operations

### DIFF
--- a/extensions/AzureAISearch/AzureAISearch/AzureAISearchMemory.cs
+++ b/extensions/AzureAISearch/AzureAISearch/AzureAISearchMemory.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
@@ -100,6 +99,8 @@ public class AzureAISearchMemory : IMemoryDb, IMemoryDbBatchUpsert
     /// <inheritdoc />
     public Task CreateIndexAsync(string index, int vectorSize, CancellationToken cancellationToken = default)
     {
+        // Vectors cannot be less than 2 - TODO: use different index schema
+        vectorSize = Math.Max(2, vectorSize);
         return this.CreateIndexAsync(index, AzureAISearchMemoryRecord.GetSchema(vectorSize), cancellationToken);
     }
 

--- a/extensions/AzureAISearch/AzureAISearch/AzureAISearchMemory.cs
+++ b/extensions/AzureAISearch/AzureAISearch/AzureAISearchMemory.cs
@@ -30,8 +30,7 @@ namespace Microsoft.KernelMemory.MemoryDb.AzureAISearch;
 /// * support custom schema
 /// * support custom Azure AI Search logic
 /// </summary>
-[Experimental("KMEXP03")]
-public sealed class AzureAISearchMemory : IMemoryDb
+public class AzureAISearchMemory : IMemoryDb, IMemoryDbBatchUpsert
 {
     private readonly ITextEmbeddingGenerator _embeddingGenerator;
     private readonly ILogger<AzureAISearchMemory> _log;
@@ -127,13 +126,24 @@ public sealed class AzureAISearchMemory : IMemoryDb
     /// <inheritdoc />
     public async Task<string> UpsertAsync(string index, MemoryRecord record, CancellationToken cancellationToken = default)
     {
+        var result = this.BatchUpsertAsync(index, new[] { record }, cancellationToken);
+        var id = await result.SingleAsync(cancellationToken).ConfigureAwait(false);
+        return id;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<string> BatchUpsertAsync(
+        string index,
+        IEnumerable<MemoryRecord> records,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
         var client = this.GetSearchClient(index);
-        AzureAISearchMemoryRecord localRecord = AzureAISearchMemoryRecord.FromMemoryRecord(record);
+        var localRecords = records.Select(AzureAISearchMemoryRecord.FromMemoryRecord);
 
         try
         {
             await client.IndexDocumentsAsync(
-                IndexDocumentsBatch.Upload(new[] { localRecord }),
+                IndexDocumentsBatch.Upload(localRecords),
                 new IndexDocumentsOptions { ThrowOnAnyError = true },
                 cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -142,7 +152,10 @@ public sealed class AzureAISearchMemory : IMemoryDb
             throw new IndexNotFound(e.Message, e);
         }
 
-        return record.Id;
+        foreach (var record in records)
+        {
+            yield return record.Id;
+        }
     }
 
     /// <inheritdoc />
@@ -352,25 +365,6 @@ public sealed class AzureAISearchMemory : IMemoryDb
         }
 
         return false;
-    }
-
-    private async IAsyncEnumerable<string> UpsertBatchAsync(
-        string index,
-        IEnumerable<MemoryRecord> records,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
-    {
-        var client = this.GetSearchClient(index);
-
-        foreach (MemoryRecord record in records)
-        {
-            var localRecord = AzureAISearchMemoryRecord.FromMemoryRecord(record);
-            await client.IndexDocumentsAsync(
-                IndexDocumentsBatch.Upload(new[] { localRecord }),
-                new IndexDocumentsOptions { ThrowOnAnyError = true },
-                cancellationToken: cancellationToken).ConfigureAwait(false);
-
-            yield return record.Id;
-        }
     }
 
     /// <summary>
@@ -625,7 +619,7 @@ public sealed class AzureAISearchMemory : IMemoryDb
 
     private static double ScoreToCosineSimilarity(double score)
     {
-        return 2 - 1 / score;
+        return 2 - (1 / score);
     }
 
     private static double CosineSimilarityToScore(double similarity)

--- a/service/Core/Configuration/KernelMemoryConfig.cs
+++ b/service/Core/Configuration/KernelMemoryConfig.cs
@@ -55,6 +55,11 @@ public class KernelMemoryConfig
         public List<string> MemoryDbTypes { get; set; } = new();
 
         /// <summary>
+        /// How many documents to send in a single batch memory operation (if the Memory Db supports batching).
+        /// </summary>
+        public int UpsertBatchSize { get; set; } = 1;
+
+        /// <summary>
         /// The OCR service used to recognize text in images.
         /// </summary>
         public string ImageOcrType { get; set; } = string.Empty;

--- a/service/Core/Configuration/KernelMemoryConfig.cs
+++ b/service/Core/Configuration/KernelMemoryConfig.cs
@@ -55,9 +55,10 @@ public class KernelMemoryConfig
         public List<string> MemoryDbTypes { get; set; } = new();
 
         /// <summary>
-        /// How many documents to send in a single batch memory operation (if the Memory Db supports batching).
+        /// How many memory DB records to insert at once when extracting memories
+        /// from uploaded documents (used only if the Memory Db supports batching).
         /// </summary>
-        public int UpsertBatchSize { get; set; } = 1;
+        public int MemoryDbUpsertBatchSize { get; set; } = 1;
 
         /// <summary>
         /// The OCR service used to recognize text in images.

--- a/service/Core/Handlers/SaveRecordsHandler.cs
+++ b/service/Core/Handlers/SaveRecordsHandler.cs
@@ -45,10 +45,12 @@ public sealed class SaveRecordsHandler : IPipelineStepHandler
 
     private readonly IPipelineOrchestrator _orchestrator;
     private readonly List<IMemoryDb> _memoryDbs;
+    private readonly List<IMemoryDb> _memoryDbsWithSingleUpsert;
+    private readonly List<IMemoryDb> _memoryDbsWithBatchUpsert;
     private readonly ILogger<SaveRecordsHandler> _log;
     private readonly bool _embeddingGenerationEnabled;
-
     private readonly int _upsertBatchSize;
+    private readonly bool _usingBatchUpsert;
 
     /// <inheritdoc />
     public string StepName { get; }
@@ -74,7 +76,7 @@ public sealed class SaveRecordsHandler : IPipelineStepHandler
         this._orchestrator = orchestrator;
         this._memoryDbs = orchestrator.GetMemoryDbs();
 
-        this._upsertBatchSize = (config ?? new KernelMemoryConfig()).DataIngestion.UpsertBatchSize;
+        this._upsertBatchSize = (config ?? new KernelMemoryConfig()).DataIngestion.MemoryDbUpsertBatchSize;
 
         if (this._memoryDbs.Count < 1)
         {
@@ -83,6 +85,20 @@ public sealed class SaveRecordsHandler : IPipelineStepHandler
         else
         {
             this._log.LogInformation("Handler {0} ready, {1} vector storages", stepName, this._memoryDbs.Count);
+        }
+
+        // Ideally we want to call MarkProcessedBy(this) after storing each memory record, to avoid unnecessary
+        // duplicate upserts in case of transient errors. However, if there's a DB supporting batch upserts
+        // this optimization is not available (without further refactoring, marking each file for each memory DB).
+        // Here we split the list of DBs in two lists, those supporting batching and those not, prioritizing
+        // the single upsert if possible, to have the best retry strategy when possible.
+        this._memoryDbsWithSingleUpsert = this._memoryDbs;
+        this._memoryDbsWithBatchUpsert = new List<IMemoryDb>();
+        if (this._upsertBatchSize > 1)
+        {
+            this._memoryDbsWithSingleUpsert = this._memoryDbs.Where(x => x is not IMemoryDbBatchUpsert).ToList();
+            this._memoryDbsWithBatchUpsert = this._memoryDbs.Where(x => x is IMemoryDbBatchUpsert).ToList();
+            this._usingBatchUpsert = this._memoryDbsWithBatchUpsert.Count > 0;
         }
     }
 
@@ -95,215 +111,186 @@ public sealed class SaveRecordsHandler : IPipelineStepHandler
         await this.DeletePreviousRecordsAsync(pipeline, cancellationToken).ConfigureAwait(false);
         pipeline.PreviousExecutionsToPurge = new List<DataPipeline>();
 
-        return this._embeddingGenerationEnabled
-            ? await this.SaveEmbeddingsAsync(pipeline, cancellationToken).ConfigureAwait(false)
-            : await this.SavePartitionsAsync(pipeline, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Loop through all the EMBEDDINGS generated, creating a memory record for each one
-    /// </summary>
-    public async Task<(bool success, DataPipeline updatedPipeline)> SaveEmbeddingsAsync(
-        DataPipeline pipeline, CancellationToken cancellationToken = default)
-    {
-        var embeddingsFound = false;
+        var recordsFound = false;
 
         // TODO: replace with ConditionalWeakTable indexing on this._memoryDbs
         var createdIndexes = new HashSet<string>();
 
-        // For each embedding file => For each Memory DB => Upsert record
-        foreach (FileDetailsWithRecordId[] embeddingFiles in GetListOfEmbeddingFiles(pipeline).Chunk(this._upsertBatchSize))
+        // Case 1 (_embeddingGenerationEnabled = true): Loop through all the EMBEDDINGS generated, creating a memory record for each one
+        // Case 2 (_embeddingGenerationEnabled = false): Loop through all the PARTITIONS and SYNTHETIC chunks, creating a memory record for each one
+        var sourceFiles = this._embeddingGenerationEnabled
+            ? GetListOfEmbeddingFiles(pipeline).Chunk(this._upsertBatchSize)
+            : GetListOfPartitionAndSyntheticFiles(pipeline).Chunk(this._upsertBatchSize);
+
+        foreach (FileDetailsWithRecordId[] files in sourceFiles)
         {
+            if (files.Length == 0) { continue; }
+
+            // List of records to upsert, used only when batching
             var records = new List<MemoryRecord>();
-
-            foreach (FileDetailsWithRecordId embeddingFile in embeddingFiles)
-            {
-                if (embeddingFile.File.AlreadyProcessedBy(this))
-                {
-                    embeddingsFound = true;
-                    this._log.LogTrace("File {0} already processed by this handler", embeddingFile.File.Name);
-                    continue;
-                }
-
-                string vectorJson = await this._orchestrator.ReadTextFileAsync(pipeline, embeddingFile.File.Name, cancellationToken).ConfigureAwait(false);
-                EmbeddingFileContent? embeddingData = JsonSerializer.Deserialize<EmbeddingFileContent>(vectorJson.RemoveBOM().Trim());
-                if (embeddingData == null)
-                {
-                    throw new OrchestrationException($"Unable to deserialize embedding file {embeddingFile.File.Name}");
-                }
-
-                embeddingsFound = true;
-
-                DataPipeline.FileDetails fileDetails = pipeline.GetFile(embeddingFile.File.ParentId);
-                string partitionContent = await this._orchestrator.ReadTextFileAsync(pipeline, embeddingData.SourceFileName, cancellationToken).ConfigureAwait(false);
-                string url = await this.GetSourceUrlAsync(pipeline, fileDetails, cancellationToken).ConfigureAwait(false);
-
-                var record = PrepareRecord(
-                    pipeline: pipeline,
-                    recordId: embeddingFile.RecordId,
-                    fileName: fileDetails.Name,
-                    url: url,
-                    fileId: embeddingFile.File.ParentId,
-                    partitionFileId: embeddingFile.File.SourcePartitionId,
-                    partitionContent: partitionContent,
-                    partitionNumber: embeddingFile.File.PartitionNumber,
-                    sectionNumber: embeddingFile.File.SectionNumber,
-                    partitionEmbedding: embeddingData.Vector,
-                    embeddingGeneratorProvider: embeddingData.GeneratorProvider,
-                    embeddingGeneratorName: embeddingData.GeneratorName,
-                    embeddingFile.File.Tags);
-
-                records.Add(record);
-            }
-
-            await this.SaveRecordsAsync(pipeline, createdIndexes, records, cancellationToken).ConfigureAwait(false);
-
-            foreach (FileDetailsWithRecordId embeddingFile in embeddingFiles)
-            {
-                embeddingFile.File.MarkProcessedBy(this);
-            }
-        }
-
-        if (!embeddingsFound)
-        {
-            this._log.LogWarning("Pipeline '{0}/{1}': embeddings not found, cannot save embeddings, moving to next pipeline step.", pipeline.Index, pipeline.DocumentId);
-        }
-
-        return (true, pipeline);
-    }
-
-    /// <summary>
-    /// Loop through all the PARTITIONS and SYNTHETIC chunks, creating a memory record for each one
-    /// </summary>
-    public async Task<(bool success, DataPipeline updatedPipeline)> SavePartitionsAsync(
-        DataPipeline pipeline, CancellationToken cancellationToken = default)
-    {
-        var partitionsFound = false;
-
-        // TODO: replace with ConditionalWeakTable indexing on this._memoryDbs
-        var createdIndexes = new HashSet<string>();
-
-        // Create records only for partitions (text chunks) and synthetic data
-        foreach (FileDetailsWithRecordId[] files in GetListOfPartitionAndSyntheticFiles(pipeline).Chunk(this._upsertBatchSize))
-        {
-            var records = new List<MemoryRecord>();
-
             foreach (FileDetailsWithRecordId file in files)
             {
                 if (file.File.AlreadyProcessedBy(this))
                 {
-                    partitionsFound = true;
+                    recordsFound = true;
                     this._log.LogTrace("File {0} already processed by this handler", file.File.Name);
                     continue;
                 }
 
-                partitionsFound = true;
+                MemoryRecord record;
+                DataPipeline.FileDetails fileDetails = pipeline.GetFile(file.File.ParentId);
 
-                switch (file.File.MimeType)
+                // Get source URL (only for web pages)
+                string webPageUrl = await this.GetSourceUrlAsync(pipeline, fileDetails, cancellationToken).ConfigureAwait(false);
+
+                if (this._embeddingGenerationEnabled)
                 {
-                    case MimeTypes.PlainText:
-                    case MimeTypes.MarkDown:
+                    recordsFound = true;
 
-                        DataPipeline.FileDetails partitionFileDetails = pipeline.GetFile(file.File.ParentId);
-                        string partitionContent = await this._orchestrator.ReadTextFileAsync(pipeline, file.File.Name, cancellationToken).ConfigureAwait(false);
-                        string url = await this.GetSourceUrlAsync(pipeline, partitionFileDetails, cancellationToken).ConfigureAwait(false);
+                    // Read vector data from embedding file
+                    string vectorJson = await this._orchestrator.ReadTextFileAsync(pipeline, file.File.Name, cancellationToken).ConfigureAwait(false);
+                    EmbeddingFileContent? embeddingData = JsonSerializer.Deserialize<EmbeddingFileContent>(vectorJson.RemoveBOM().Trim());
+                    if (embeddingData == null) { throw new OrchestrationException($"Unable to deserialize embedding file {file.File.Name}"); }
 
-                        var record = PrepareRecord(
-                            pipeline: pipeline,
-                            recordId: file.RecordId,
-                            fileName: partitionFileDetails.Name,
-                            url: url,
-                            fileId: file.File.ParentId,
-                            partitionFileId: file.File.Id,
-                            partitionContent: partitionContent,
-                            partitionNumber: partitionFileDetails.PartitionNumber,
-                            sectionNumber: partitionFileDetails.SectionNumber,
-                            partitionEmbedding: new Embedding(),
-                            embeddingGeneratorProvider: "",
-                            embeddingGeneratorName: "",
-                            file.File.Tags);
+                    // Get text partition content
+                    string partitionContent = await this._orchestrator.ReadTextFileAsync(pipeline, embeddingData.SourceFileName, cancellationToken).ConfigureAwait(false);
 
-                        records.Add(record);
-                        break;
-
-                    default:
-                        this._log.LogWarning("File {0} cannot be used to generate embedding, type not supported", file.File.Name);
-                        continue;
+                    // Prepare record, including embedding details
+                    record = PrepareRecord(
+                        pipeline: pipeline,
+                        recordId: file.RecordId,
+                        fileName: fileDetails.Name,
+                        url: webPageUrl,
+                        fileId: file.File.ParentId,
+                        partitionFileId: file.File.SourcePartitionId,
+                        partitionContent: partitionContent,
+                        partitionNumber: file.File.PartitionNumber,
+                        sectionNumber: file.File.SectionNumber,
+                        partitionEmbedding: embeddingData.Vector,
+                        embeddingGeneratorProvider: embeddingData.GeneratorProvider,
+                        embeddingGeneratorName: embeddingData.GeneratorName,
+                        file.File.Tags);
                 }
+                else
+                {
+                    switch (file.File.MimeType)
+                    {
+                        case MimeTypes.PlainText:
+                        case MimeTypes.MarkDown:
+                            recordsFound = true;
+
+                            // Get text partition content
+                            string partitionContent = await this._orchestrator.ReadTextFileAsync(pipeline, file.File.Name, cancellationToken).ConfigureAwait(false);
+
+                            // Prepare record, without embedding data
+                            record = PrepareRecord(
+                                pipeline: pipeline,
+                                recordId: file.RecordId,
+                                fileName: fileDetails.Name,
+                                url: webPageUrl,
+                                fileId: file.File.ParentId,
+                                partitionFileId: file.File.Id,
+                                partitionContent: partitionContent,
+                                partitionNumber: fileDetails.PartitionNumber,
+                                sectionNumber: fileDetails.SectionNumber,
+                                partitionEmbedding: new Embedding(),
+                                embeddingGeneratorProvider: "",
+                                embeddingGeneratorName: "",
+                                file.File.Tags);
+                            break;
+
+                        default:
+                            this._log.LogWarning("File {0} cannot be used to generate embedding, type not supported", file.File.Name);
+                            // skip record
+                            continue;
+                    }
+                }
+
+                records.Add(record);
+
+                foreach (IMemoryDb db in this._memoryDbsWithSingleUpsert)
+                {
+                    await this.CreateIndexOnceAsync(db, createdIndexes, pipeline.Index, record.Vector.Length, cancellationToken).ConfigureAwait(false);
+                    await this.SaveRecordAsync(pipeline, db, record, createdIndexes, cancellationToken).ConfigureAwait(false);
+                }
+
+                // If possible mark the file as processed now, so in case of retries it won't be processed again
+                if (!this._usingBatchUpsert) { file.File.MarkProcessedBy(this); }
             }
 
-            await this.SaveRecordsAsync(pipeline, createdIndexes, records, cancellationToken).ConfigureAwait(false);
-
-            foreach (FileDetailsWithRecordId file in files)
+            if (this._usingBatchUpsert)
             {
-                file.File.MarkProcessedBy(this);
+                if (records.Count > 0)
+                {
+                    foreach (IMemoryDb db in this._memoryDbsWithBatchUpsert)
+                    {
+                        await this.CreateIndexOnceAsync(db, createdIndexes, pipeline.Index, records[0].Vector.Length, cancellationToken).ConfigureAwait(false);
+                        await this.SaveRecordsBatchAsync(pipeline, db, records, createdIndexes, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+
+                foreach (FileDetailsWithRecordId file in files)
+                {
+                    file.File.MarkProcessedBy(this);
+                }
             }
         }
 
-        if (!partitionsFound)
+        if (!recordsFound)
         {
-            this._log.LogWarning("Pipeline '{0}/{1}': partitions and synthetic records not found, cannot save, moving to next pipeline step.", pipeline.Index, pipeline.DocumentId);
+            this._log.LogWarning("Pipeline '{0}/{1}': step {2}: no records found, cannot save, moving to next pipeline step.", pipeline.Index, pipeline.DocumentId, this.StepName);
         }
 
         return (true, pipeline);
     }
 
-    private async Task SaveRecordsAsync(DataPipeline pipeline, HashSet<string> createdIndexes, List<MemoryRecord> records, CancellationToken cancellationToken)
+    private static IEnumerable<FileDetailsWithRecordId> GetListOfEmbeddingFiles(DataPipeline pipeline)
     {
-        if (records.Count != 0)
+        return pipeline.Files.SelectMany(f1 => f1.GeneratedFiles.Where(
+                f2 => f2.Value.ArtifactType == DataPipeline.ArtifactTypes.TextEmbeddingVector)
+            .Select(x => new FileDetailsWithRecordId(pipeline, x.Value)));
+    }
+
+    private static IEnumerable<FileDetailsWithRecordId> GetListOfPartitionAndSyntheticFiles(DataPipeline pipeline)
+    {
+        return pipeline.Files.SelectMany(f1 => f1.GeneratedFiles.Where(
+                f2 => f2.Value.ArtifactType is DataPipeline.ArtifactTypes.TextPartition or DataPipeline.ArtifactTypes.SyntheticData)
+            .Select(x => new FileDetailsWithRecordId(pipeline, x.Value)));
+    }
+
+    private async Task SaveRecordAsync(DataPipeline pipeline, IMemoryDb db, MemoryRecord record, HashSet<string> createdIndexes, CancellationToken cancellationToken)
+    {
+        try
         {
-            foreach (IMemoryDb client in this._memoryDbs)
-            {
-                if (client is IMemoryDbBatchUpsert batchClient)
-                {
-                    // Memory supports batch operations, so we can upsert multiple records at once
-                    try
-                    {
-                        await this.CreateIndexOnceAsync(client, createdIndexes, pipeline.Index, records[0].Vector.Length, cancellationToken).ConfigureAwait(false);
-
-                        this._log.LogTrace("Batch saving {0} records in index '{1}'", records.Count, pipeline.Index);
-                        await SaveAndLogRecordsAsync(pipeline, records, batchClient, cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (IndexNotFound e)
-                    {
-                        this._log.LogWarning(e, "Index {0} not found, attempting to create it", pipeline.Index);
-                        await this.CreateIndexOnceAsync(client, createdIndexes, pipeline.Index, records[0].Vector.Length, cancellationToken, true).ConfigureAwait(false);
-
-                        this._log.LogTrace("Retry: Batch saving {0} records in index '{1}'", records.Count, pipeline.Index);
-                        await SaveAndLogRecordsAsync(pipeline, records, batchClient, cancellationToken).ConfigureAwait(false);
-                    }
-                }
-                else
-                {
-                    // Memory does not support batch operations, so we have to upsert one by one
-                    foreach (var record in records)
-                    {
-                        try
-                        {
-                            await this.CreateIndexOnceAsync(client, createdIndexes, pipeline.Index, record.Vector.Length, cancellationToken).ConfigureAwait(false);
-
-                            this._log.LogTrace("Saving record {0} in index '{1}'", record.Id, pipeline.Index);
-                            await client.UpsertAsync(pipeline.Index, record, cancellationToken).ConfigureAwait(false);
-                        }
-                        catch (IndexNotFound e)
-                        {
-                            this._log.LogWarning(e, "Index {0} not found, attempting to create it", pipeline.Index);
-                            await this.CreateIndexOnceAsync(client, createdIndexes, pipeline.Index, record.Vector.Length, cancellationToken, true).ConfigureAwait(false);
-
-                            this._log.LogTrace("Retry: saving record {0} in index '{1}'", record.Id, pipeline.Index);
-                            await client.UpsertAsync(pipeline.Index, record, cancellationToken).ConfigureAwait(false);
-                        }
-                    }
-                }
-            }
+            this._log.LogTrace("Saving record {0} in index '{1}'", record.Id, pipeline.Index);
+            await db.UpsertAsync(pipeline.Index, record, cancellationToken).ConfigureAwait(false);
         }
-
-        async Task SaveAndLogRecordsAsync(DataPipeline pipeline, List<MemoryRecord> records, IMemoryDbBatchUpsert batchClient, CancellationToken cancellationToken)
+        catch (IndexNotFound e)
         {
-            await foreach (var recordId in batchClient.BatchUpsertAsync(pipeline.Index, records, cancellationToken).ConfigureAwait(false))
-            {
-                this._log.LogTrace("Saved record {0} in index '{1}'", recordId, pipeline.Index);
-            }
+            this._log.LogWarning(e, "Index {0} not found, attempting to create it", pipeline.Index);
+            await this.CreateIndexOnceAsync(db, createdIndexes, pipeline.Index, record.Vector.Length, cancellationToken, true).ConfigureAwait(false);
+
+            this._log.LogTrace("Retry: saving record {0} in index '{1}'", record.Id, pipeline.Index);
+            await db.UpsertAsync(pipeline.Index, record, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task SaveRecordsBatchAsync(DataPipeline pipeline, IMemoryDb db, List<MemoryRecord> records, HashSet<string> createdIndexes, CancellationToken cancellationToken)
+    {
+        var dbBatch = ((IMemoryDbBatchUpsert)db);
+        ArgumentNullExceptionEx.ThrowIfNull(dbBatch, nameof(dbBatch), $"{db.GetType().FullName} doesn't implement {nameof(IMemoryDbBatchUpsert)}");
+        try
+        {
+            this._log.LogTrace("Saving batch of {0} records in index '{1}'", records.Count, pipeline.Index);
+            await dbBatch.BatchUpsertAsync(pipeline.Index, records, cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (IndexNotFound e)
+        {
+            this._log.LogWarning(e, "Index {0} not found, attempting to create it", pipeline.Index);
+            await this.CreateIndexOnceAsync(db, createdIndexes, pipeline.Index, records[0].Vector.Length, cancellationToken, true).ConfigureAwait(false);
+
+            this._log.LogTrace("Retry: Saving batch of {0} records in index '{1}'", records.Count, pipeline.Index);
+            await dbBatch.BatchUpsertAsync(pipeline.Index, records, cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -333,20 +320,6 @@ public sealed class SaveRecordsHandler : IPipelineStepHandler
                 }
             }
         }
-    }
-
-    private static IEnumerable<FileDetailsWithRecordId> GetListOfEmbeddingFiles(DataPipeline pipeline)
-    {
-        return pipeline.Files.SelectMany(f1 => f1.GeneratedFiles.Where(
-                f2 => f2.Value.ArtifactType == DataPipeline.ArtifactTypes.TextEmbeddingVector)
-            .Select(x => new FileDetailsWithRecordId(pipeline, x.Value)));
-    }
-
-    private static IEnumerable<FileDetailsWithRecordId> GetListOfPartitionAndSyntheticFiles(DataPipeline pipeline)
-    {
-        return pipeline.Files.SelectMany(f1 => f1.GeneratedFiles.Where(
-                f2 => f2.Value.ArtifactType == DataPipeline.ArtifactTypes.TextPartition || f2.Value.ArtifactType == DataPipeline.ArtifactTypes.SyntheticData)
-            .Select(x => new FileDetailsWithRecordId(pipeline, x.Value)));
     }
 
     private async Task CreateIndexOnceAsync(

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -144,8 +144,9 @@
       "MemoryDbTypes": [
         "SimpleVectorDb"
       ],
-      // How many documents to send in a single batch memory operation (if the Memory Db supports batching).
-      "UpsertBatchSize": 1,
+      // How many memory DB records to insert at once when extracting memories from
+      // uploaded documents (used only if the Memory Db supports batching).
+      "MemoryDbUpsertBatchSize": 1,
       // "None" or "AzureAIDocIntel"
       "ImageOcrType": "None",
       // Partitioning / Chunking settings

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -144,6 +144,8 @@
       "MemoryDbTypes": [
         "SimpleVectorDb"
       ],
+      // How many documents to send in a single batch memory operation (if the Memory Db supports batching).
+      "UpsertBatchSize": 1,
       // "None" or "AzureAIDocIntel"
       "ImageOcrType": "None",
       // Partitioning / Chunking settings


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

Add support for batch support in Azure AI Search and SaveRecordsHandler.

## High level description (Approach, Design)

* New `KernelMemory:DataIngestion:MemoryDbUpsertBatchSize` setting (default: 1) to manage memory records batch size.
* Implement the new optional `IMemoryDbBatchUpsert` interface in `AzureAISearchMemory`.
* Fix old bug in `AzureAISearchMemory` occurring when `EmbeddingGenerationEnabled` is `false`.
