### PR TITLE
Fix web client base address

### DIFF
--- a/clients/dotnet/WebClient/StringExtensions.cs
+++ b/clients/dotnet/WebClient/StringExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.KernelMemory;
+
+internal static class StringExtensions
+{
+    public static string CleanBaseAddress(this string endpoint)
+    {
+        ArgumentNullExceptionEx.ThrowIfNull(endpoint, nameof(endpoint), "Kernel Memory API endpoint is NULL");
+
+        return endpoint.TrimEnd('/') + '/';
+    }
+
+    public static string CleanUrlPath(this string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) { path = "/"; }
+
+        return path.TrimStart('/');
+    }
+}


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

When deploying KM web service with a custom base address, the web client would still send requests to the default root of the endpoint (due to how .NET HttpClient merges BaseAddress and paths).

## High level description (Approach, Design)

* Add workaround for HttpClient merge of base address + path
* Add a couple of missing await / ConfigureAwait