### PR TITLE
Cleanup logger DI + other DI work

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
     <PropertyGroup>
         <!-- Central version prefix - applies to all nuget packages. -->
-        <Version>0.63.0</Version>
+        <Version>0.64.0</Version>
 
         <!-- C# lang version, https://learn.microsoft.com/dotnet/csharp/whats-new -->
         <LangVersion>12</LangVersion>

--- a/KernelMemory.sln
+++ b/KernelMemory.sln
@@ -288,6 +288,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Evaluation.FunctionalTests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "209-dotnet-using-context-overrides", "examples\209-dotnet-using-context-overrides\209-dotnet-using-context-overrides.csproj", "{06A507C7-46B9-4D36-B88B-B4E4A0E8C0AC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "210-KM-without-builder", "examples\210-KM-without-builder\210-KM-without-builder.csproj", "{00A3DDF3-2230-4AEC-8B5B-B75F958D194B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -543,6 +545,9 @@ Global
 		{06A507C7-46B9-4D36-B88B-B4E4A0E8C0AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{06A507C7-46B9-4D36-B88B-B4E4A0E8C0AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{06A507C7-46B9-4D36-B88B-B4E4A0E8C0AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00A3DDF3-2230-4AEC-8B5B-B75F958D194B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00A3DDF3-2230-4AEC-8B5B-B75F958D194B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00A3DDF3-2230-4AEC-8B5B-B75F958D194B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -631,6 +636,7 @@ Global
 		{D1308C73-79B6-4635-B50D-420742D09C20} = {0A43C65C-6007-4BB4-B3FE-8D439FC91841}
 		{C746CE00-8BAE-4B46-A757-FE85D68747CE} = {DBEA0A6B-474A-4E8C-BCC8-D5D43C063A54}
 		{06A507C7-46B9-4D36-B88B-B4E4A0E8C0AC} = {0A43C65C-6007-4BB4-B3FE-8D439FC91841}
+		{00A3DDF3-2230-4AEC-8B5B-B75F958D194B} = {0A43C65C-6007-4BB4-B3FE-8D439FC91841}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CC136C62-115C-41D1-B414-F9473EFF6EA8}

--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ running the service locally with OpenAPI enabled.
 25. [Expanding chunks retrieving adjacent partitions](examples/207-dotnet-expanding-chunks-on-retrieval)
 26. [Using local models via LM Studio](examples/208-dotnet-lmstudio)
 27. [Using Context Parameters to customize RAG prompt during a request](examples/209-dotnet-using-context-overrides)
+28. [Creating a Memory instance without KernelMemoryBuilder](examples/210-KM-without-builder)
 
 ## Tools
 

--- a/examples/002-dotnet-Serverless/Program.cs
+++ b/examples/002-dotnet-Serverless/Program.cs
@@ -30,6 +30,7 @@ public static class Program
         var azDocIntelConfig = new AzureAIDocIntelConfig();
         var azureAISearchConfig = new AzureAISearchConfig();
         var postgresConfig = new PostgresConfig();
+        var azureBlobConfig = new AzureBlobsConfig();
 
         new ConfigurationBuilder()
             .AddJsonFile("appsettings.json")
@@ -42,6 +43,7 @@ public static class Program
             .BindSection("KernelMemory:Services:LlamaSharp", llamaConfig)
             .BindSection("KernelMemory:Services:AzureAIDocIntel", azDocIntelConfig)
             .BindSection("KernelMemory:Services:AzureAISearch", azureAISearchConfig)
+            .BindSection("KernelMemory:Services:AzureBlobs", azureBlobConfig)
             .BindSection("KernelMemory:Services:Postgres", postgresConfig)
             .BindSection("KernelMemory:Retrieval:SearchClient", searchClientConfig);
 
@@ -49,11 +51,11 @@ public static class Program
             .AddSingleton(memoryConfiguration)
             // .WithOpenAIDefaults(Environment.GetEnvironmentVariable("OPENAI_API_KEY")) // Use OpenAI for text generation and embedding
             // .WithOpenAI(openAIConfig)                                    // Use OpenAI for text generation and embedding
-            // .WithLlamaTextGeneration(llamaConfig)                        // Generate answers ans summaries using LLama
+            // .WithLlamaTextGeneration(llamaConfig)                        // Generate answers and summaries using LLama
             // .WithAzureAISearchMemoryDb(azureAISearchConfig)              // Store memories in Azure AI Search
             // .WithPostgresMemoryDb(postgresConfig)                        // Store memories in Postgres
             // .WithQdrantMemoryDb("http://127.0.0.1:6333")                 // Store memories in Qdrant
-            // .WithAzureBlobsStorage(new AzureBlobsConfig {...})           // Store files in Azure Blobs
+            // .WithAzureBlobsDocumentStorage(azureBlobConfig)              // Store files in Azure Blobs
             // .WithSimpleVectorDb(SimpleVectorDbConfig.Persistent)         // Store memories on disk
             // .WithSimpleFileStorage(SimpleFileStorageConfig.Persistent)   // Store files on disk
             .WithAzureOpenAITextGeneration(azureOpenAITextConfig, new DefaultGPTTokenizer())
@@ -61,7 +63,7 @@ public static class Program
 
         if (s_imageSupportDemoEnabled)
         {
-            if (string.IsNullOrWhiteSpace(azDocIntelConfig.APIKey))
+            if (azDocIntelConfig.Auth == AzureAIDocIntelConfig.AuthTypes.APIKey && string.IsNullOrWhiteSpace(azDocIntelConfig.APIKey))
             {
                 Console.WriteLine("Azure AI Document Intelligence API key not found. OCR demo disabled.");
                 s_imageSupportDemoEnabled = false;

--- a/examples/108-dotnet-custom-content-decoders/Program.cs
+++ b/examples/108-dotnet-custom-content-decoders/Program.cs
@@ -46,9 +46,9 @@ public class CustomPdfDecoder : IContentDecoder
 {
     private readonly ILogger<CustomPdfDecoder> _log;
 
-    public CustomPdfDecoder(ILogger<CustomPdfDecoder>? log = null)
+    public CustomPdfDecoder(ILoggerFactory? loggerFactory = null)
     {
-        this._log = log ?? DefaultLogger<CustomPdfDecoder>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<CustomPdfDecoder>();
     }
 
     /// <inheritdoc />

--- a/examples/201-dotnet-serverless-custom-handler/Program.cs
+++ b/examples/201-dotnet-serverless-custom-handler/Program.cs
@@ -36,11 +36,11 @@ public class MyHandler : IPipelineStepHandler
     public MyHandler(
         string stepName,
         IPipelineOrchestrator orchestrator,
-        ILogger<MyHandler>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this.StepName = stepName;
         this._orchestrator = orchestrator;
-        this._log = log ?? DefaultLogger<MyHandler>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<MyHandler>();
     }
 
     /// <inheritdoc />

--- a/examples/202-dotnet-custom-handler-as-a-service/MyHandler.cs
+++ b/examples/202-dotnet-custom-handler-as-a-service/MyHandler.cs
@@ -11,11 +11,11 @@ public class MyHandler : IHostedService, IPipelineStepHandler
     public MyHandler(
         string stepName,
         IPipelineOrchestrator orchestrator,
-        ILogger<MyHandler>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this.StepName = stepName;
         this._orchestrator = orchestrator;
-        this._log = log ?? DefaultLogger<MyHandler>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<MyHandler>();
 
         this._log.LogInformation("Instantiating handler {0}...", this.GetType().FullName);
     }

--- a/examples/210-KM-without-builder/210-KM-without-builder.csproj
+++ b/examples/210-KM-without-builder/210-KM-without-builder.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\service\Core\Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/examples/210-KM-without-builder/Program.cs
+++ b/examples/210-KM-without-builder/Program.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.KernelMemory;
+using Microsoft.KernelMemory.AI;
+using Microsoft.KernelMemory.AI.AzureOpenAI;
+using Microsoft.KernelMemory.AI.TikToken;
+using Microsoft.KernelMemory.Configuration;
+using Microsoft.KernelMemory.DataFormats;
+using Microsoft.KernelMemory.DataFormats.AzureAIDocIntel;
+using Microsoft.KernelMemory.DataFormats.Image;
+using Microsoft.KernelMemory.DataFormats.Office;
+using Microsoft.KernelMemory.DataFormats.Pdf;
+using Microsoft.KernelMemory.DataFormats.Text;
+using Microsoft.KernelMemory.DataFormats.WebPages;
+using Microsoft.KernelMemory.DocumentStorage.AzureBlobs;
+using Microsoft.KernelMemory.Handlers;
+using Microsoft.KernelMemory.MemoryDb.AzureAISearch;
+using Microsoft.KernelMemory.MemoryStorage;
+using Microsoft.KernelMemory.Pipeline;
+using Microsoft.KernelMemory.Prompts;
+using Microsoft.KernelMemory.Search;
+
+/// <summary>
+/// This example shows how to create an instance of Kernel Memory without using Kernel Memory builder
+/// and without .NET Dependency Injection, in other words how to compose all classes manually.
+///
+/// The example focuses on MemoryServerless, but it works as well for MemoryService with some extra code.
+///
+/// This is just for the purpose of demonstration.
+/// </summary>
+[Experimental("KMEXP00")]
+#pragma warning disable CA1849 // No need to use async code
+public static class Program
+{
+    public static async Task Main()
+    {
+        // Configurations
+        var kernelMemoryConfig = new KernelMemoryConfig();
+        var searchClientConfig = new SearchClientConfig();
+        var azureBlobsConfig = new AzureBlobsConfig();
+        var azureAISearchConfig = new AzureAISearchConfig();
+        var azureOpenAIEmbeddingConfig = new AzureOpenAIConfig();
+        var azureOpenAITextConfig = new AzureOpenAIConfig();
+        var azureAIDocIntelConfig = new AzureAIDocIntelConfig();
+        var textPartitioningOptions = new TextPartitioningOptions();
+        var msExcelDecoderConfig = new MsExcelDecoderConfig();
+        var msPowerPointDecoderConfig = new MsPowerPointDecoderConfig();
+
+        // Use ASP.NET to load settings == optional ========================
+        WebApplicationBuilder appBuilder = WebApplication.CreateBuilder();
+        appBuilder.Configuration
+            .AddJsonFile("appsettings.json")
+            .AddJsonFile("appsettings.Development.json", optional: true)
+            .AddEnvironmentVariables();
+        var app = appBuilder.Build();
+        app.Configuration
+            .BindSection("KernelMemory", kernelMemoryConfig)
+            .BindSection("KernelMemory:DataIngestion:TextPartitioning", textPartitioningOptions)
+            .BindSection("KernelMemory:Retrieval:SearchClient", searchClientConfig)
+            .BindSection("KernelMemory:Services:AzureBlobs", azureBlobsConfig)
+            .BindSection("KernelMemory:Services:AzureAISearch", azureAISearchConfig)
+            .BindSection("KernelMemory:Services:AzureOpenAIEmbedding", azureOpenAIEmbeddingConfig)
+            .BindSection("KernelMemory:Services:AzureOpenAIText", azureOpenAITextConfig)
+            .BindSection("KernelMemory:Services:AzureAIDocIntel", azureAIDocIntelConfig);
+        // =================================================================
+
+        // Logger
+        LoggerFactory? loggerFactory = null; // Alternative: app.Services.GetService<ILoggerFactory>();
+
+        // Generic dependencies
+        var mimeTypeDetection = new MimeTypesDetection();
+        var promptProvider = new EmbeddedPromptProvider();
+
+        // AI dependencies
+        var tokenizer = new TikTokenGPT4Tokenizer();
+        var embeddingGeneratorHttpClient = new HttpClient();
+        var embeddingGenerator = new AzureOpenAITextEmbeddingGenerator(azureOpenAIEmbeddingConfig, tokenizer, loggerFactory, embeddingGeneratorHttpClient);
+        var textGeneratorHttpClient = new HttpClient();
+        var textGenerator = new AzureOpenAITextGenerator(azureOpenAITextConfig, tokenizer, loggerFactory, textGeneratorHttpClient);
+
+        // Storage
+        var documentStorage = new AzureBlobsStorage(azureBlobsConfig, mimeTypeDetection, loggerFactory);
+        var memoryDb = new AzureAISearchMemory(azureAISearchConfig, embeddingGenerator, loggerFactory);
+
+        // Ingestion pipeline orchestration
+        var memoryDbs = new List<IMemoryDb> { memoryDb };
+        var embeddingGenerators = new List<ITextEmbeddingGenerator> { embeddingGenerator };
+        var orchestrator = new InProcessPipelineOrchestrator(documentStorage, embeddingGenerators, memoryDbs, textGenerator, mimeTypeDetection, null, kernelMemoryConfig, loggerFactory);
+
+        // Ingestion handlers' dependencies
+        var webScraperHttpClient = new HttpClient();
+        var webScraper = new WebScraper(webScraperHttpClient);
+        var ocrEngine = new AzureAIDocIntelEngine(azureAIDocIntelConfig, loggerFactory);
+        var decoders = new List<IContentDecoder>
+        {
+            new TextDecoder(loggerFactory),
+            new HtmlDecoder(loggerFactory),
+            new MarkDownDecoder(loggerFactory),
+            new PdfDecoder(loggerFactory),
+            new MsWordDecoder(loggerFactory),
+            new MsExcelDecoder(msExcelDecoderConfig, loggerFactory),
+            new MsPowerPointDecoder(msPowerPointDecoderConfig, loggerFactory),
+            new ImageDecoder(ocrEngine, loggerFactory),
+        };
+
+        // Ingestion handlers
+        orchestrator.AddHandler(new TextExtractionHandler("extract", orchestrator, decoders, webScraper, loggerFactory));
+        orchestrator.AddHandler(new TextPartitioningHandler("partition", orchestrator, textPartitioningOptions, loggerFactory));
+        orchestrator.AddHandler(new GenerateEmbeddingsHandler("gen_embeddings", orchestrator, loggerFactory));
+        orchestrator.AddHandler(new SaveRecordsHandler("save_records", orchestrator, kernelMemoryConfig, loggerFactory));
+        orchestrator.AddHandler(new SummarizationHandler("summarize", orchestrator, promptProvider, loggerFactory));
+        orchestrator.AddHandler(new DeleteGeneratedFilesHandler("delete_generated_files", documentStorage, loggerFactory));
+        orchestrator.AddHandler(new DeleteIndexHandler("private_delete_index", documentStorage, memoryDbs, loggerFactory));
+        orchestrator.AddHandler(new DeleteDocumentHandler("private_delete_document", documentStorage, memoryDbs, loggerFactory));
+
+        // Create memory instance
+        var searchClient = new SearchClient(memoryDb, textGenerator, searchClientConfig, promptProvider, loggerFactory);
+        var memory = new MemoryServerless(orchestrator, searchClient, kernelMemoryConfig);
+
+        // End-to-end test
+        await memory.ImportTextAsync("I'm waiting for Godot", documentId: "tg01");
+        Console.WriteLine(await memory.AskAsync("Who am I waiting for?"));
+    }
+}

--- a/examples/210-KM-without-builder/appsettings.json
+++ b/examples/210-KM-without-builder/appsettings.json
@@ -1,0 +1,443 @@
+{
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://*:9001"
+      }
+      // "Https": {
+      //  "Url": "https://*:9002"
+      // }
+    }
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      // Examples: how to handle logs differently by class
+      //      "Microsoft.KernelMemory.Pipeline.Queue.DevTools.SimpleQueue": "Information",
+      //      "Microsoft.KernelMemory.Handlers.TextExtractionHandler": "Information",
+      //      "Microsoft.KernelMemory.Handlers.TextPartitioningHandler": "Information",
+      //      "Microsoft.KernelMemory.Handlers.GenerateEmbeddingsHandler": "Information",
+      //      "Microsoft.KernelMemory.Handlers.SaveEmbeddingsHandler": "Information",
+      //      "Microsoft.KernelMemory.DocumentStorage.AzureBlobs": "Information",
+      //      "Microsoft.KernelMemory.Pipeline.Queue.AzureQueues": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    },
+    "Console": {
+      "LogToStandardErrorThreshold": "Critical",
+      "FormatterName": "simple",
+      "FormatterOptions": {
+        "TimestampFormat": "[HH:mm:ss.fff] ",
+        "SingleLine": true,
+        "UseUtcTimestamp": false,
+        "IncludeScopes": false,
+        "JsonWriterOptions": {
+          "Indented": true
+        }
+      }
+    }
+  },
+  "KernelMemory": {
+    "Service": {
+      // Whether to run the web service that allows to upload files and search memory
+      // Use these booleans to deploy the web service and the handlers on same/different VMs
+      "RunWebService": true,
+      // Whether to expose OpenAPI swagger UI at http://127.0.0.1:9001/swagger/index.html
+      "OpenApiEnabled": false,
+      // Whether to run the asynchronous pipeline handlers
+      // Use these booleans to deploy the web service and the handlers on same/different VMs
+      "RunHandlers": true,
+      // Handlers to load for callers (use "steps" to choose which handlers
+      // to use to process a document during the ingestion)
+      "Handlers": {
+        // The key, e.g. "extract", is the name used when starting a pipeline with specific steps
+        "extract": {
+          "Assembly": "Microsoft.KernelMemory.Core.dll",
+          "Class": "Microsoft.KernelMemory.Handlers.TextExtractionHandler"
+        },
+        "partition": {
+          "Assembly": "Microsoft.KernelMemory.Core.dll",
+          "Class": "Microsoft.KernelMemory.Handlers.TextPartitioningHandler"
+        },
+        "gen_embeddings": {
+          "Assembly": "Microsoft.KernelMemory.Core.dll",
+          "Class": "Microsoft.KernelMemory.Handlers.GenerateEmbeddingsHandler"
+        },
+        "save_records": {
+          "Assembly": "Microsoft.KernelMemory.Core.dll",
+          "Class": "Microsoft.KernelMemory.Handlers.SaveRecordsHandler"
+        },
+        "summarize": {
+          "Assembly": "Microsoft.KernelMemory.Core.dll",
+          "Class": "Microsoft.KernelMemory.Handlers.SummarizationHandler"
+        },
+        "delete_generated_files": {
+          "Assembly": "Microsoft.KernelMemory.Core.dll",
+          "Class": "Microsoft.KernelMemory.Handlers.DeleteGeneratedFilesHandler"
+        },
+        "private_delete_document": {
+          "Assembly": "Microsoft.KernelMemory.Core.dll",
+          "Class": "Microsoft.KernelMemory.Handlers.DeleteDocumentHandler"
+        },
+        "private_delete_index": {
+          "Assembly": "Microsoft.KernelMemory.Core.dll",
+          "Class": "Microsoft.KernelMemory.Handlers.DeleteIndexHandler"
+        },
+        "disabled_handler_example": {
+          // Setting Class or Assembly to "" in appsettings.Development.json or appsettings.Production.json
+          // allows to remove a handler defined in appsettings.json
+          "Class": "",
+          "Assembly": ""
+        }
+      }
+    },
+    "ServiceAuthorization": {
+      // Whether clients must provide some credentials to interact with the HTTP API
+      "Enabled": false,
+      // Currently "APIKey" is the only type supported
+      "AuthenticationType": "APIKey",
+      // HTTP header name to check
+      "HttpHeaderName": "Authorization",
+      // Define two separate API Keys, to allow key rotation. Both are active.
+      // Keys must be different and case-sensitive, and at least 32 chars long.
+      // Contain only alphanumeric chars and allowed symbols.
+      // Symbols allowed: . _ - (dot, underscore, minus).
+      "AccessKey1": "",
+      "AccessKey2": ""
+    },
+    // "AzureBlobs" or "SimpleFileStorage"
+    "DocumentStorageType": "SimpleFileStorage",
+    // "AzureOpenAIText", "OpenAI" or "LlamaSharp"
+    "TextGeneratorType": "",
+    // Name of the index to use when none is specified
+    "DefaultIndexName": "default",
+    // Data ingestion pipelines configuration.
+    "DataIngestion": {
+      // - InProcess: in process .NET orchestrator, synchronous/no queues
+      // - Distributed: asynchronous queue based orchestrator
+      "OrchestrationType": "Distributed",
+      "DistributedOrchestration": {
+        // "AzureQueues", "RabbitMQ", "SimpleQueues"
+        "QueueType": "SimpleQueues"
+      },
+      // Whether the pipeline generates and saves the vectors/embeddings in the memory DBs.
+      // When using a memory DB that automatically generates embeddings internally,
+      // or performs semantic search internally anyway, this should be False,
+      // and avoid generating embeddings that are not used.
+      // Examples:
+      // * you are using Azure AI Search "semantic search" without "vector search": in this
+      //   case you don't need embeddings because Azure AI Search uses a more advanced approach
+      //   internally.
+      // * you are using a custom Memory DB connector that generates embeddings on the fly
+      //   when writing records and when searching: in this case you don't need the pipeline
+      //   to calculate embeddings, because your connector does all the work.
+      // * you are using a basic "text search" and a DB without "vector search": in this case
+      //   embeddings would be unused, so it's better to disable them to save cost and latency.
+      "EmbeddingGenerationEnabled": true,
+      // Multiple generators can be used, e.g. for data migration, A/B testing, etc.
+      // None of these are used for `ITextEmbeddingGeneration` dependency injection,
+      // see Retrieval settings.
+      "EmbeddingGeneratorTypes": [
+      ],
+      // Vectors can be written to multiple storages, e.g. for data migration, A/B testing, etc.
+      // "AzureAISearch", "Qdrant", "Postgres", "Redis", "SimpleVectorDb", "SqlServer", etc.
+      "MemoryDbTypes": [
+        "SimpleVectorDb"
+      ],
+      // How many memory DB records to insert at once when extracting memories from
+      // uploaded documents (used only if the Memory Db supports batching).
+      "MemoryDbUpsertBatchSize": 1,
+      // "None" or "AzureAIDocIntel"
+      "ImageOcrType": "None",
+      // Partitioning / Chunking settings
+      // How does the partitioning work?
+      // * Given a document, text is extracted, and text is split in sentences, called "lines of text".
+      // * Sentences are merged into paragraphs, called "partitions".
+      // * For each partition, one (potentially more) memory is generated.
+      "TextPartitioning": {
+        // Maximum length of lines of text (aka sentences), in tokens. Tokens depend on the LLM in use.
+        // Sentences are grouped into paragraphs, see the next setting.
+        "MaxTokensPerLine": 300,
+        // Maximum length of paragraphs (aka partitions), in tokens. Tokens depend on the LLM in use.
+        "MaxTokensPerParagraph": 1000,
+        // How many tokens from a paragraph to keep in the following paragraph.
+        "OverlappingTokens": 100
+      },
+      // Note: keep the list empty in this file, to avoid unexpected merges
+      // with the list defined in appsettings.*.json.
+      // If the list is empty, KernelMemoryConfig uses 'Constants.DefaultPipeline'.
+      "DefaultSteps": [
+        // Default steps defined in 'Constants.DefaultPipeline'
+        // "extract",
+        // "partition",
+        // "gen_embeddings",
+        // "save_records",
+      ]
+    },
+    "Retrieval": {
+      // "AzureOpenAIEmbedding" or "OpenAI"
+      // This is the generator registered for `ITextEmbeddingGeneration` dependency injection.
+      "EmbeddingGeneratorType": "",
+      // "AzureAISearch", "Qdrant", "Postgres", "Redis", "SimpleVectorDb", "SqlServer", etc.
+      "MemoryDbType": "SimpleVectorDb",
+      // Search client settings
+      "SearchClient": {
+        // Maximum number of tokens accepted by the LLM used to generate answers.
+        // The number includes the tokens used for the answer, e.g. when using
+        // GPT4-32k, set this number to 32768.
+        // If the value is not set or less than one, SearchClient will use the
+        // max amount of tokens supported by the model in use.
+        "MaxAskPromptSize": -1,
+        // Maximum number of relevant sources to consider when generating an answer.
+        // The value is also used as the max number of results returned by SearchAsync
+        // when passing a limit less or equal to zero.
+        "MaxMatchesCount": 100,
+        // How many tokens to reserve for the answer generated by the LLM.
+        // E.g. if the LLM supports max 4000 tokens, and AnswerTokens is 300, then
+        // the prompt sent to LLM will contain max 3700 tokens, composed by
+        // prompt + question + grounding information retrieved from memory.
+        "AnswerTokens": 300,
+        // Text to return when the LLM cannot produce an answer.
+        "EmptyAnswer": "INFO NOT FOUND",
+        // Number between 0 and 2 that controls the randomness of the completion.
+        // The higher the temperature, the more random the completion.
+        "Temperature": 0,
+        // Number between 0 and 2 that controls the diversity of the completion.
+        // The higher the TopP, the more diverse the completion.
+        "TopP": 0,
+        // Number between -2.0 and 2.0. Positive values penalize new tokens based on whether
+        // they appear in the text so far, increasing the model's likelihood to talk about
+        // new topics.
+        "PresencePenalty": 0,
+        // Number between -2.0 and 2.0. Positive values penalize new tokens based on their
+        // existing frequency in the text so far, decreasing the model's likelihood to repeat
+        // the same line verbatim.
+        "FrequencyPenalty": 0,
+        // Sequences where the completion will stop generating further tokens.
+        "StopSequences": []
+        // Modify the likelihood of specified tokens appearing in the completion.
+        //"TokenSelectionBiases": { }
+      }
+    },
+    "Services": {
+      "Anthropic": {
+        "Endpoint": "https://api.anthropic.com",
+        "EndpointVersion": "2023-06-01",
+        "ApiKey": "",
+        // See https://docs.anthropic.com/claude/docs/models-overview for list of models and details
+        "TextModelName": "claude-3-haiku-20240307",
+        // How many tokens the model can receive in input and generate in output
+        // See https://docs.anthropic.com/claude/docs/models-overview
+        "MaxTokenIn": 200000,
+        "MaxTokenOut": 4096,
+        "DefaultSystemPrompt": "You are an assistant that will answer user query based on a context",
+        "HttpClientName": ""
+      },
+      "AzureAISearch": {
+        // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>",
+        "APIKey": "",
+        // Hybrid search is not enabled by default. Note that when using hybrid search
+        // relevance scores are different, usually lower, than when using just vector search
+        "UseHybridSearch": false
+      },
+      "AzureAIDocIntel": {
+        // "APIKey" or "AzureIdentity".
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        // Required when Auth == APIKey
+        "APIKey": "",
+        "Endpoint": ""
+      },
+      "AzureBlobs": {
+        // "ConnectionString" or "AzureIdentity". For other options see <AzureBlobConfig>.
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        // Azure Storage account name, required when using AzureIdentity auth
+        // Note: you can use an env var 'KernelMemory__Services__AzureBlobs__Account' to set this
+        "Account": "",
+        // Container where to create directories and upload files
+        "Container": "smemory",
+        // Required when Auth == ConnectionString
+        // Note: you can use an env var 'KernelMemory__Services__AzureBlobs__ConnectionString' to set this
+        "ConnectionString": "",
+        // Setting used only for country clouds
+        "EndpointSuffix": "core.windows.net"
+      },
+      "AzureOpenAIEmbedding": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 8191,
+        // The number of dimensions output embeddings should have.
+        // Only supported in "text-embedding-3" and later models developed with
+        // MRL, see https://arxiv.org/abs/2205.13147
+        "EmbeddingDimensions": null
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
+        "MaxRetries": 10
+      },
+      "AzureQueues": {
+        // "ConnectionString" or "AzureIdentity". For other options see <AzureQueueConfig>.
+        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
+        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        "Auth": "AzureIdentity",
+        // Azure Storage account name, required when using AzureIdentity auth
+        // Note: you can use an env var 'KernelMemory__Services__AzureQueue__Account' to set this
+        "Account": "",
+        // Required when Auth == ConnectionString
+        // Note: you can use an env var 'KernelMemory__Services__AzureQueue__ConnectionString' to set this
+        "ConnectionString": "",
+        // Setting used only for country clouds
+        "EndpointSuffix": "core.windows.net",
+        // How often to check if there are new messages
+        "PollDelayMsecs": 100,
+        // How many messages to fetch at a time
+        "FetchBatchSize": 3,
+        // How long to lock messages once fetched. Azure Queue default is 30 secs
+        "FetchLockSeconds": 300,
+        // How many times to dequeue a messages and process before moving it to a poison queue
+        "MaxRetriesBeforePoisonQueue": 20,
+        // Suffix used for the poison queues.
+        "PoisonQueueSuffix": "-poison"
+      },
+      "Elasticsearch": {
+        // SHA-256 fingerprint. When running the docker image this is printed after starting the server
+        // See https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-stack-security.html#_use_the_ca_fingerprint_5
+        "CertificateFingerPrint": "",
+        // e.g. https://localhost:9200
+        "Endpoint": "",
+        // e.g. "elastic"
+        "UserName": "",
+        "Password": "",
+        "IndexPrefix": "",
+        "ShardCount": 1,
+        "Replicas": 0
+      },
+      "LlamaSharp": {
+        // path to file, e.g. "llama-2-7b-chat.Q6_K.gguf"
+        "ModelPath": "",
+        // Max number of tokens supported by the model
+        "MaxTokenTotal": 4096
+        // Optional parameters
+        // "GpuLayerCount": 32,
+        // "Seed": 1337,
+      },
+      "MongoDbAtlas": {
+        "ConnectionString": "mongodb://root:root@localhost:27777/?authSource=admin",
+        "DatabaseName": "KernelMemory",
+        "UseSingleCollectionForVectorSearch": false
+      },
+      "OpenAI": {
+        // Name of the model used to generate text (text completion or chat completion)
+        "TextModel": "gpt-3.5-turbo-16k",
+        // The max number of tokens supported by the text model.
+        "TextModelMaxTokenTotal": 16384,
+        // What type of text generation, by default autodetect using the model name.
+        // Possible values: "Auto", "TextCompletion", "Chat"
+        "TextGenerationType": "Auto",
+        // Name of the model used to generate text embeddings
+        "EmbeddingModel": "text-embedding-ada-002",
+        // The max number of tokens supported by the embedding model
+        // See https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
+        "EmbeddingModelMaxTokenTotal": 8191,
+        // OpenAI API Key
+        "APIKey": "",
+        // OpenAI Organization ID (usually empty, unless you have multiple accounts on different orgs)
+        "OrgId": "",
+        // Endpoint to use. By default the system uses 'https://api.openai.com/v1'.
+        // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
+        "Endpoint": "",
+        // How many times to retry in case of throttling
+        "MaxRetries": 10,
+        // The number of dimensions output embeddings should have.
+        // Only supported in "text-embedding-3" and later models developed with
+        // MRL, see https://arxiv.org/abs/2205.13147
+        "EmbeddingDimensions": null
+      },
+      "Postgres": {
+        // Postgres instance connection string
+        "ConnectionString": "Host=localhost;Port=5432;Username=public;Password=;Database=public",
+        // Mandatory prefix to add to the name of table managed by KM,
+        // e.g. to exclude other tables in the same schema.
+        "TableNamePrefix": "km-"
+      },
+      "Qdrant": {
+        // Qdrant endpoint
+        "Endpoint": "http://127.0.0.1:6333",
+        // Qdrant API key, e.g. when using Qdrant cloud
+        "APIKey": ""
+      },
+      "RabbitMQ": {
+        "Host": "127.0.0.1",
+        "Port": "5672",
+        "Username": "user",
+        "Password": "",
+        "VirtualHost": "/",
+        "MessageTTLSecs": 3600
+      },
+      "Redis": {
+        // Redis connection string, e.g. "localhost:6379,password=..."
+        "ConnectionString": "",
+        // List of tags that clients will use to filter memories. When using Redis,
+        // the list of tags must be configured, for data to be saved correctly.
+        "Tags": {
+          "type": ",",
+          "user": ",",
+          "ext": ","
+        }
+      },
+      "SimpleFileStorage": {
+        // Options: "Disk" or "Volatile". Volatile data is lost after each execution.
+        "StorageType": "Volatile",
+        // Directory where files are stored.
+        "Directory": "_files"
+      },
+      "SimpleQueues": {
+        // Options: "Disk" or "Volatile". Volatile data is lost after each execution.
+        "StorageType": "Volatile",
+        // Directory where files are stored.
+        "Directory": "_queues"
+      },
+      "SimpleVectorDb": {
+        // Options: "Disk" or "Volatile". Volatile data is lost after each execution.
+        "StorageType": "Volatile",
+        // Directory where files are stored.
+        "Directory": "_vectors"
+      },
+      "SqlServer": {
+        // MS SQL Server Connection string, e.g.
+        //    "Server=tcp:127.0.0.1,1433;Initial Catalog=master;Persist Security Info=False;User ID=sa;Password=00_CHANGE_ME_00;MultipleActiveResultSets=False;TrustServerCertificate=True;Connection Timeout=30;"
+        "ConnectionString": "",
+        "Schema": "dbo",
+        "MemoryCollectionTableName": "KMCollections",
+        "MemoryTableName": "KMMemories",
+        "EmbeddingsTableName": "KMEmbeddings",
+        "TagsTableName": "KMMemoriesTags"
+      }
+    }
+  }
+}

--- a/examples/301-discord-test-application/DiscordMessageHandler.cs
+++ b/examples/301-discord-test-application/DiscordMessageHandler.cs
@@ -39,7 +39,7 @@ public sealed class DiscordMessageHandler : IPipelineStepHandler, IDisposable, I
         ILoggerFactory? loggerFactory = null)
     {
         this.StepName = stepName;
-        this._log = loggerFactory?.CreateLogger<DiscordMessageHandler>() ?? DefaultLogger<DiscordMessageHandler>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<DiscordMessageHandler>();
 
         this._orchestrator = orchestrator;
         this._serviceProvider = serviceProvider;

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,5 +28,6 @@ Some examples about how to use Kernel Memory.
 24. [.NET configuration and logging](206-dotnet-configuration-and-logging)
 25. [Expanding chunks retrieving adjacent partitions](207-dotnet-expanding-chunks-on-retrieval)
 26. [Using local models via LM Studio](208-dotnet-lmstudio)
-26. [Using Context Parameters to customize RAG prompt during a request](209-dotnet-using-context-overrides)
-27. [Fetching data from Discord](301-discord-test-application)
+27. [Using Context Parameters to customize RAG prompt during a request](209-dotnet-using-context-overrides)
+28. [Creating a Memory instance without KernelMemoryBuilder](210-KM-without-builder)
+29. [Fetching data from Discord](301-discord-test-application)

--- a/extensions/Anthropic/AnthropicTextGeneration.cs
+++ b/extensions/Anthropic/AnthropicTextGeneration.cs
@@ -34,12 +34,12 @@ public sealed class AnthropicTextGeneration : ITextGenerator, IDisposable
     /// <param name="config">Client configuration, including credentials and model details</param>
     /// <param name="textTokenizer">Tokenizer used to count tokens</param>
     /// <param name="httpClientFactory">Optional factory used to inject a pre-configured HTTP client for requests to Anthropic API</param>
-    /// <param name="logFactory">Optional factory used to inject configured loggers</param>
+    /// <param name="loggerFactory">Optional factory used to inject configured loggers</param>
     public AnthropicTextGeneration(
         AnthropicConfiguration config,
         ITextTokenizer? textTokenizer = null,
         IHttpClientFactory? httpClientFactory = null,
-        ILoggerFactory? logFactory = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this._modelName = config.TextModelName;
         this._defaultSystemPrompt = !string.IsNullOrWhiteSpace(config.DefaultSystemPrompt) ? config.DefaultSystemPrompt : DefaultSystemPrompt;
@@ -47,9 +47,7 @@ public sealed class AnthropicTextGeneration : ITextGenerator, IDisposable
         // Using the smallest value for now - KM support MaxTokenIn and MaxTokenOut TODO
         this.MaxTokenTotal = config.MaxTokenOut;
 
-        this._log = (logFactory != null)
-            ? logFactory.CreateLogger<AnthropicTextGeneration>()
-            : DefaultLogger<AnthropicTextGeneration>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<AnthropicTextGeneration>();
 
         if (httpClientFactory == null)
         {

--- a/extensions/Anthropic/DependencyInjection.cs
+++ b/extensions/Anthropic/DependencyInjection.cs
@@ -56,7 +56,7 @@ public static partial class DependencyInjection
                     config: config,
                     textTokenizer: textTokenizer,
                     httpClientFactory: serviceProvider.GetService<IHttpClientFactory>(),
-                    logFactory: serviceProvider.GetService<ILoggerFactory>()));
+                    loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
         }
 
         return services.AddSingleton<ITextGenerator, AnthropicTextGeneration>();

--- a/extensions/AzureAIDocIntel/AzureAIDocIntelEngine.cs
+++ b/extensions/AzureAIDocIntel/AzureAIDocIntelEngine.cs
@@ -26,12 +26,12 @@ public sealed class AzureAIDocIntelEngine : IOcrEngine
     /// Creates a new instance of the Azure AI Document Intelligence.
     /// </summary>
     /// <param name="config">Azure AI Document Intelligence settings</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public AzureAIDocIntelEngine(
         AzureAIDocIntelConfig config,
-        ILogger<AzureAIDocIntelEngine>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
-        this._log = log ?? DefaultLogger<AzureAIDocIntelEngine>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<AzureAIDocIntelEngine>();
 
         switch (config.Auth)
         {

--- a/extensions/AzureAISearch/AzureAISearch/AzureAISearchMemory.cs
+++ b/extensions/AzureAISearch/AzureAISearch/AzureAISearchMemory.cs
@@ -40,14 +40,14 @@ public class AzureAISearchMemory : IMemoryDb, IMemoryDbUpsertBatch
     /// </summary>
     /// <param name="config">Azure AI Search configuration</param>
     /// <param name="embeddingGenerator">Text embedding generator</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public AzureAISearchMemory(
         AzureAISearchConfig config,
         ITextEmbeddingGenerator embeddingGenerator,
-        ILogger<AzureAISearchMemory>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this._embeddingGenerator = embeddingGenerator;
-        this._log = log ?? DefaultLogger<AzureAISearchMemory>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<AzureAISearchMemory>();
         this._useHybridSearch = config.UseHybridSearch;
 
         if (string.IsNullOrEmpty(config.Endpoint))

--- a/extensions/AzureBlobs/AzureBlobsStorage.cs
+++ b/extensions/AzureBlobs/AzureBlobsStorage.cs
@@ -33,10 +33,10 @@ public sealed class AzureBlobsStorage : IDocumentStorage
     public AzureBlobsStorage(
         AzureBlobsConfig config,
         IMimeTypeDetection? mimeTypeDetection = null,
-        ILogger<AzureBlobsStorage>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this._mimeTypeDetection = mimeTypeDetection ?? new MimeTypesDetection();
-        this._log = log ?? DefaultLogger<AzureBlobsStorage>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<AzureBlobsStorage>();
 
         BlobServiceClient client;
         switch (config.Auth)

--- a/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
+++ b/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
@@ -28,17 +28,8 @@ public sealed class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator,
         ITextTokenizer? textTokenizer = null,
         ILoggerFactory? loggerFactory = null,
         HttpClient? httpClient = null)
-        : this(config, textTokenizer, loggerFactory?.CreateLogger<AzureOpenAITextEmbeddingGenerator>(), httpClient)
     {
-    }
-
-    public AzureOpenAITextEmbeddingGenerator(
-        AzureOpenAIConfig config,
-        ITextTokenizer? textTokenizer = null,
-        ILogger<AzureOpenAITextEmbeddingGenerator>? log = null,
-        HttpClient? httpClient = null)
-    {
-        this._log = log ?? DefaultLogger<AzureOpenAITextEmbeddingGenerator>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<AzureOpenAITextEmbeddingGenerator>();
 
         if (textTokenizer == null)
         {
@@ -61,7 +52,8 @@ public sealed class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator,
                     credential: new DefaultAzureCredential(),
                     modelId: config.Deployment,
                     httpClient: httpClient,
-                    dimensions: config.EmbeddingDimensions);
+                    dimensions: config.EmbeddingDimensions,
+                    loggerFactory: loggerFactory);
                 break;
 
             case AzureOpenAIConfig.AuthTypes.ManualTokenCredential:
@@ -71,7 +63,8 @@ public sealed class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator,
                     credential: config.GetTokenCredential(),
                     modelId: config.Deployment,
                     httpClient: httpClient,
-                    dimensions: config.EmbeddingDimensions);
+                    dimensions: config.EmbeddingDimensions,
+                    loggerFactory: loggerFactory);
                 break;
 
             case AzureOpenAIConfig.AuthTypes.APIKey:
