### PR TITLE
Fix #527 - Use NVarchar(max) db type for tags in SQL Server

### DIFF
--- a/extensions/SQLServer/SQLServer.FunctionalTests/DefaultTests.cs
+++ b/extensions/SQLServer/SQLServer.FunctionalTests/DefaultTests.cs
@@ -103,4 +103,35 @@ public class DefaultTests : BaseFunctionalTestCase
     {
         await DocumentUploadTest.ItSupportsTags(this._memory, this.Log);
     }
+
+    [Fact]
+    [Trait("Category", "SQLServer")]
+    public async Task ItCanImportDocumentWithManyTagsAtATime()
+    {
+        const string Id = "ItCanImportDocumentWithManyTagsAtATime-file1-NASA-news.pdf";
+
+        var tags = new TagCollection
+              {
+                { "type", "news" },
+                { "type", "test" },
+                { "ext", "pdf" }
+              };
+
+        for (int i = 0; i < 100; i++)
+        {
+            tags.AddSyntheticTag($"tagTest{i}");
+        }
+
+        await this._memory.ImportDocumentAsync(
+              "file1-NASA-news.pdf",
+              documentId: Id,
+              tags: tags,
+              steps: Constants.PipelineWithoutSummary);
+
+        while (!await this._memory.IsDocumentReadyAsync(documentId: Id))
+        {
+            this.Log("Waiting for memory ingestion to complete...");
+            await Task.Delay(TimeSpan.FromSeconds(2));
+        }
+    }
 }

--- a/extensions/SQLServer/SQLServer/SqlServerMemory.cs
+++ b/extensions/SQLServer/SQLServer/SqlServerMemory.cs
@@ -467,11 +467,11 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbBatchUpsert, IDisposab
                 USING (
                     SELECT
                         {this.GetFullTableName(this._config.MemoryTableName)}.[id],
-                        cast([tags].[key] AS NVARCHAR(256)) COLLATE SQL_Latin1_General_CP1_CI_AS AS [tag_name],
+                        cast([tags].[key] AS NVARCHAR(MAX)) COLLATE SQL_Latin1_General_CP1_CI_AS AS [tag_name],
                         [tag_value].[value] AS [value]
                     FROM {this.GetFullTableName(this._config.MemoryTableName)}
                     CROSS APPLY openjson(@tags) [tags]
-                    CROSS APPLY openjson(cast([tags].[value] AS NVARCHAR(256)) COLLATE SQL_Latin1_General_CP1_CI_AS) [tag_value]
+                    CROSS APPLY openjson(cast([tags].[value] AS NVARCHAR(MAX)) COLLATE SQL_Latin1_General_CP1_CI_AS) [tag_value]
                     WHERE {this.GetFullTableName(this._config.MemoryTableName)}.[key] = @key
                         AND {this.GetFullTableName(this._config.MemoryTableName)}.[collection] = @index
                 ) AS [src]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

Resolve the issue #527 by removing size limit for tags field.

## High level description (Approach, Design)

the merge command used nvarchar(256) field for tags management but it requires to remove this limit.

