### PR TITLE
fix: maxDistance cast to string

### DIFF
--- a/extensions/Postgres/Postgres/Internals/PostgresDbClient.cs
+++ b/extensions/Postgres/Postgres/Internals/PostgresDbClient.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Globalization;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
@@ -416,7 +415,7 @@ internal sealed class PostgresDbClient : IDisposable
         }
 
         var maxDistance = 1 - minSimilarity;
-        filterSql += $" AND {this._colEmbedding} <=> @embedding < {maxDistance.ToString(CultureInfo.InvariantCulture)}";
+        filterSql += $" AND {this._colEmbedding} <=> @embedding < @maxDistance";
 
         if (sqlUserValues == null) { sqlUserValues = new(); }
 
@@ -448,6 +447,7 @@ internal sealed class PostgresDbClient : IDisposable
             ";
 
                 cmd.Parameters.AddWithValue("@embedding", target);
+                cmd.Parameters.AddWithValue("@maxDistance", maxDistance);
                 cmd.Parameters.AddWithValue("@limit", limit);
                 cmd.Parameters.AddWithValue("@offset", offset);
 

--- a/extensions/Postgres/Postgres/Internals/PostgresDbClient.cs
+++ b/extensions/Postgres/Postgres/Internals/PostgresDbClient.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Globalization;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
@@ -415,7 +416,7 @@ internal sealed class PostgresDbClient : IDisposable
         }
 
         var maxDistance = 1 - minSimilarity;
-        filterSql += $" AND {this._colEmbedding} <=> @embedding < {maxDistance}";
+        filterSql += $" AND {this._colEmbedding} <=> @embedding < {maxDistance.ToString(CultureInfo.InvariantCulture)}";
 
         if (sqlUserValues == null) { sqlUserValues = new(); }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
During string interpolation if dotnet culture is set to French it used comma as the decimal separator instead of period, which cased SQL error "unexpected ,"

## High level description (Approach, Design)
Forcing culture-insensitive cast using `maxDistance.ToString(CultureInfo.InvariantCulture)`

