### PR TITLE
Update SearchClient to use webPageUrl instead of static fileName for webpages (fixes microsoft/kernel-memory#491)

### DIFF
--- a/service/Core/Search/SearchClient.cs
+++ b/service/Core/Search/SearchClient.cs
@@ -238,6 +238,8 @@ internal sealed class SearchClient : ISearchClient
 
             string fileName = memory.GetFileName(this._log);
 
+            string webPageUrl = memory.GetWebPageUrl(index);
+
             var partitionText = memory.GetPartitionText(this._log).Trim();
             if (string.IsNullOrEmpty(partitionText))
             {
@@ -248,7 +250,7 @@ internal sealed class SearchClient : ISearchClient
             factsAvailableCount++;
 
             // TODO: add file age in days, to push relevance of newer documents
-            var fact = $"==== [File:{fileName};Relevance:{relevance:P1}]:\n{partitionText}\n";
+            var fact = $"==== [File:{(fileName == "content.url" ? webPageUrl : fileName)};Relevance:{relevance:P1}]:\n{partitionText}\n";
 
             // Use the partition/chunk only if there's room for it
             var size = this._textGenerator.CountTokens(fact);


### PR DESCRIPTION
Update SearchClient to use webPageUrl instead of static fileName for webpages

<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
When providing webpages as facts, the "filename" currently is a static "content.url" - this provides no value when asking the LLM to include sources directly in the response (e.g. to have per paragraph sources).

## High level description (Approach, Design)
When creating the facts, instead of "content.url" the webpage url is added