@@ -81,7 +74,8 @@ public sealed class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator,
                     apiKey: config.APIKey,
                     modelId: config.Deployment,
                     httpClient: httpClient,
-                    dimensions: config.EmbeddingDimensions);
+                    dimensions: config.EmbeddingDimensions,
+                    loggerFactory: loggerFactory);
                 break;
 
             default:

--- a/extensions/AzureOpenAI/AzureOpenAITextGenerator.cs
+++ b/extensions/AzureOpenAI/AzureOpenAITextGenerator.cs
@@ -32,17 +32,8 @@ public sealed class AzureOpenAITextGenerator : ITextGenerator
         ITextTokenizer? textTokenizer = null,
         ILoggerFactory? loggerFactory = null,
         HttpClient? httpClient = null)
-        : this(config, textTokenizer, loggerFactory?.CreateLogger<AzureOpenAITextGenerator>(), httpClient)
     {
-    }
-
-    public AzureOpenAITextGenerator(
-        AzureOpenAIConfig config,
-        ITextTokenizer? textTokenizer = null,
-        ILogger<AzureOpenAITextGenerator>? log = null,
-        HttpClient? httpClient = null)
-    {
-        this._log = log ?? DefaultLogger<AzureOpenAITextGenerator>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<AzureOpenAITextGenerator>();
 
         if (textTokenizer == null)
         {

--- a/extensions/AzureQueues/AzureQueuesPipeline.cs
+++ b/extensions/AzureQueues/AzureQueuesPipeline.cs
@@ -65,12 +65,12 @@ public sealed class AzureQueuesPipeline : IQueue
 
     public AzureQueuesPipeline(
         AzureQueuesConfig config,
-        ILogger<AzureQueuesPipeline>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this._config = config;
         this._config.Validate();
 
-        this._log = log ?? DefaultLogger<AzureQueuesPipeline>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<AzureQueuesPipeline>();
 
         switch (config.Auth)
         {

--- a/extensions/Discord/Discord/DiscordConnector.cs
+++ b/extensions/Discord/Discord/DiscordConnector.cs
@@ -12,6 +12,7 @@ using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.KernelMemory.Diagnostics;
 
 namespace Microsoft.KernelMemory.Sources.DiscordBot;
 
@@ -34,13 +35,13 @@ public sealed class DiscordConnector : IHostedService, IDisposable, IAsyncDispos
     /// </summary>
     /// <param name="config">Discord settings</param>
     /// <param name="memory">Memory instance used to upload files when messages arrives</param>
-    /// <param name="logFactory">App log factory</param>
+    /// <param name="loggerFactory">App log factory</param>
     public DiscordConnector(
         DiscordConnectorConfig config,
         IKernelMemory memory,
-        ILoggerFactory logFactory)
+        ILoggerFactory? loggerFactory = null)
     {
-        this._log = logFactory.CreateLogger<DiscordConnector>();
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<DiscordConnector>();
         this._authToken = config.DiscordToken;
 
         var dc = new DiscordSocketConfig

--- a/extensions/Elasticsearch/Elasticsearch/ElasticsearchMemory.cs
+++ b/extensions/Elasticsearch/Elasticsearch/ElasticsearchMemory.cs
@@ -26,14 +26,14 @@ public class ElasticsearchMemory : IMemoryDb
     /// Create a new instance of Elasticsearch KM connector
     /// </summary>
     /// <param name="config">Elasticsearch configuration</param>
-    /// <param name="client">Elasticsearch client</param>
-    /// <param name="log">Application logger</param>
     /// <param name="embeddingGenerator">Embedding generator</param>
+    /// <param name="client">Elasticsearch client</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public ElasticsearchMemory(
         ElasticsearchConfig config,
         ITextEmbeddingGenerator embeddingGenerator,
         ElasticsearchClient? client = null,
-        ILogger<ElasticsearchMemory>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         ArgumentNullExceptionEx.ThrowIfNull(embeddingGenerator, nameof(embeddingGenerator), "The embedding generator is NULL");
         ArgumentNullExceptionEx.ThrowIfNull(config, nameof(config), "The configuration is NULL");
@@ -41,7 +41,7 @@ public class ElasticsearchMemory : IMemoryDb
         this._embeddingGenerator = embeddingGenerator;
         this._config = config;
         this._client = client ?? new ElasticsearchClient(this._config.ToElasticsearchClientSettings());
-        this._log = log ?? DefaultLogger<ElasticsearchMemory>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<ElasticsearchMemory>();
     }
 
     /// <inheritdoc />

--- a/extensions/LlamaSharp/LlamaSharp/LlamaSharpTextGenerator.cs
+++ b/extensions/LlamaSharp/LlamaSharp/LlamaSharpTextGenerator.cs
@@ -30,27 +30,13 @@ public sealed class LlamaSharpTextGenerator : ITextGenerator, IDisposable
     /// </summary>
     /// <param name="config">Configuration settings</param>
     /// <param name="textTokenizer">Optional text tokenizer, replacing the one provided by the model</param>
-    /// <param name="loggerFactory">Optional .NET logger factory</param>
+    /// <param name="loggerFactory">Application logger instance</param>
     public LlamaSharpTextGenerator(
         LlamaSharpConfig config,
         ITextTokenizer? textTokenizer = null,
         ILoggerFactory? loggerFactory = null)
-        : this(config, textTokenizer, loggerFactory?.CreateLogger<LlamaSharpTextGenerator>())
     {
-    }
-
-    /// <summary>
-    /// Create new instance
-    /// </summary>
-    /// <param name="config">Configuration settings</param>
-    /// <param name="textTokenizer">Optional text tokenizer, replacing the one provided by the model</param>
-    /// <param name="log">Logger instance</param>
-    public LlamaSharpTextGenerator(
-        LlamaSharpConfig config,
-        ITextTokenizer? textTokenizer = null,
-        ILogger<LlamaSharpTextGenerator>? log = null)
-    {
-        this._log = log ?? DefaultLogger<LlamaSharpTextGenerator>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<LlamaSharpTextGenerator>();
 
         config.Validate();
         this.MaxTokenTotal = (int)config.MaxTokenTotal;

--- a/extensions/MongoDbAtlas/MongoDbAtlas/MongoDbAtlasMemory.cs
+++ b/extensions/MongoDbAtlas/MongoDbAtlas/MongoDbAtlasMemory.cs
@@ -34,16 +34,16 @@ public sealed class MongoDbAtlasMemory : MongoDbAtlasBaseStorage, IMemoryDb
     /// </summary>
     /// <param name="config">Configuration</param>
     /// <param name="embeddingGenerator">Embedding generator</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public MongoDbAtlasMemory(
         MongoDbAtlasConfig config,
         ITextEmbeddingGenerator embeddingGenerator,
-        ILogger<MongoDbAtlasMemory>? log = null) : base(config)
+        ILoggerFactory? loggerFactory = null) : base(config)
     {
         ArgumentNullExceptionEx.ThrowIfNull(embeddingGenerator, nameof(embeddingGenerator), "Embedding generator is null");
 
         this._embeddingGenerator = embeddingGenerator;
-        this._log = log ?? DefaultLogger<MongoDbAtlasMemory>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<MongoDbAtlasMemory>();
         this._utils = new MongoDbAtlasSearchHelper(this.Config.ConnectionString, this.Config.DatabaseName);
     }
 

--- a/extensions/OpenAI/OpenAITextEmbeddingGenerator.cs
+++ b/extensions/OpenAI/OpenAITextEmbeddingGenerator.cs
@@ -43,8 +43,7 @@ public sealed class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator, ITex
         ITextTokenizer? textTokenizer = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._log = loggerFactory?.CreateLogger<OpenAITextEmbeddingGenerator>()
-                    ?? DefaultLogger<OpenAITextEmbeddingGenerator>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<OpenAITextEmbeddingGenerator>();
 
         this.SetTokenizer(textTokenizer);
         this.MaxTokens = config.EmbeddingModelMaxTokenTotal;
@@ -52,8 +51,8 @@ public sealed class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator, ITex
         this._client = new OpenAITextEmbeddingGenerationService(
             modelId: config.EmbeddingModel,
             openAIClient: openAIClient,
-            loggerFactory: loggerFactory,
-            dimensions: config.EmbeddingDimensions);
+            dimensions: config.EmbeddingDimensions,
+            loggerFactory: loggerFactory);
     }
 
     /// <summary>
