### PR TITLE
Add ChunkHeader option to request context

### DIFF
--- a/service/Abstractions/Constants.cs
+++ b/service/Abstractions/Constants.cs
@@ -34,6 +34,9 @@ public static class Constants
 
             // Used to override OverlappingTokens config
             public const string OverlappingTokens = "custom_partitioning_overlapping_tokens_int";
+
+            // Used to prepend header to each partition
+            public const string ChunkHeader = "custom_partitioning_chunk_header_str";
         }
 
         public static class EmbeddingGeneration

--- a/service/Abstractions/Context/IContext.cs
+++ b/service/Abstractions/Context/IContext.cs
@@ -200,6 +200,16 @@ public static class CustomContextExtensions
         return defaultValue;
     }
 
+    public static string? GetCustomPartitioningChunkHeaderOrDefault(this IContext? context, string? defaultValue)
+    {
+        if (context.TryGetArg<string>(Constants.CustomContext.Partitioning.ChunkHeader, out var customValue))
+        {
+            return customValue;
+        }
+
+        return defaultValue;
+    }
+
     public static int GetCustomEmbeddingGenerationBatchSizeOrDefault(this IContext? context, int defaultValue)
     {
         if (context.TryGetArg<int>(Constants.CustomContext.EmbeddingGeneration.BatchSize, out var customValue))

--- a/service/Core/Handlers/TextPartitioningHandler.cs
+++ b/service/Core/Handlers/TextPartitioningHandler.cs
@@ -90,6 +90,8 @@ public sealed class TextPartitioningHandler : IPipelineStepHandler
         // Allow to override the number of overlapping tokens using context arguments
         var overlappingTokens = Math.Max(0, context.GetCustomPartitioningOverlappingTokensOrDefault(this._options.OverlappingTokens));
 
+        string? chunkHeader = context.GetCustomPartitioningChunkHeaderOrDefault(null);
+
         foreach (DataPipeline.FileDetails uploadedFile in pipeline.Files)
         {
             // Track new files being generated (cannot edit originalFile.GeneratedFiles while looping it)
@@ -128,7 +130,7 @@ public sealed class TextPartitioningHandler : IPipelineStepHandler
                         string content = partitionContent.ToString();
                         sentences = TextChunker.SplitPlainTextLines(content, maxTokensPerLine: this._options.MaxTokensPerLine, tokenCounter: this._tokenCounter);
                         partitions = TextChunker.SplitPlainTextParagraphs(
-                            sentences, maxTokensPerParagraph: maxTokensPerParagraph, overlapTokens: overlappingTokens, tokenCounter: this._tokenCounter);
+                            sentences, maxTokensPerParagraph: maxTokensPerParagraph, overlapTokens: overlappingTokens, tokenCounter: this._tokenCounter, chunkHeader: chunkHeader);
                         break;
                     }
 


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)
I have a use case to prepend a header (in my case the original file path from sharepoint) in to each partition to be able to include that in the embedding and RAG. This is a minimal change with the addition of the RequestContext and leverages the existing `chunkHeader` parameter in the TextChunker.

## High level description (Approach, Design)
Adds constant for `ChunkHeader` in the `Constants.CustomContext.Partitioning` class.

In `TextPartitioningHandler` we look for the existence of that context argument and default to `null` (existing behavior is null here)
