### PR TITLE
Add debug logs for embedding generation

### DIFF
--- a/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
+++ b/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
@@ -100,7 +100,7 @@ public sealed class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator,
     /// <inheritdoc/>
     public Task<Embedding> GenerateEmbeddingAsync(string text, CancellationToken cancellationToken = default)
     {
-        this._log.LogDebug("Generating embeddings");
+        this._log.LogTrace("Generating embedding");
         return this._client.GenerateEmbeddingAsync(text, cancellationToken);
     }
 

--- a/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
+++ b/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
@@ -100,6 +100,7 @@ public sealed class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator,
     /// <inheritdoc/>
     public Task<Embedding> GenerateEmbeddingAsync(string text, CancellationToken cancellationToken = default)
     {
+        this._log.LogDebug("Generating embeddings");
         return this._client.GenerateEmbeddingAsync(text, cancellationToken);
     }
 

--- a/extensions/OpenAI/OpenAITextEmbeddingGenerator.cs
+++ b/extensions/OpenAI/OpenAITextEmbeddingGenerator.cs
@@ -99,7 +99,7 @@ public sealed class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator, ITex
     /// <inheritdoc/>
     public Task<Embedding> GenerateEmbeddingAsync(string text, CancellationToken cancellationToken = default)
     {
-        this._log.LogDebug("Generating embeddings");
+        this._log.LogTrace("Generating embedding");
         return this._client.GenerateEmbeddingAsync(text, cancellationToken);
     }
 

--- a/extensions/OpenAI/OpenAITextEmbeddingGenerator.cs
+++ b/extensions/OpenAI/OpenAITextEmbeddingGenerator.cs
@@ -99,6 +99,7 @@ public sealed class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator, ITex
     /// <inheritdoc/>
     public Task<Embedding> GenerateEmbeddingAsync(string text, CancellationToken cancellationToken = default)
     {
+        this._log.LogDebug("Generating embeddings");
         return this._client.GenerateEmbeddingAsync(text, cancellationToken);
     }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
In the new `GenerateEmbeddingBatchAsync` method, a debug log message is written. For coherence, this PR adds the same message also for `GenerateEmbeddingAsync`.