@@ -70,8 +69,7 @@ public sealed class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator, ITex
         ITextTokenizer? textTokenizer = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._log = loggerFactory?.CreateLogger<OpenAITextEmbeddingGenerator>()
-                    ?? DefaultLogger<OpenAITextEmbeddingGenerator>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<OpenAITextEmbeddingGenerator>();
 
         this.SetTokenizer(textTokenizer);
         this.MaxTokens = config.EmbeddingModelMaxTokenTotal;
@@ -81,7 +79,6 @@ public sealed class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator, ITex
 
     /// <summary>
     /// Create new instance.
-    /// This constructor passes the given logger factory to the internal SK service.
     /// </summary>
     /// <param name="config">Endpoint and model configuration</param>
     /// <param name="textTokenizer">Text tokenizer, possibly matching the model used</param>
@@ -93,8 +90,7 @@ public sealed class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator, ITex
         ILoggerFactory? loggerFactory = null,
         HttpClient? httpClient = null)
     {
-        this._log = loggerFactory?.CreateLogger<OpenAITextEmbeddingGenerator>()
-                    ?? DefaultLogger<OpenAITextEmbeddingGenerator>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<OpenAITextEmbeddingGenerator>();
 
         this.SetTokenizer(textTokenizer);
         this.MaxTokens = config.EmbeddingModelMaxTokenTotal;
@@ -103,31 +99,6 @@ public sealed class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator, ITex
             modelId: config.EmbeddingModel,
             openAIClient: OpenAIClientBuilder.BuildOpenAIClient(config, httpClient),
             loggerFactory: loggerFactory,
-            dimensions: config.EmbeddingDimensions);
-    }
-
-    /// <summary>
-    /// Create new instance.
-    /// This constructor does not pass the given logger to the internal SK service.
-    /// </summary>
-    /// <param name="config">Endpoint and model configuration</param>
-    /// <param name="textTokenizer">Text tokenizer, possibly matching the model used</param>
-    /// <param name="log">Application logger</param>
-    /// <param name="httpClient">Optional HTTP client with custom settings</param>
-    public OpenAITextEmbeddingGenerator(
-        OpenAIConfig config,
-        ITextTokenizer? textTokenizer = null,
-        ILogger<OpenAITextEmbeddingGenerator>? log = null,
-        HttpClient? httpClient = null)
-    {
-        this._log = log ?? DefaultLogger<OpenAITextEmbeddingGenerator>.Instance;
-
-        this.SetTokenizer(textTokenizer);
-        this.MaxTokens = config.EmbeddingModelMaxTokenTotal;
-
-        this._client = new OpenAITextEmbeddingGenerationService(
-            modelId: config.EmbeddingModel,
-            openAIClient: OpenAIClientBuilder.BuildOpenAIClient(config, httpClient),
             dimensions: config.EmbeddingDimensions);
     }
 

