### PR TITLE
Added support for newest Microsoft.ML.Tokenizer.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.TraceSource" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.ML.Tokenizers" Version="0.22.0-preview.24179.1" />
+    <PackageVersion Include="Microsoft.ML.Tokenizers" Version="0.22.0-preview.24271.1" />
     <PackageVersion Include="Microsoft.KernelMemory.Core" Version="0.51.240513.2" />
     <PackageVersion Include="Microsoft.KernelMemory.Service.AspNetCore" Version="0.51.240513.2" />
     <PackageVersion Include="MongoDB.Driver.GridFS" Version="2.25.0" />

--- a/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
+++ b/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Azure.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.AI.OpenAI;
+using Microsoft.KernelMemory.AI.OpenAI.Internals;
 using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
@@ -37,16 +38,6 @@ public sealed class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
         HttpClient? httpClient = null)
     {
         this._log = log ?? DefaultLogger<AzureOpenAITextEmbeddingGenerator>.Instance;
-
-        if (textTokenizer == null)
-        {
-            this._log.LogWarning(
-                "Tokenizer not specified, will use {0}. The token count might be incorrect, causing unexpected errors",
-                nameof(DefaultGPTTokenizer));
-            textTokenizer = new DefaultGPTTokenizer();
-        }
-
-        this._textTokenizer = textTokenizer;
 
         this.MaxTokens = config.MaxTokenTotal;
 
@@ -85,6 +76,8 @@ public sealed class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator
             default:
                 throw new NotImplementedException($"Azure OpenAI auth type '{config.Auth}' not available");
         }
+
+        this._textTokenizer = textTokenizer ?? GptTokenizerDetector.GetTokenizerForEmbeddingModel(this._client, this._log);
     }
 
     /// <inheritdoc/>

--- a/extensions/AzureOpenAI/AzureOpenAITextGenerator.cs
+++ b/extensions/AzureOpenAI/AzureOpenAITextGenerator.cs
@@ -13,7 +13,7 @@ using Azure.Core.Pipeline;
 using Azure.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.AI.AzureOpenAI.Internals;
-using Microsoft.KernelMemory.AI.OpenAI;
+using Microsoft.KernelMemory.AI.OpenAI.Internals;
 using Microsoft.KernelMemory.Diagnostics;
 
 namespace Microsoft.KernelMemory.AI.AzureOpenAI;
@@ -28,11 +28,11 @@ public sealed class AzureOpenAITextGenerator : ITextGenerator
     private readonly string _deployment;
 
     public AzureOpenAITextGenerator(
-        AzureOpenAIConfig config,
-        ITextTokenizer? textTokenizer = null,
-        ILoggerFactory? loggerFactory = null,
-        HttpClient? httpClient = null)
-        : this(config, textTokenizer, loggerFactory?.CreateLogger<AzureOpenAITextGenerator>(), httpClient)
+           AzureOpenAIConfig config,
+           ITextTokenizer? textTokenizer = null,
+           ILoggerFactory? loggerFactory = null,
+           HttpClient? httpClient = null)
+           : this(config, textTokenizer, loggerFactory?.CreateLogger<AzureOpenAITextGenerator>(), httpClient)
     {
     }
 
@@ -43,16 +43,6 @@ public sealed class AzureOpenAITextGenerator : ITextGenerator
         HttpClient? httpClient = null)
     {
         this._log = log ?? DefaultLogger<AzureOpenAITextGenerator>.Instance;
-
-        if (textTokenizer == null)
-        {
-            this._log.LogWarning(
-                "Tokenizer not specified, will use {0}. The token count might be incorrect, causing unexpected errors",
-                nameof(DefaultGPTTokenizer));
-            textTokenizer = new DefaultGPTTokenizer();
-        }
-
-        this._textTokenizer = textTokenizer;
 
         if (string.IsNullOrEmpty(config.Endpoint))
         {
@@ -105,6 +95,8 @@ public sealed class AzureOpenAITextGenerator : ITextGenerator
             default:
                 throw new ConfigurationException($"Azure OpenAI: authentication type '{config.Auth:G}' is not supported");
         }
+
+        this._textTokenizer = textTokenizer ?? GptTokenizerDetector.GetTokenizer(this._isTextModel, this._deployment, this._client, this._log);
     }
 
     /// <inheritdoc/>

--- a/extensions/AzureOpenAI/DependencyInjection.cs
+++ b/extensions/AzureOpenAI/DependencyInjection.cs
@@ -35,7 +35,6 @@ public static partial class KernelMemoryBuilderExtensions
         HttpClient? httpClient = null)
     {
         config.Validate();
-        textTokenizer ??= new DefaultGPTTokenizer();
         builder.Services.AddAzureOpenAIEmbeddingGeneration(config, textTokenizer);
 
         if (!onlyForRetrieval)
@@ -66,7 +65,6 @@ public static partial class KernelMemoryBuilderExtensions
         HttpClient? httpClient = null)
     {
         config.Validate();
-        textTokenizer ??= new DefaultGPTTokenizer();
         builder.Services.AddAzureOpenAITextGeneration(config, textTokenizer, httpClient);
         return builder;
     }
