### PR TITLE
fix: postgres search query does not use index

### DIFF
--- a/extensions/Postgres/Postgres/Internals/PostgresDbClient.cs
+++ b/extensions/Postgres/Postgres/Internals/PostgresDbClient.cs
@@ -430,10 +430,10 @@ internal sealed class PostgresDbClient : IDisposable
             {
 #pragma warning disable CA2100 // SQL reviewed
                 cmd.CommandText = @$"
-                SELECT {columns}, 1 - ({this._colEmbedding} <=> @embedding) AS {similarityActualValue}
+                SELECT {columns}, {this._colEmbedding} <=> @embedding AS {similarityActualValue}
                 FROM {tableName}
                 WHERE {filterSql}
-                ORDER BY {similarityActualValue} DESC
+                ORDER BY {similarityActualValue} ASC
                 LIMIT @limit
                 OFFSET @offset
             ";


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
I've imported about 6 million documents with PostgresDB as backend. I've created an HNSW index. When doing a search (using WebClient.Ask/Search) I keep getting timeouts. Upon further investigation, I saw that the query used in Kernel Memory is not optimisable as it's doing an inline calculation of "1 - the difference".

After I removed the "1 - " in our fork & deployed it, it was successfully using the index and I would get a response within 5 - 10 seconds.
I've used pgAdmin4 to confirm that the new query is using the index.

See also discussion with @dluc here: https://github.com/microsoft/kernel-memory/discussions/663#discussioncomment-9952593



