### PR TITLE
Add support for embedding dimensions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,9 +53,9 @@
   </ItemGroup>
   <!-- Semantic Kernel -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.10.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.10.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.10.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.11.1" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.11.1" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.11.1" />
   </ItemGroup>
   <!-- Documentation -->
   <ItemGroup>

--- a/extensions/AzureOpenAI/AzureOpenAIConfig.cs
+++ b/extensions/AzureOpenAI/AzureOpenAIConfig.cs
@@ -68,7 +68,9 @@ public class AzureOpenAIConfig
     public int MaxRetries { get; set; } = 10;
 
     /// <summary>
-    /// The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.
+    /// The number of dimensions output embeddings should have.
+    /// Only supported in "text-embedding-3" and later models developed with
+    /// MRL, see https://arxiv.org/abs/2205.13147
     /// </summary>
     public int? EmbeddingDimensions { get; set; }
 
@@ -126,7 +128,7 @@ public class AzureOpenAIConfig
             throw new ConfigurationException($"Azure OpenAI: {nameof(this.MaxTokenTotal)} cannot be less than 1");
         }
 
-        if (this.EmbeddingDimensions.HasValue && this.EmbeddingDimensions.Value < 1)
+        if (this.EmbeddingDimensions is < 1)
         {
             throw new ConfigurationException($"Azure OpenAI: {nameof(this.EmbeddingDimensions)} cannot be less than 1");
         }

--- a/extensions/AzureOpenAI/AzureOpenAIConfig.cs
+++ b/extensions/AzureOpenAI/AzureOpenAIConfig.cs
@@ -68,6 +68,11 @@ public class AzureOpenAIConfig
     public int MaxRetries { get; set; } = 10;
 
     /// <summary>
+    /// The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.
+    /// </summary>
+    public int? EmbeddingDimensions { get; set; }
+
+    /// <summary>
     /// Set credentials manually from code
     /// </summary>
     /// <param name="credential">Token credentials</param>
@@ -119,6 +124,11 @@ public class AzureOpenAIConfig
         if (this.MaxTokenTotal < 1)
         {
             throw new ConfigurationException($"Azure OpenAI: {nameof(this.MaxTokenTotal)} cannot be less than 1");
+        }
+
+        if (this.EmbeddingDimensions.HasValue && this.EmbeddingDimensions.Value < 1)
+        {
+            throw new ConfigurationException($"Azure OpenAI: {nameof(this.EmbeddingDimensions)} cannot be less than 1");
         }
     }
 }

--- a/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
+++ b/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
@@ -58,7 +58,8 @@ public sealed class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
                     modelId: config.Deployment,
                     endpoint: config.Endpoint,
                     credential: new DefaultAzureCredential(),
-                    httpClient: httpClient);
+                    httpClient: httpClient,
+                    dimensions: config.EmbeddingDimensions);
                 break;
 
             case AzureOpenAIConfig.AuthTypes.ManualTokenCredential:
@@ -67,7 +68,8 @@ public sealed class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
                     modelId: config.Deployment,
                     endpoint: config.Endpoint,
                     credential: config.GetTokenCredential(),
-                    httpClient: httpClient);
+                    httpClient: httpClient,
+                    dimensions: config.EmbeddingDimensions);
                 break;
 
             case AzureOpenAIConfig.AuthTypes.APIKey:
@@ -76,7 +78,8 @@ public sealed class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
                     modelId: config.Deployment,
                     endpoint: config.Endpoint,
                     apiKey: config.APIKey,
-                    httpClient: httpClient);
+                    httpClient: httpClient,
+                    dimensions: config.EmbeddingDimensions);
                 break;
 
             default:

--- a/extensions/OpenAI/OpenAIConfig.cs
+++ b/extensions/OpenAI/OpenAIConfig.cs
@@ -69,7 +69,9 @@ public class OpenAIConfig
     public int MaxRetries { get; set; } = 10;
 
     /// <summary>
-    /// The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.
+    /// The number of dimensions output embeddings should have.
+    /// Only supported in "text-embedding-3" and later models developed with
+    /// MRL, see https://arxiv.org/abs/2205.13147
     /// </summary>
     public int? EmbeddingDimensions { get; set; }
 
@@ -93,7 +95,7 @@ public class OpenAIConfig
             throw new ConfigurationException($"OpenAI: {nameof(this.EmbeddingModelMaxTokenTotal)} cannot be less than 1");
         }
 
