### PR TITLE
Naming adjustments

### DIFF
--- a/examples/110-dotnet-anthropic/Program.cs
+++ b/examples/110-dotnet-anthropic/Program.cs
@@ -5,7 +5,7 @@ using Microsoft.KernelMemory.AI.Anthropic;
 using Microsoft.KernelMemory.DocumentStorage.DevTools;
 using Microsoft.KernelMemory.MemoryStorage.DevTools;
 
-var anthropicConfig = new AnthropicConfiguration();
+var anthropicConfig = new AnthropicConfig();
 var azureOpenAIEmbeddingConfig = new AzureOpenAIConfig();
 
 new ConfigurationBuilder()

--- a/extensions/Anthropic/AnthropicConfig.cs
+++ b/extensions/Anthropic/AnthropicConfig.cs
@@ -7,7 +7,7 @@ namespace Microsoft.KernelMemory.AI.Anthropic;
 /// <summary>
 /// Configuration for Text Generation with Anthropic
 /// </summary>
-public class AnthropicConfiguration
+public class AnthropicConfig
 {
     /// <summary>
     /// Anthropic web service endpoint

--- a/extensions/Anthropic/AnthropicTextGeneration.cs
+++ b/extensions/Anthropic/AnthropicTextGeneration.cs
@@ -36,7 +36,7 @@ public sealed class AnthropicTextGeneration : ITextGenerator, IDisposable
     /// <param name="httpClientFactory">Optional factory used to inject a pre-configured HTTP client for requests to Anthropic API</param>
     /// <param name="loggerFactory">Optional factory used to inject configured loggers</param>
     public AnthropicTextGeneration(
-        AnthropicConfiguration config,
+        AnthropicConfig config,
         ITextTokenizer? textTokenizer = null,
         IHttpClientFactory? httpClientFactory = null,
         ILoggerFactory? loggerFactory = null)

--- a/extensions/Anthropic/DependencyInjection.cs
+++ b/extensions/Anthropic/DependencyInjection.cs
@@ -23,7 +23,7 @@ public static partial class KernelMemoryBuilderExtensions
     /// <param name="textTokenizer">Optional tokenizer, default one will be used if passed null.</param>
     public static IKernelMemoryBuilder WithAnthropicTextGeneration(
         this IKernelMemoryBuilder builder,
-        AnthropicConfiguration config,
+        AnthropicConfig config,
         ITextTokenizer? textTokenizer = null)
     {
         builder.Services.AddAnthropicTextGeneration(config, textTokenizer);
@@ -44,7 +44,7 @@ public static partial class DependencyInjection
     /// <param name="textTokenizer">Tokenizer to measure content size</param>
     public static IServiceCollection AddAnthropicTextGeneration(
         this IServiceCollection services,
-        AnthropicConfiguration config,
+        AnthropicConfig config,
         ITextTokenizer? textTokenizer = null)
     {
         services.AddSingleton(config);

--- a/service/Core/SemanticKernel/KernelMemoryBuilderExtensions.cs
+++ b/service/Core/SemanticKernel/KernelMemoryBuilderExtensions.cs
@@ -22,19 +22,19 @@ public static partial class KernelMemoryBuilderExtensions
     /// <param name="builder">KM builder</param>
     /// <param name="service">SK text generation service instance</param>
     /// <param name="config">SK text generator settings</param>
-    /// <param name="tokenizer">Tokenizer used to count tokens used by prompts</param>
+    /// <param name="textTokenizer">Tokenizer used to count tokens used by prompts</param>
     ///  <param name="loggerFactory">.NET logger factory</param>
     /// <returns>KM builder</returns>
     public static IKernelMemoryBuilder WithSemanticKernelTextGenerationService(
         this IKernelMemoryBuilder builder,
         ITextGenerationService service,
         SemanticKernelConfig config,
-        ITextTokenizer? tokenizer = null,
+        ITextTokenizer? textTokenizer = null,
         ILoggerFactory? loggerFactory = null)
     {
         if (service == null) { throw new ConfigurationException("Memory Builder: the semantic kernel text generation service instance is NULL"); }
 
-        return builder.AddSingleton<ITextGenerator>(new SemanticKernelTextGenerator(service, config, tokenizer, loggerFactory));
+        return builder.AddSingleton<ITextGenerator>(new SemanticKernelTextGenerator(service, config, textTokenizer, loggerFactory));
     }
 
     ///  <summary>
@@ -44,7 +44,7 @@ public static partial class KernelMemoryBuilderExtensions
     ///  <param name="builder">KM builder</param>
     ///  <param name="service">SK text embedding generation instance</param>
     ///  <param name="config">SK text embedding generator settings</param>
-    ///  <param name="tokenizer">Tokenizer used to count tokens sent to the embedding generator</param>
+    ///  <param name="textTokenizer">Tokenizer used to count tokens sent to the embedding generator</param>
     ///  <param name="loggerFactory">.NET logger factory</param>
     ///  <param name="onlyForRetrieval">Whether to use this embedding generator only during data ingestion, and not for retrieval (search and ask API)</param>
     ///  <returns>KM builder</returns>
@@ -52,13 +52,13 @@ public static partial class KernelMemoryBuilderExtensions
         this IKernelMemoryBuilder builder,
         ITextEmbeddingGenerationService service,
         SemanticKernelConfig config,
-        ITextTokenizer? tokenizer = null,
+        ITextTokenizer? textTokenizer = null,
         ILoggerFactory? loggerFactory = null,
         bool onlyForRetrieval = false)
     {
         if (service == null) { throw new ConfigurationException("Memory Builder: the semantic kernel text embedding generation service instance is NULL"); }
 
-        var generator = new SemanticKernelTextEmbeddingGenerator(service, config, tokenizer, loggerFactory);
+        var generator = new SemanticKernelTextEmbeddingGenerator(service, config, textTokenizer, loggerFactory);
         builder.AddSingleton<ITextEmbeddingGenerator>(generator);
 
         if (!onlyForRetrieval)

--- a/service/Service/ServiceConfiguration.cs
+++ b/service/Service/ServiceConfiguration.cs
@@ -420,7 +420,7 @@ internal sealed class ServiceConfiguration
                 break;
 
             case string x when x.Equals("Anthropic", StringComparison.OrdinalIgnoreCase):
-                builder.Services.AddAnthropicTextGeneration(this.GetServiceConfig<AnthropicConfiguration>("Anthropic"));
+                builder.Services.AddAnthropicTextGeneration(this.GetServiceConfig<AnthropicConfig>("Anthropic"));
                 break;
 
             case string x when x.Equals("LlamaSharp", StringComparison.OrdinalIgnoreCase):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
Rename class and method parameters to match the overall naming convention. See #705 and #706.