--- a/extensions/OpenAI/OpenAITextGenerator.cs
+++ b/extensions/OpenAI/OpenAITextGenerator.cs
@@ -56,7 +56,7 @@ public sealed class OpenAITextGenerator : ITextGenerator
         ITextTokenizer? textTokenizer = null,
         ILoggerFactory? loggerFactory = null)
     {
-        this._log = loggerFactory?.CreateLogger<OpenAITextGenerator>() ?? DefaultLogger<OpenAITextGenerator>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<OpenAITextGenerator>();
 
         this.MaxTokenTotal = config.TextModelMaxTokenTotal;
         this.SetCompletionType(config);
@@ -77,7 +77,7 @@ public sealed class OpenAITextGenerator : ITextGenerator
         ILoggerFactory? loggerFactory = null,
         HttpClient? httpClient = null)
     {
-        this._log = loggerFactory?.CreateLogger<OpenAITextGenerator>() ?? DefaultLogger<OpenAITextGenerator>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<OpenAITextGenerator>();
 
         this.MaxTokenTotal = config.TextModelMaxTokenTotal;
         this.SetCompletionType(config);

--- a/extensions/Postgres/Postgres/Internals/PostgresDbClient.cs
+++ b/extensions/Postgres/Postgres/Internals/PostgresDbClient.cs
@@ -46,11 +46,11 @@ internal sealed class PostgresDbClient : IDisposable
     /// Initializes a new instance of the <see cref="PostgresDbClient"/> class.
     /// </summary>
     /// <param name="config">Configuration</param>
-    /// <param name="log">Application logger</param>
-    public PostgresDbClient(PostgresConfig config, ILogger? log = null)
+    /// <param name="loggerFactory">Application logger factory</param>
+    public PostgresDbClient(PostgresConfig config, ILoggerFactory? loggerFactory = null)
     {
         config.Validate();
-        this._log = log ?? DefaultLogger<PostgresDbClient>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<PostgresDbClient>();
 
         NpgsqlDataSourceBuilder dataSourceBuilder = new(config.ConnectionString);
         this._dbNamePresent = config.ConnectionString.Contains("Database=", StringComparison.OrdinalIgnoreCase);

--- a/extensions/Postgres/Postgres/PostgresMemory.cs
+++ b/extensions/Postgres/Postgres/PostgresMemory.cs
@@ -32,13 +32,13 @@ public sealed class PostgresMemory : IMemoryDb, IDisposable
     /// </summary>
     /// <param name="config">Postgres configuration</param>
     /// <param name="embeddingGenerator">Text embedding generator</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public PostgresMemory(
         PostgresConfig config,
         ITextEmbeddingGenerator embeddingGenerator,
-        ILogger<PostgresMemory>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
-        this._log = log ?? DefaultLogger<PostgresMemory>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<PostgresMemory>();
 
         this._embeddingGenerator = embeddingGenerator;
         if (this._embeddingGenerator == null)
@@ -49,7 +49,7 @@ public sealed class PostgresMemory : IMemoryDb, IDisposable
         // Normalize underscore and check for invalid symbols
         config.TableNamePrefix = NormalizeTableNamePrefix(config.TableNamePrefix);
 
-        this._db = new PostgresDbClient(config, this._log);
+        this._db = new PostgresDbClient(config, loggerFactory);
     }
 
     /// <inheritdoc />

--- a/extensions/Qdrant/Qdrant/Internals/QdrantClient.cs
+++ b/extensions/Qdrant/Qdrant/Internals/QdrantClient.cs
@@ -60,17 +60,17 @@ internal sealed class QdrantClient<T> where T : DefaultQdrantPayload, new()
     /// <summary>
     /// Initializes a new instance of this class.
     /// </summary>
-    /// <param name="endpoint">The Qdrant Vector Database endpoint.</param>
+    /// <param name="endpoint">The Qdrant Vector Database endpoint</param>
     /// <param name="apiKey">API key for Qdrant cloud</param>
-    /// <param name="httpClient">Optional HTTP client override.</param>
-    /// <param name="log">Application logger.</param>
+    /// <param name="httpClient">Optional HTTP client override</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public QdrantClient(
         string endpoint,
         string? apiKey = null,
         HttpClient? httpClient = null,
-        ILogger<QdrantClient<T>>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
-        this._log = log ?? DefaultLogger<QdrantClient<T>>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<QdrantClient<T>>();
         this._apiKey = apiKey;
         this._httpClient = httpClient ?? new HttpClient(NonDisposableHttpClientHandler.Instance, disposeHandler: false);
         this._httpClient.BaseAddress = SanitizeEndpoint(endpoint);

--- a/extensions/Qdrant/Qdrant/QdrantMemory.cs
+++ b/extensions/Qdrant/Qdrant/QdrantMemory.cs
@@ -33,11 +33,11 @@ public sealed class QdrantMemory : IMemoryDb, IMemoryDbUpsertBatch
     /// </summary>
     /// <param name="config">Qdrant connector configuration</param>
     /// <param name="embeddingGenerator">Text embedding generator</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public QdrantMemory(
         QdrantConfig config,
         ITextEmbeddingGenerator embeddingGenerator,
-        ILogger<QdrantMemory>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this._embeddingGenerator = embeddingGenerator;
 
@@ -46,8 +46,8 @@ public sealed class QdrantMemory : IMemoryDb, IMemoryDbUpsertBatch
             throw new QdrantException("Embedding generator not configured");
         }
 
