### PR TITLE
Remove "support hybrid search" from TODO list

### DIFF
--- a/extensions/AzureAISearch/AzureAISearch/AzureAISearchMemory.cs
+++ b/extensions/AzureAISearch/AzureAISearch/AzureAISearchMemory.cs
@@ -26,7 +26,6 @@ namespace Microsoft.KernelMemory.MemoryDb.AzureAISearch;
 /// Azure AI Search connector for Kernel Memory
 /// TODO:
 /// * support semantic search
-/// * support hybrid search
 /// * support custom schema
 /// * support custom Azure AI Search logic
 /// </summary>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
Now that Azure AI Search supports hybrid search (see https://github.com/microsoft/kernel-memory/pull/428), the corresponding item from the TODO list of **AzureAISearchMemory.cs** can be removed.

