### PR TITLE
Fix for when RangeUsed() in worksheet returns null.

### DIFF
--- a/service/Core/DataFormats/Office/MsExcelDecoder.cs
+++ b/service/Core/DataFormats/Office/MsExcelDecoder.cs
@@ -64,7 +64,13 @@ public sealed class MsExcelDecoder : IContentDecoder
                 sb.AppendLine(this._config.WorksheetNumberTemplate.Replace("{number}", $"{worksheetNumber}", StringComparison.OrdinalIgnoreCase));
             }
 
-            foreach (IXLRangeRow? row in worksheet.RangeUsed().RowsUsed())
+            var rowsUsed = worksheet.RangeUsed()?.RowsUsed();
+            if (rowsUsed == null)
+            {
+                continue;
+            }
+
+            foreach (IXLRangeRow? row in rowsUsed)
             {
                 if (row == null) { continue; }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
I have an excel document that has a special worksheet which is not even visible in Excel. I don't know the specifics behind this, but 
`RangeUsed()` returns null for this worksheet. This PR addresses this by skipping the worksheets for which RangeUsed() returns null.

## High level description (Approach, Design)
Fix for a special kind of Excel document.