### PR TITLE
Add more log settings to appsettings.json, change defaults

### DIFF
--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -22,6 +22,19 @@
       //      "Microsoft.KernelMemory.ContentStorage.AzureBlobs": "Information",
       //      "Microsoft.KernelMemory.Pipeline.Queue.AzureQueues": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "Console": {
+      "LogToStandardErrorThreshold": "Critical",
+      "FormatterName": "simple",
+      "FormatterOptions": {
+        "TimestampFormat": "[HH:mm:ss.fff] ",
+        "SingleLine": true,
+        "UseUtcTimestamp": false,
+        "IncludeScopes": false,
+        "JsonWriterOptions": {
+          "Indented": true
+        }
+      }
     }
   },
   "KernelMemory": {


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

Show how to configure logger.

## High level description (Approach, Design)

Add more log settings to appsettings.json, to help with the configuration. No code changes, these are automatically picked up by .NET.

Change/Set defaults:

* "**TimestampFormat**": "[HH:mm:ss.fff] "
* "**SingleLine**": true
* "**UseUtcTimestamp**": false
* "**IncludeScopes**": false
* "**JsonWriterOptions**": { "Indented": true  }
* "**LogToStandardErrorThreshold**": "Critical"
   * see https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.console.consoleloggeroptions.logtostandarderrorthreshold