-        this._log = log ?? DefaultLogger<QdrantMemory>.Instance;
-        this._qdrantClient = new QdrantClient<DefaultQdrantPayload>(endpoint: config.Endpoint, apiKey: config.APIKey);
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<QdrantMemory>();
+        this._qdrantClient = new QdrantClient<DefaultQdrantPayload>(endpoint: config.Endpoint, apiKey: config.APIKey, loggerFactory: loggerFactory);
     }
 
     /// <inheritdoc />

--- a/extensions/RabbitMQ/RabbitMQPipeline.cs
+++ b/extensions/RabbitMQ/RabbitMQPipeline.cs
@@ -26,9 +26,9 @@ public sealed class RabbitMQPipeline : IQueue
     /// <summary>
     /// Create a new RabbitMQ queue instance
     /// </summary>
-    public RabbitMQPipeline(RabbitMqConfig config, ILogger<RabbitMQPipeline>? log = null)
+    public RabbitMQPipeline(RabbitMqConfig config, ILoggerFactory? loggerFactory = null)
     {
-        this._log = log ?? DefaultLogger<RabbitMQPipeline>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<RabbitMQPipeline>();
 
         // see https://www.rabbitmq.com/dotnet-api-guide.html#consuming-async
         var factory = new ConnectionFactory

--- a/extensions/Redis/Redis.TestApplication/Program.cs
+++ b/extensions/Redis/Redis.TestApplication/Program.cs
@@ -158,7 +158,7 @@ public static class Program
                 EmbeddingModel = "text-embedding-ada-002",
                 EmbeddingModelMaxTokenTotal = 8_191,
                 APIKey = openAIApiKey
-            }, log: null);
+            }, loggerFactory: null);
         }
         else
         {

--- a/extensions/SQLServer/SQLServer/SqlServerMemory.cs
+++ b/extensions/SQLServer/SQLServer/SqlServerMemory.cs
@@ -54,15 +54,15 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
     /// </summary>
     /// <param name="config">The SQL server instance configuration.</param>
     /// <param name="embeddingGenerator">The text embedding generator.</param>
-    /// <param name="log">The logger.</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public SqlServerMemory(
         SqlServerConfig config,
         ITextEmbeddingGenerator embeddingGenerator,
-        ILogger<SqlServerMemory>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this._config = config;
         this._embeddingGenerator = embeddingGenerator ?? throw new ConfigurationException("Embedding generator not configured");
-        this._log = log ?? DefaultLogger<SqlServerMemory>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<SqlServerMemory>();
     }
 
     /// <inheritdoc/>