@@ -84,7 +82,6 @@ public static partial class DependencyInjection
         HttpClient? httpClient = null)
     {
         config.Validate();
-        textTokenizer ??= new DefaultGPTTokenizer();
         return services
             .AddSingleton<ITextEmbeddingGenerator>(serviceProvider => new AzureOpenAITextEmbeddingGenerator(
                 config,
@@ -100,7 +97,6 @@ public static partial class DependencyInjection
         HttpClient? httpClient = null)
     {
         config.Validate();
-        textTokenizer ??= new DefaultGPTTokenizer();
         return services
             .AddSingleton<ITextGenerator>(serviceProvider => new AzureOpenAITextGenerator(
                 config: config,

--- a/extensions/AzureOpenAI/Internals/GptTokenizerDetector.cs
+++ b/extensions/AzureOpenAI/Internals/GptTokenizerDetector.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using Azure.AI.OpenAI;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using Microsoft.SemanticKernel.Services;
+
+namespace Microsoft.KernelMemory.AI.OpenAI.Internals;
+
+internal static class GptTokenizerDetector
+{
+    internal static GptTokenizer GetTokenizer(bool isTextModel, string deployment, OpenAIClient client, ILogger logger)
+    {
+        //To determine tokenizer we need to perform one generation and then determine
+        //the model from the response text.
+        string? model = null;
+        if (isTextModel)
+        {
+            var openaiOptions = new CompletionsOptions
+            {
+                DeploymentName = deployment,
+                MaxTokens = 50,
+                Temperature = 0.0f,
+            };
+            openaiOptions.Prompts.Add("answer OK!");
+            var answer = client.GetCompletions(openaiOptions, cancellationToken: CancellationToken.None);
+            //now we have a raw response from where we can retrieve the model
+            var rawResponse = answer.GetRawResponse().Content.ToString();
+            ChatCompletion? chatCompletion = JsonSerializer.Deserialize<ChatCompletion>(rawResponse);
+            model = chatCompletion?.Model;
+        }
+        else
+        {
+            var openaiOptions = new ChatCompletionsOptions
+            {
+                DeploymentName = deployment,
+                MaxTokens = 50,
+                Temperature = 0.0f,
+            };
+            openaiOptions.Messages.Add(new ChatRequestUserMessage("answer OK!"));
+            var answer = client.GetChatCompletions(openaiOptions, cancellationToken: CancellationToken.None);
+
+            //now we have a raw response from where we can retrieve the model
+            var rawResponse = answer.GetRawResponse().Content.ToString();
+            ChatCompletion? chatCompletion = JsonSerializer.Deserialize<ChatCompletion>(rawResponse);
+            model = chatCompletion?.Model;
+        }
+        return GetTokenizerFromModelName(logger, model);
+    }
+
+    internal static GptTokenizer GetTokenizerForEmbeddingModel(AzureOpenAITextEmbeddingGenerationService client, ILogger logger)
+    {
+        var model = client.GetModelId();
+        return GetTokenizerFromModelName(logger, model);
+    }
+
+    private static GptTokenizer GetTokenizerFromModelName(ILogger logger, string? model)
+    {
+        if (!string.IsNullOrEmpty(model))
+        {
+            try
+            {
+                return new GptTokenizer(model);
+            }
+            catch (ArgumentException ex)
+            {
+                //This can happen if the answer model is not correct and cannot be converted to tokenizer.
+                //in this situation we are more conservative, we simply log the error, and then return a default
+                //Gpt3 tokenizer that is the cl100k model.
+                logger.LogError(ex, "Error converting OpenaAI model {0} to tokenizer", model);
+            }
+        }
+        return new GptTokenizer("gpt3");
+    }
+
+    private class ChatCompletion
+    {
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+    }
+}

--- a/extensions/OpenAI/DefaultGPTTokenizer.cs
+++ b/extensions/OpenAI/DefaultGPTTokenizer.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.KernelMemory.AI.OpenAI;
 
 /// <summary>
 /// Default tokenizer, using GPT3 logic.
 /// </summary>
+[Experimental("KMEXP02")]
 public sealed class DefaultGPTTokenizer : ITextTokenizer
 {
     /// <inheritdoc />

--- a/extensions/OpenAI/Internals/GptTokenizer.cs
+++ b/extensions/OpenAI/Internals/GptTokenizer.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.ML.Tokenizers;
+
+namespace Microsoft.KernelMemory.AI.OpenAI;
+
+/// <summary>
+/// This text tokenizer uses latest and optimized Tiktoken model directly
+/// from Microsoft packages that offer optimized countTokens method.
+/// </summary>
+public class GptTokenizer : ITextTokenizer
+{
+    private readonly Tokenizer _tikToken;
+
+    public GptTokenizer(string baseModelName)
+    {
+        this._tikToken = Tiktoken.CreateTiktokenForModel(baseModelName);
+    }
+
+    public int CountTokens(string text)
+    {
+        return this._tikToken.CountTokens(text);
+    }
+}

--- a/extensions/OpenAI/OpenAI.csproj
+++ b/extensions/OpenAI/OpenAI.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" />
+        <PackageReference Include="Microsoft.ML.Tokenizers" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Actually, if you do not specify a specific tokenizer for azure openai you will use a default implementation of GPT3 Token. The aim of this PR is using the newest Microsoft.Ml.Tokenizer, that support also count() to calculate token count without creating the array of tokens.

I've done modification only for AzureopenAI, but if the PR is ok I'll add also to the Standard OpenAi configuration.

Actually I had to modify the config file, because with Azure we have deployment name that does not identify correctly the deployment. I've added ModelName property that allow the user to specify the model used (maybe it could be possible to determine automatically the format with an api call).

This allows to create the correct tokenizer based on model and use a faster tokenizer. (Gpt-4o has a different tokenizer).

