### PR TITLE
Fix reading StopSequences from the config

### DIFF
--- a/service/Abstractions/AI/TextGenerationOptions.cs
+++ b/service/Abstractions/AI/TextGenerationOptions.cs
@@ -44,7 +44,7 @@ public class TextGenerationOptions
     /// <summary>
     /// Sequences where the completion will stop generating further tokens.
     /// </summary>
-    public IList<string> StopSequences { get; set; } = Array.Empty<string>();
+    public IList<string> StopSequences { get; set; } = new List<string>();
 
     /// <summary>
     /// How many completions to generate for each prompt. Default is 1.

--- a/service/Abstractions/AI/TextGenerationOptions.cs
+++ b/service/Abstractions/AI/TextGenerationOptions.cs
@@ -44,7 +44,7 @@ public class TextGenerationOptions
     /// <summary>
     /// Sequences where the completion will stop generating further tokens.
     /// </summary>
-    public IList<string> StopSequences { get; set; } = new List<string>();
+    public IList<string> StopSequences { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// How many completions to generate for each prompt. Default is 1.

--- a/service/Abstractions/Search/SearchClientConfig.cs
+++ b/service/Abstractions/Search/SearchClientConfig.cs
@@ -70,7 +70,7 @@ public class SearchClientConfig
     /// <summary>
     /// Up to 4 sequences where the completion will stop generating further tokens.
     /// </summary>
-    public IList<string> StopSequences { get; set; } = Array.Empty<string>();
+    public IList<string> StopSequences { get; set; } = new List<string>();
 
     /// <summary>
     /// Modify the likelihood of specified tokens appearing in the completion.


### PR DESCRIPTION
## Motivation and Context
Currently, StopSequences initialized with Array.Empty<T>() are not deserialized correctly, resulting in an empty list even when values are provided in the configuration. 

## High level description
By changing the initialization to use new List<T>(), we ensure that the StopSequences are properly deserialized from the configuration. For more details, I have created a issue: [dotnet/runtime#103282](https://github.com/dotnet/runtime/issues/103282).