--- a/service/Abstractions/Models/MemoryAnswer.cs
+++ b/service/Abstractions/Models/MemoryAnswer.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -62,5 +65,26 @@ public class MemoryAnswer
     {
         return JsonSerializer.Deserialize<MemoryAnswer>(json, s_caseInsensitiveJsonOptions)
                ?? new MemoryAnswer();
+    }
+
+    public override string ToString()
+    {
+        var result = new StringBuilder();
+        result.AppendLine(this.Result);
+
+        if (!this.NoResult)
+        {
+            var sources = new Dictionary<string, string>();
+            foreach (var x in this.RelevantSources)
+            {
+                string date = x.Partitions.First().LastUpdate.ToString("D", CultureInfo.CurrentCulture);
+                sources[x.Index + x.Link] = $"  - {x.SourceName} [{date}]";
+            }
+
+            result.AppendLine("- Sources:");
+            result.AppendLine(string.Join("\n", sources.Values));
+        }
+
+        return result.ToString();
     }
 }

--- a/service/Core/AI/NoEmbeddingGenerator.cs
+++ b/service/Core/AI/NoEmbeddingGenerator.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.KernelMemory.Diagnostics;
 
 namespace Microsoft.KernelMemory.AI;
 
@@ -13,11 +14,11 @@ namespace Microsoft.KernelMemory.AI;
 /// </summary>
 public class NoEmbeddingGenerator : ITextEmbeddingGenerator
 {
-    private readonly ILogger<ITextEmbeddingGenerator> _log;
+    private readonly ILogger<NoEmbeddingGenerator> _log;
 
-    public NoEmbeddingGenerator(ILoggerFactory loggerFactory)
+    public NoEmbeddingGenerator(ILoggerFactory? loggerFactory = null)
     {
-        this._log = loggerFactory.CreateLogger<ITextEmbeddingGenerator>();
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<NoEmbeddingGenerator>();
     }
 
     /// <inheritdoc />

--- a/service/Core/AI/NoTextGenerator.cs
+++ b/service/Core/AI/NoTextGenerator.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Extensions.Logging;
+using Microsoft.KernelMemory.Diagnostics;
 
 namespace Microsoft.KernelMemory.AI;
 
@@ -13,11 +14,11 @@ namespace Microsoft.KernelMemory.AI;
 /// </summary>
 public class NoTextGenerator : ITextGenerator
 {
-    private readonly ILogger<ITextGenerator> _log;
+    private readonly ILogger<NoTextGenerator> _log;
 
-    public NoTextGenerator(ILoggerFactory loggerFactory)
+    public NoTextGenerator(ILoggerFactory? loggerFactory = null)
     {
-        this._log = loggerFactory.CreateLogger<ITextGenerator>();
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<NoTextGenerator>();
     }
 
     /// <inheritdoc />

--- a/service/Core/DataFormats/Image/ImageDecoder.cs
+++ b/service/Core/DataFormats/Image/ImageDecoder.cs
@@ -17,10 +17,10 @@ public sealed class ImageDecoder : IContentDecoder
     private readonly IOcrEngine? _ocrEngine;
     private readonly ILogger<ImageDecoder> _log;
 
-    public ImageDecoder(IOcrEngine? ocrEngine = null, ILogger<ImageDecoder>? log = null)
+    public ImageDecoder(IOcrEngine? ocrEngine = null, ILoggerFactory? loggerFactory = null)
     {
         this._ocrEngine = ocrEngine;
-        this._log = log ?? DefaultLogger<ImageDecoder>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<ImageDecoder>();
     }
 
     /// <inheritdoc />

--- a/service/Core/DataFormats/Office/MsExcelDecoder.cs
+++ b/service/Core/DataFormats/Office/MsExcelDecoder.cs
@@ -20,10 +20,10 @@ public sealed class MsExcelDecoder : IContentDecoder
     private readonly MsExcelDecoderConfig _config;
     private readonly ILogger<MsExcelDecoder> _log;
 
-    public MsExcelDecoder(MsExcelDecoderConfig? config = null, ILogger<MsExcelDecoder>? log = null)
+    public MsExcelDecoder(MsExcelDecoderConfig? config = null, ILoggerFactory? loggerFactory = null)
     {
         this._config = config ?? new MsExcelDecoderConfig();
-        this._log = log ?? DefaultLogger<MsExcelDecoder>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<MsExcelDecoder>();
     }
 
     /// <inheritdoc />

--- a/service/Core/DataFormats/Office/MsPowerPointDecoder.cs
+++ b/service/Core/DataFormats/Office/MsPowerPointDecoder.cs
@@ -22,10 +22,10 @@ public sealed class MsPowerPointDecoder : IContentDecoder
     private readonly MsPowerPointDecoderConfig _config;
     private readonly ILogger<MsPowerPointDecoder> _log;
 
-    public MsPowerPointDecoder(MsPowerPointDecoderConfig? config = null, ILogger<MsPowerPointDecoder>? log = null)
+    public MsPowerPointDecoder(MsPowerPointDecoderConfig? config = null, ILoggerFactory? loggerFactory = null)
     {
         this._config = config ?? new MsPowerPointDecoderConfig();
-        this._log = log ?? DefaultLogger<MsPowerPointDecoder>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<MsPowerPointDecoder>();
     }
 
     /// <inheritdoc />

--- a/service/Core/DataFormats/Office/MsWordDecoder.cs
+++ b/service/Core/DataFormats/Office/MsWordDecoder.cs
@@ -20,9 +20,9 @@ public sealed class MsWordDecoder : IContentDecoder
 {
     private readonly ILogger<MsWordDecoder> _log;
 
-    public MsWordDecoder(ILogger<MsWordDecoder>? log = null)
+    public MsWordDecoder(ILoggerFactory? loggerFactory = null)
     {
-        this._log = log ?? DefaultLogger<MsWordDecoder>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<MsWordDecoder>();
     }
 
     /// <inheritdoc />

--- a/service/Core/DataFormats/Pdf/PdfDecoder.cs
+++ b/service/Core/DataFormats/Pdf/PdfDecoder.cs
@@ -20,9 +20,9 @@ public sealed class PdfDecoder : IContentDecoder
 {
     private readonly ILogger<PdfDecoder> _log;
 
-    public PdfDecoder(ILogger<PdfDecoder>? log = null)
+    public PdfDecoder(ILoggerFactory? loggerFactory = null)
     {
-        this._log = log ?? DefaultLogger<PdfDecoder>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<PdfDecoder>();
     }
 
     /// <inheritdoc />

--- a/service/Core/DataFormats/Text/MarkDownDecoder.cs
+++ b/service/Core/DataFormats/Text/MarkDownDecoder.cs
@@ -16,9 +16,9 @@ public sealed class MarkDownDecoder : IContentDecoder
 {
     private readonly ILogger<MarkDownDecoder> _log;
 
-    public MarkDownDecoder(ILogger<MarkDownDecoder>? log = null)
+    public MarkDownDecoder(ILoggerFactory? loggerFactory = null)
     {
-        this._log = log ?? DefaultLogger<MarkDownDecoder>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<MarkDownDecoder>();
     }
 
     /// <inheritdoc />

--- a/service/Core/DataFormats/Text/TextDecoder.cs
+++ b/service/Core/DataFormats/Text/TextDecoder.cs
@@ -16,9 +16,9 @@ public sealed class TextDecoder : IContentDecoder
 {
     private readonly ILogger<TextDecoder> _log;
 
-    public TextDecoder(ILogger<TextDecoder>? log = null)
+    public TextDecoder(ILoggerFactory? loggerFactory = null)
     {
-        this._log = log ?? DefaultLogger<TextDecoder>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<TextDecoder>();
     }
 
     /// <inheritdoc />

--- a/service/Core/DataFormats/WebPages/HtmlDecoder.cs
+++ b/service/Core/DataFormats/WebPages/HtmlDecoder.cs
@@ -17,9 +17,9 @@ public sealed class HtmlDecoder : IContentDecoder
 {
     private readonly ILogger<HtmlDecoder> _log;
 
-    public HtmlDecoder(ILogger<HtmlDecoder>? log = null)
+    public HtmlDecoder(ILoggerFactory? loggerFactory = null)
     {
-        this._log = log ?? DefaultLogger<HtmlDecoder>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<HtmlDecoder>();
     }
 
     /// <inheritdoc />

--- a/service/Core/DataFormats/WebPages/WebScraper.cs
+++ b/service/Core/DataFormats/WebPages/WebScraper.cs
@@ -25,12 +25,12 @@ public sealed class WebScraper : IWebScraper, IDisposable
 
     public WebScraper(
         HttpClient? httpClient = null,
-        ILogger<WebScraper>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this._httpClient = httpClient ?? new HttpClient();
         this._httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(Telemetry.HttpUserAgent);
 
-        this._log = log ?? DefaultLogger<WebScraper>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<WebScraper>();
     }
 
     /// <inheritdoc />

--- a/service/Core/DocumentStorage/DevTools/SimpleFileStorage.cs
+++ b/service/Core/DocumentStorage/DevTools/SimpleFileStorage.cs
@@ -21,17 +21,17 @@ public class SimpleFileStorage : IDocumentStorage
     public SimpleFileStorage(
         SimpleFileStorageConfig config,
         IMimeTypeDetection? mimeTypeDetection = null,
-        ILogger<SimpleFileStorage>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
-        this._log = log ?? DefaultLogger<SimpleFileStorage>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<SimpleFileStorage>();
         switch (config.StorageType)
         {
             case FileSystemTypes.Disk:
-                this._fileSystem = new DiskFileSystem(config.Directory, mimeTypeDetection, this._log);
+                this._fileSystem = new DiskFileSystem(config.Directory, mimeTypeDetection, loggerFactory);
                 break;
 
             case FileSystemTypes.Volatile:
-                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, mimeTypeDetection, this._log);
+                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, mimeTypeDetection, loggerFactory);
                 break;
 
             default:

--- a/service/Core/FileSystem/DevTools/DiskFileSystem.cs
+++ b/service/Core/FileSystem/DevTools/DiskFileSystem.cs
@@ -30,11 +30,11 @@ internal sealed class DiskFileSystem : IFileSystem
     public DiskFileSystem(
         string directory,
         IMimeTypeDetection? mimeTypeDetection = null,
-        ILogger? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this._dataPath = directory;
         this._mimeTypeDetection = mimeTypeDetection ?? new MimeTypesDetection();
-        this._log = log ?? DefaultLogger<DiskFileSystem>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<DiskFileSystem>();
         this.CreateDirectory(this._dataPath);
     }
 

--- a/service/Core/FileSystem/DevTools/VolatileFileSystem.cs
+++ b/service/Core/FileSystem/DevTools/VolatileFileSystem.cs
@@ -36,10 +36,10 @@ internal sealed class VolatileFileSystem : IFileSystem
     /// <summary>
     /// Ctor accessible to unit tests only.
     /// </summary>
-    internal VolatileFileSystem(IMimeTypeDetection? mimeTypeDetection = null, ILogger? log = null)
+    internal VolatileFileSystem(IMimeTypeDetection? mimeTypeDetection = null, ILoggerFactory? loggerFactory = null)
     {
         this._mimeTypeDetection = mimeTypeDetection ?? new MimeTypesDetection();
-        this._log = log ?? DefaultLogger<VolatileFileSystem>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<VolatileFileSystem>();
     }
 
     /// <summary>
@@ -47,13 +47,15 @@ internal sealed class VolatileFileSystem : IFileSystem
     /// (directories and files) across clients. E.g. the simple queue requires a shared
     /// instance to work properly.
     /// </summary>
-    public static VolatileFileSystem GetInstance(string directory, IMimeTypeDetection? mimeTypeDetection = null, ILogger? log = null)
+    public static VolatileFileSystem GetInstance(string directory, IMimeTypeDetection? mimeTypeDetection = null, ILoggerFactory? loggerFactory = null)
     {
         directory = directory.Trim('/').Trim('\\').ToLowerInvariant();
         if (!s_singletons.ContainsKey(directory))
         {
             // s_singletons[directory] = new VolatileFileSystem(log);
-            s_singletons.AddOrUpdate(directory, _ => new VolatileFileSystem(mimeTypeDetection, log), (_, _) => new VolatileFileSystem(mimeTypeDetection, log));
+            s_singletons.AddOrUpdate(directory,
+                _ => new VolatileFileSystem(mimeTypeDetection, loggerFactory),
+                (_, _) => new VolatileFileSystem(mimeTypeDetection, loggerFactory));
         }
 
         return s_singletons[directory];

--- a/service/Core/Handlers/DeleteDocumentHandler.cs
+++ b/service/Core/Handlers/DeleteDocumentHandler.cs
@@ -23,12 +23,12 @@ public sealed class DeleteDocumentHandler : IPipelineStepHandler
         string stepName,
         IDocumentStorage documentStorage,
         List<IMemoryDb> memoryDbs,
-        ILogger<DeleteDocumentHandler>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this.StepName = stepName;
         this._documentStorage = documentStorage;
         this._memoryDbs = memoryDbs;
-        this._log = log ?? DefaultLogger<DeleteDocumentHandler>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<DeleteDocumentHandler>();
 
         this._log.LogInformation("Handler '{0}' ready", stepName);
     }

--- a/service/Core/Handlers/DeleteGeneratedFilesHandler.cs
+++ b/service/Core/Handlers/DeleteGeneratedFilesHandler.cs
@@ -19,11 +19,11 @@ public sealed class DeleteGeneratedFilesHandler : IPipelineStepHandler
     public DeleteGeneratedFilesHandler(
         string stepName,
         IDocumentStorage documentStorage,
-        ILogger<DeleteGeneratedFilesHandler>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this.StepName = stepName;
         this._documentStorage = documentStorage;
-        this._log = log ?? DefaultLogger<DeleteGeneratedFilesHandler>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<DeleteGeneratedFilesHandler>();
 
         this._log.LogInformation("Handler '{0}' ready", stepName);
     }

--- a/service/Core/Handlers/DeleteIndexHandler.cs
+++ b/service/Core/Handlers/DeleteIndexHandler.cs
@@ -23,12 +23,12 @@ public sealed class DeleteIndexHandler : IPipelineStepHandler
         string stepName,
         IDocumentStorage documentStorage,
         List<IMemoryDb> memoryDbs,
-        ILogger<DeleteIndexHandler>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this.StepName = stepName;
         this._documentStorage = documentStorage;
         this._memoryDbs = memoryDbs;
-        this._log = log ?? DefaultLogger<DeleteIndexHandler>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<DeleteIndexHandler>();
 
         this._log.LogInformation("Handler '{0}' ready", stepName);
     }

--- a/service/Core/Handlers/GenerateEmbeddingsHandler.cs
+++ b/service/Core/Handlers/GenerateEmbeddingsHandler.cs
@@ -33,14 +33,14 @@ public sealed class GenerateEmbeddingsHandler : IPipelineStepHandler
     /// </summary>
     /// <param name="stepName">Pipeline step for which the handler will be invoked</param>
     /// <param name="orchestrator">Current orchestrator used by the pipeline, giving access to content and other helps.</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public GenerateEmbeddingsHandler(
         string stepName,
         IPipelineOrchestrator orchestrator,
-        ILogger<GenerateEmbeddingsHandler>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this.StepName = stepName;
-        this._log = log ?? DefaultLogger<GenerateEmbeddingsHandler>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<GenerateEmbeddingsHandler>();
         this._embeddingGenerationEnabled = orchestrator.EmbeddingGenerationEnabled;
 
         this._orchestrator = orchestrator;

--- a/service/Core/Handlers/GenerateEmbeddingsParallelHandler.cs
+++ b/service/Core/Handlers/GenerateEmbeddingsParallelHandler.cs
@@ -33,14 +33,14 @@ public sealed class GenerateEmbeddingsParallelHandler : IPipelineStepHandler
     /// </summary>
     /// <param name="stepName">Pipeline step for which the handler will be invoked</param>
     /// <param name="orchestrator">Current orchestrator used by the pipeline, giving access to content and other helps.</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public GenerateEmbeddingsParallelHandler(
         string stepName,
         IPipelineOrchestrator orchestrator,
-        ILogger<GenerateEmbeddingsParallelHandler>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this.StepName = stepName;
-        this._log = log ?? DefaultLogger<GenerateEmbeddingsParallelHandler>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<GenerateEmbeddingsParallelHandler>();
         this._embeddingGenerationEnabled = orchestrator.EmbeddingGenerationEnabled;
 
         this._orchestrator = orchestrator;

--- a/service/Core/Handlers/HandlerAsAHostedService.cs
+++ b/service/Core/Handlers/HandlerAsAHostedService.cs
@@ -26,13 +26,13 @@ public sealed class HandlerAsAHostedService<T> : IHostedService where T : IPipel
         string stepName,
         IPipelineOrchestrator orchestrator,
         T handler,
-        ILogger<HandlerAsAHostedService<T>>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this._stepName = stepName;
         this._orchestrator = orchestrator;
         this._handler = handler;
 
-        this._log = log ?? DefaultLogger<HandlerAsAHostedService<T>>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<HandlerAsAHostedService<T>>();
         this._log.LogInformation("Handler as service created: {0}", stepName);
     }
 

--- a/service/Core/Handlers/SaveRecordsHandler.cs
+++ b/service/Core/Handlers/SaveRecordsHandler.cs
@@ -62,15 +62,15 @@ public sealed class SaveRecordsHandler : IPipelineStepHandler
     /// <param name="stepName">Pipeline step for which the handler will be invoked</param>
     /// <param name="orchestrator">Current orchestrator used by the pipeline, giving access to content and other helps.</param>
     /// <param name="config">Configuration settings</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public SaveRecordsHandler(
         string stepName,
         IPipelineOrchestrator orchestrator,
         KernelMemoryConfig? config = null,
-        ILogger<SaveRecordsHandler>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this.StepName = stepName;
-        this._log = log ?? DefaultLogger<SaveRecordsHandler>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<SaveRecordsHandler>();
         this._embeddingGenerationEnabled = orchestrator.EmbeddingGenerationEnabled;
 
         this._orchestrator = orchestrator;

--- a/service/Core/Handlers/SummarizationHandler.cs
+++ b/service/Core/Handlers/SummarizationHandler.cs
@@ -35,12 +35,12 @@ public sealed class SummarizationHandler : IPipelineStepHandler
     /// <param name="stepName">Pipeline step for which the handler will be invoked</param>
     /// <param name="orchestrator">Current orchestrator used by the pipeline, giving access to content and other helps.</param>
     /// <param name="promptProvider">Class responsible for providing a given prompt</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public SummarizationHandler(
         string stepName,
         IPipelineOrchestrator orchestrator,
         IPromptProvider? promptProvider = null,
-        ILogger<SummarizationHandler>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this.StepName = stepName;
         this._orchestrator = orchestrator;
@@ -48,7 +48,7 @@ public sealed class SummarizationHandler : IPipelineStepHandler
         promptProvider ??= new EmbeddedPromptProvider();
         this._summarizationPrompt = promptProvider.ReadPrompt(Constants.PromptNamesSummarize);
 
-        this._log = log ?? DefaultLogger<SummarizationHandler>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<SummarizationHandler>();
 
         this._log.LogInformation("Handler '{0}' ready", stepName);
     }

--- a/service/Core/Handlers/SummarizationParallelHandler.cs
+++ b/service/Core/Handlers/SummarizationParallelHandler.cs
@@ -34,12 +34,12 @@ public sealed class SummarizationParallelHandler : IPipelineStepHandler
     /// <param name="stepName">Pipeline step for which the handler will be invoked</param>
     /// <param name="orchestrator">Current orchestrator used by the pipeline, giving access to content and other helps.</param>
     /// <param name="promptProvider">Class responsible for providing a given prompt</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public SummarizationParallelHandler(
         string stepName,
         IPipelineOrchestrator orchestrator,
         IPromptProvider? promptProvider = null,
-        ILogger<SummarizationParallelHandler>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this.StepName = stepName;
         this._orchestrator = orchestrator;
@@ -47,7 +47,7 @@ public sealed class SummarizationParallelHandler : IPipelineStepHandler
         promptProvider ??= new EmbeddedPromptProvider();
         this._summarizationPrompt = promptProvider.ReadPrompt(Constants.PromptNamesSummarize);
 
-        this._log = log ?? DefaultLogger<SummarizationParallelHandler>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<SummarizationParallelHandler>();
 
         this._log.LogInformation("Handler '{0}' ready", stepName);
     }

--- a/service/Core/Handlers/TextExtractionHandler.cs
+++ b/service/Core/Handlers/TextExtractionHandler.cs
@@ -36,18 +36,18 @@ public sealed class TextExtractionHandler : IPipelineStepHandler, IDisposable
     /// <param name="orchestrator">Current orchestrator used by the pipeline, giving access to content and other helps.</param>
     /// <param name="decoders">The list of content decoders for extracting content</param>
     /// <param name="webScraper">Web scraper instance used to fetch web pages</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public TextExtractionHandler(
         string stepName,
         IPipelineOrchestrator orchestrator,
         IEnumerable<IContentDecoder> decoders,
         IWebScraper? webScraper = null,
-        ILogger<TextExtractionHandler>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this.StepName = stepName;
         this._orchestrator = orchestrator;
         this._decoders = decoders;
-        this._log = log ?? DefaultLogger<TextExtractionHandler>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<TextExtractionHandler>();
         this._webScraper = webScraper ?? new WebScraper();
 
         this._log.LogInformation("Handler '{0}' ready", stepName);

--- a/service/Core/Handlers/TextPartitioningHandler.cs
+++ b/service/Core/Handlers/TextPartitioningHandler.cs
@@ -33,12 +33,12 @@ public sealed class TextPartitioningHandler : IPipelineStepHandler
     /// <param name="stepName">Pipeline step for which the handler will be invoked</param>
     /// <param name="orchestrator">Current orchestrator used by the pipeline, giving access to content and other helps.</param>
     /// <param name="options">The customize text partitioning option</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public TextPartitioningHandler(
         string stepName,
         IPipelineOrchestrator orchestrator,
         TextPartitioningOptions? options = null,
-        ILogger<TextPartitioningHandler>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this.StepName = stepName;
         this._orchestrator = orchestrator;
@@ -46,7 +46,7 @@ public sealed class TextPartitioningHandler : IPipelineStepHandler
         this._options = options ?? new TextPartitioningOptions();
         this._options.Validate();
 
-        this._log = log ?? DefaultLogger<TextPartitioningHandler>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<TextPartitioningHandler>();
         this._log.LogInformation("Handler '{0}' ready", stepName);
 
         this._tokenCounter = DefaultGPTTokenizer.StaticCountTokens;

--- a/service/Core/MemoryStorage/DevTools/SimpleTextDb.cs
+++ b/service/Core/MemoryStorage/DevTools/SimpleTextDb.cs
@@ -29,17 +29,17 @@ public class SimpleTextDb : IMemoryDb
 
     public SimpleTextDb(
         SimpleTextDbConfig config,
-        ILogger<SimpleTextDb>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
-        this._log = log ?? DefaultLogger<SimpleTextDb>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<SimpleTextDb>();
         switch (config.StorageType)
         {
             case FileSystemTypes.Disk:
-                this._fileSystem = new DiskFileSystem(config.Directory, null, this._log);
+                this._fileSystem = new DiskFileSystem(config.Directory, null, loggerFactory);
                 break;
 
             case FileSystemTypes.Volatile:
-                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, null, this._log);
+                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, null, loggerFactory);
                 break;
 
             default:

--- a/service/Core/MemoryStorage/DevTools/SimpleVectorDb.cs
+++ b/service/Core/MemoryStorage/DevTools/SimpleVectorDb.cs
@@ -34,11 +34,11 @@ public class SimpleVectorDb : IMemoryDb
     /// </summary>
     /// <param name="config">Simple vector db settings</param>
     /// <param name="embeddingGenerator">Text embedding generator</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public SimpleVectorDb(
         SimpleVectorDbConfig config,
         ITextEmbeddingGenerator embeddingGenerator,
-        ILogger<SimpleVectorDb>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this._embeddingGenerator = embeddingGenerator;
 
@@ -47,15 +47,15 @@ public class SimpleVectorDb : IMemoryDb
             throw new SimpleVectorDbException("Embedding generator not configured");
         }
 
-        this._log = log ?? DefaultLogger<SimpleVectorDb>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<SimpleVectorDb>();
         switch (config.StorageType)
         {
             case FileSystemTypes.Disk:
-                this._fileSystem = new DiskFileSystem(config.Directory, null, this._log);
+                this._fileSystem = new DiskFileSystem(config.Directory, null, loggerFactory);
                 break;
 
             case FileSystemTypes.Volatile:
-                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, null, this._log);
+                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, null, loggerFactory);
                 break;
 
             default:

--- a/service/Core/Pipeline/DistributedPipelineOrchestrator.cs
+++ b/service/Core/Pipeline/DistributedPipelineOrchestrator.cs
@@ -42,7 +42,7 @@ public sealed class DistributedPipelineOrchestrator : BaseOrchestrator
     /// <param name="textGenerator">Service used to generate text, e.g. synthetic memory records</param>
     /// <param name="mimeTypeDetection">Service used to detect a file type</param>
     /// <param name="config">Global KM configuration</param>
-    /// <param name="log"></param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public DistributedPipelineOrchestrator(
         QueueClientFactory queueClientFactory,
         IDocumentStorage documentStorage,
@@ -51,8 +51,8 @@ public sealed class DistributedPipelineOrchestrator : BaseOrchestrator
         ITextGenerator textGenerator,
         IMimeTypeDetection? mimeTypeDetection = null,
         KernelMemoryConfig? config = null,
-        ILogger<DistributedPipelineOrchestrator>? log = null)
-        : base(documentStorage, embeddingGenerators, memoryDbs, textGenerator, mimeTypeDetection, config, log)
+        ILoggerFactory? loggerFactory = null)
+        : base(documentStorage, embeddingGenerators, memoryDbs, textGenerator, mimeTypeDetection, config, loggerFactory?.CreateLogger<DistributedPipelineOrchestrator>())
     {
         this._queueClientFactory = queueClientFactory;
     }