-        if (this.EmbeddingDimensions.HasValue && this.EmbeddingDimensions.Value < 1)
+        if (this.EmbeddingDimensions is < 1)
         {
             throw new ConfigurationException($"OpenAI: {nameof(this.EmbeddingDimensions)} cannot be less than 1");
         }

--- a/extensions/OpenAI/OpenAIConfig.cs
+++ b/extensions/OpenAI/OpenAIConfig.cs
@@ -69,6 +69,11 @@ public class OpenAIConfig
     public int MaxRetries { get; set; } = 10;
 
     /// <summary>
+    /// The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.
+    /// </summary>
+    public int? EmbeddingDimensions { get; set; }
+
+    /// <summary>
     /// Verify that the current state is valid.
     /// </summary>
     public void Validate()
@@ -86,6 +91,11 @@ public class OpenAIConfig
         if (this.EmbeddingModelMaxTokenTotal < 1)
         {
             throw new ConfigurationException($"OpenAI: {nameof(this.EmbeddingModelMaxTokenTotal)} cannot be less than 1");
+        }
+
+        if (this.EmbeddingDimensions.HasValue && this.EmbeddingDimensions.Value < 1)
+        {
+            throw new ConfigurationException($"OpenAI: {nameof(this.EmbeddingDimensions)} cannot be less than 1");
         }
     }
 }

--- a/extensions/OpenAI/OpenAITextEmbeddingGenerator.cs
+++ b/extensions/OpenAI/OpenAITextEmbeddingGenerator.cs
@@ -50,7 +50,8 @@ public sealed class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
         this._client = new OpenAITextEmbeddingGenerationService(
             modelId: config.EmbeddingModel,
             openAIClient: openAIClient,
-            loggerFactory: loggerFactory);
+            loggerFactory: loggerFactory,
+            dimensions: config.EmbeddingDimensions);
     }
 
     /// <summary>
@@ -99,7 +100,8 @@ public sealed class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
         this._client = new OpenAITextEmbeddingGenerationService(
             modelId: config.EmbeddingModel,
             openAIClient: OpenAIClientBuilder.BuildOpenAIClient(config, httpClient),
-            loggerFactory: loggerFactory);
+            loggerFactory: loggerFactory,
+            dimensions: config.EmbeddingDimensions);
     }
 
     /// <summary>
@@ -123,7 +125,8 @@ public sealed class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
 
         this._client = new OpenAITextEmbeddingGenerationService(
             modelId: config.EmbeddingModel,
-            openAIClient: OpenAIClientBuilder.BuildOpenAIClient(config, httpClient));
+            openAIClient: OpenAIClientBuilder.BuildOpenAIClient(config, httpClient),
+            dimensions: config.EmbeddingDimensions);
     }
 
     /// <inheritdoc/>

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -264,7 +264,9 @@
         // The max number of tokens supported by model deployed
         // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
         "MaxTokenTotal": 8191,
-        // The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.
+        // The number of dimensions output embeddings should have.
+        // Only supported in "text-embedding-3" and later models developed with
+        // MRL, see https://arxiv.org/abs/2205.13147
         "EmbeddingDimensions": null
       },
       "AzureOpenAIText": {
@@ -355,7 +357,9 @@
         "Endpoint": "",
         // How many times to retry in case of throttling
         "MaxRetries": 10,
-        // The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.
+        // The number of dimensions output embeddings should have.
+        // Only supported in "text-embedding-3" and later models developed with
+        // MRL, see https://arxiv.org/abs/2205.13147
         "EmbeddingDimensions": null
       },
       "Postgres": {

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -263,7 +263,9 @@
         "Deployment": "",
         // The max number of tokens supported by model deployed
         // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 8191
+        "MaxTokenTotal": 8191,
+        // The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.
+        "EmbeddingDimensions": null
       },
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"
@@ -352,7 +354,9 @@
         // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
         "Endpoint": "",
         // How many times to retry in case of throttling
-        "MaxRetries": 10
+        "MaxRetries": 10,
+        // The number of dimensions the resulting output embeddings should have. Only supported in "text-embedding-3" and later models.
+        "EmbeddingDimensions": null
       },
       "Postgres": {
         // Postgres instance connection string


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
Semantic Kernel has been updated to support the `Dimensions` property for embeddings, to set the number of dimensions the resulting output embeddings should have (https://github.com/microsoft/semantic-kernel/issues/6026). This PR adds this support to Kernel Memory.

