### PR TITLE
Add missing properties to RabbitMQ messages

### DIFF
--- a/extensions/RabbitMQ/RabbitMQPipeline.cs
+++ b/extensions/RabbitMQ/RabbitMQPipeline.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -113,8 +112,7 @@ public sealed class RabbitMQPipeline : IQueue
         {
             try
             {
-                this._log.LogDebug("Message '{0}' received, expires after {1}ms", args.BasicProperties.MessageId,
-                    TimeSpan.FromMilliseconds(Convert.ToDouble(args.BasicProperties.Expiration, CultureInfo.InvariantCulture)).TotalMilliseconds);
+                this._log.LogDebug("Message '{0}' received, expires after {1}ms", args.BasicProperties.MessageId, args.BasicProperties.Expiration);
 
                 byte[] body = args.Body.ToArray();
                 string message = Encoding.UTF8.GetString(body);

--- a/extensions/RabbitMQ/RabbitMqConfig.cs
+++ b/extensions/RabbitMQ/RabbitMqConfig.cs
@@ -6,9 +6,35 @@ namespace Microsoft.KernelMemory;
 
 public class RabbitMqConfig
 {
+    /// <summary>
+    /// RabbitMQ hostname, e.g. "127.0.0.1"
+    /// </summary>
     public string Host { get; set; } = "";
+
+    /// <summary>
+    /// TCP port for the connection, e.g. 5672
+    /// </summary>
     public int Port { get; set; } = 0;
+
+    /// <summary>
+    /// Authentication username
+    /// </summary>
     public string Username { get; set; } = "";
+
+    /// <summary>
+    /// Authentication password
+    /// </summary>
     public string Password { get; set; } = "";
+
+    /// <summary>
+    /// RabbitMQ virtual host name, e.g. "/"
+    /// See https://www.rabbitmq.com/docs/vhosts
+    /// </summary>
     public string VirtualHost { get; set; } = "/";
+
+    /// <summary>
+    /// How long to retry messages delivery, ie how long to retry, in seconds.
+    /// Default: 3600 second, 1 hour.
+    /// </summary>
+    public int MessageTTLSecs { get; set; } = 3600;
 }

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -359,7 +359,8 @@
         "Port": "5672",
         "Username": "user",
         "Password": "",
-        "VirtualHost": "/"
+        "VirtualHost": "/",
+        "MessageTTLSecs": 3600
       },
       "Redis": {
         // Redis connection string, e.g. "localhost:6379,password=..."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
See https://github.com/microsoft/kernel-memory/issues/408#issuecomment-2063342815. This PR sets the `MessageId` and `Expiration` properties for RabbitMQ messages.