--- a/service/Core/Pipeline/InProcessPipelineOrchestrator.cs
+++ b/service/Core/Pipeline/InProcessPipelineOrchestrator.cs
@@ -33,7 +33,7 @@ public sealed class InProcessPipelineOrchestrator : BaseOrchestrator
     /// <param name="mimeTypeDetection">Service used to detect a file type</param>
     /// <param name="serviceProvider">Optional service provider to add handlers by type</param>
     /// <param name="config">Global KM configuration</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     public InProcessPipelineOrchestrator(
         IDocumentStorage documentStorage,
         List<ITextEmbeddingGenerator> embeddingGenerators,
@@ -42,8 +42,8 @@ public sealed class InProcessPipelineOrchestrator : BaseOrchestrator
         IMimeTypeDetection? mimeTypeDetection = null,
         IServiceProvider? serviceProvider = null,
         KernelMemoryConfig? config = null,
-        ILogger<InProcessPipelineOrchestrator>? log = null)
-        : base(documentStorage, embeddingGenerators, memoryDbs, textGenerator, mimeTypeDetection, config, log)
+        ILoggerFactory? loggerFactory = null)
+        : base(documentStorage, embeddingGenerators, memoryDbs, textGenerator, mimeTypeDetection, config, loggerFactory?.CreateLogger<InProcessPipelineOrchestrator>())
     {
         this._serviceProvider = serviceProvider;
     }

