### PR TITLE
Remove reduntant method calling

### DIFF
--- a/extensions/AzureQueues/DependencyInjection.cs
+++ b/extensions/AzureQueues/DependencyInjection.cs
@@ -13,8 +13,6 @@ public static partial class KernelMemoryBuilderExtensions
 {
     public static IKernelMemoryBuilder WithAzureQueuesOrchestration(this IKernelMemoryBuilder builder, AzureQueuesConfig config)
     {
-        config.Validate();
-
         builder.Services.AddAzureQueuesOrchestration(config);
         return builder;
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
In the following method:

https://github.com/microsoft/kernel-memory/blob/0d82c621df6150b59046fbd2b78afc97726beda0/extensions/AzureQueues/DependencyInjection.cs#L14-L21

There is a call to the `AzureQueuesConfig.Validate` method, but then the AddAzureQueuesOrchestration method is invoked, that in turns calls `AzureQueuesConfig.Validate` again:

https://github.com/microsoft/kernel-memory/blob/0d82c621df6150b59046fbd2b78afc97726beda0/extensions/AzureQueues/DependencyInjection.cs#L27

So, it is possible to safely remove the first invocation. 