--- a/service/Core/Pipeline/Queue/DevTools/DependencyInjection.cs
+++ b/service/Core/Pipeline/Queue/DevTools/DependencyInjection.cs
@@ -37,7 +37,7 @@ public static partial class DependencyInjection
     {
         IQueue QueueFactory(IServiceProvider serviceProvider)
         {
-            return new SimpleQueues(config, log: serviceProvider.GetService<ILogger<SimpleQueues>>());
+            return new SimpleQueues(config, loggerFactory: serviceProvider.GetService<ILoggerFactory>());
         }
 
         // The orchestrator uses multiple queue clients, each linked to a specific queue,

--- a/service/Core/Pipeline/Queue/DevTools/SimpleQueues.cs
+++ b/service/Core/Pipeline/Queue/DevTools/SimpleQueues.cs
@@ -76,19 +76,19 @@ public sealed class SimpleQueues : IQueue
     /// Create new file based queue
     /// </summary>
     /// <param name="config">File queue configuration</param>
-    /// <param name="log">Application logger</param>
+    /// <param name="loggerFactory">Application logger factory</param>
     /// <exception cref="InvalidOperationException"></exception>
-    public SimpleQueues(SimpleQueuesConfig config, ILogger<SimpleQueues>? log = null)
+    public SimpleQueues(SimpleQueuesConfig config, ILoggerFactory? loggerFactory = null)
     {
-        this._log = log ?? DefaultLogger<SimpleQueues>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<SimpleQueues>();
         switch (config.StorageType)
         {
             case FileSystemTypes.Disk:
-                this._fileSystem = new DiskFileSystem(config.Directory, null, this._log);
+                this._fileSystem = new DiskFileSystem(config.Directory, null, loggerFactory);
                 break;
 
             case FileSystemTypes.Volatile:
-                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, null, this._log);
+                this._fileSystem = VolatileFileSystem.GetInstance(config.Directory, null, loggerFactory);
                 break;
 
             default:

--- a/service/Core/Search/SearchClient.cs
+++ b/service/Core/Search/SearchClient.cs
@@ -17,7 +17,7 @@ using Microsoft.KernelMemory.Prompts;
 
 namespace Microsoft.KernelMemory.Search;
 
-internal sealed class SearchClient : ISearchClient
+public sealed class SearchClient : ISearchClient
 {
     private readonly IMemoryDb _memoryDb;
     private readonly ITextGenerator _textGenerator;
@@ -30,7 +30,7 @@ internal sealed class SearchClient : ISearchClient
         ITextGenerator textGenerator,
         SearchClientConfig? config = null,
         IPromptProvider? promptProvider = null,
-        ILogger<SearchClient>? log = null)
+        ILoggerFactory? loggerFactory = null)
     {
         this._memoryDb = memoryDb;
         this._textGenerator = textGenerator;
@@ -40,7 +40,7 @@ internal sealed class SearchClient : ISearchClient
         promptProvider ??= new EmbeddedPromptProvider();
         this._answerPrompt = promptProvider.ReadPrompt(Constants.PromptNamesAnswerWithFacts);
 
-        this._log = log ?? DefaultLogger<SearchClient>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<SearchClient>();
 
         if (this._memoryDb == null)
         {

--- a/service/Core/SemanticKernel/SemanticKernelTextEmbeddingGenerator.cs
+++ b/service/Core/SemanticKernel/SemanticKernelTextEmbeddingGenerator.cs
@@ -34,8 +34,7 @@ internal sealed class SemanticKernelTextEmbeddingGenerator : ITextEmbeddingGener
         this._service = textEmbeddingGenerationService;
         this.MaxTokens = config.MaxTokenTotal;
 
-        var log = loggerFactory?.CreateLogger<SemanticKernelTextEmbeddingGenerator>();
-        this._log = log ?? DefaultLogger<SemanticKernelTextEmbeddingGenerator>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<SemanticKernelTextEmbeddingGenerator>();
 
         if (textTokenizer == null)
         {

--- a/service/Core/SemanticKernel/SemanticKernelTextGenerator.cs
+++ b/service/Core/SemanticKernel/SemanticKernelTextGenerator.cs
@@ -36,8 +36,7 @@ internal sealed class SemanticKernelTextGenerator : ITextGenerator
         this._service = textGenerationService;
         this.MaxTokenTotal = config.MaxTokenTotal;
 
-        var log = loggerFactory?.CreateLogger<SemanticKernelTextGenerator>();
-        this._log = log ?? DefaultLogger<SemanticKernelTextGenerator>.Instance;
+        this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<SemanticKernelTextGenerator>();
 
         if (textTokenizer == null)
         {


### PR DESCRIPTION
* Align the code approach to how logger is injected, using `ILoggerFactory`, so that the same log configuration can be passed down when using `new` (Postgres, Qdrant, SK, others)
* Change `SearchClient` visibility from internal to public, allowing to create `MemoryServerless` instances without `KernelMemoryBuilder`
* Add example showing how to create a `MemoryServerless` instance without `KernelMemoryBuilder`.
* Some other cleanup, more for the future, e.g. reducing the use of `new`
* Add `ToString` override method to `MemoryAnswer`