### PR TITLE
Updated microsoft ML tokenizer to latest beta.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,7 +33,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.TraceSource" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.ML.Tokenizers" Version="0.22.0-preview.24179.1" />
+    <PackageVersion Include="Microsoft.ML.Tokenizers" Version="0.22.0-preview.24271.1" />
     <PackageVersion Include="Microsoft.KernelMemory.Core" Version="0.66.240709.1" />
     <PackageVersion Include="Microsoft.KernelMemory.Service.AspNetCore" Version="0.66.240709.1" />
     <PackageVersion Include="MongoDB.Driver.GridFS" Version="2.27.0" />

--- a/extensions/OpenAI/OpenAI.UnitTests/GPTTokenizersTests.cs
+++ b/extensions/OpenAI/OpenAI.UnitTests/GPTTokenizersTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.KernelMemory.AI.OpenAI;
 using Microsoft.KM.TestHelpers;
@@ -9,6 +9,25 @@ namespace Microsoft.OpenAI.UnitTests;
 
 public class GPTTokenizersTests(ITestOutputHelper output) : BaseUnitTestCase(output)
 {
+    [Fact]
+    [Trait("Category", "UnitTest")]
+    [Trait("Category", "AI")]
+    public void CanTokenize()
+    {
+        const string helloWorld = "hello world";
+        var gpt2 = new GPT2Tokenizer();
+        var tokens = gpt2.GetTokens(helloWorld);
+        Assert.Equal(["hello", " world"], tokens);
+
+        var gpt3 = new GPT3Tokenizer();
+        tokens = gpt3.GetTokens(helloWorld);
+        Assert.Equal(["hello", " world"], tokens);
+
+        var gpt4 = new GPT4Tokenizer();
+        tokens = gpt4.GetTokens(helloWorld);
+        Assert.Equal(["hello", " world"], tokens);
+    }
+
     [Fact]
     [Trait("Category", "UnitTest")]
     [Trait("Category", "AI")]

--- a/extensions/OpenAI/OpenAI/Tokenizers/GPT2Tokenizer.cs
+++ b/extensions/OpenAI/OpenAI/Tokenizers/GPT2Tokenizer.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.ML.Tokenizers;
 
 // ReSharper disable once CheckNamespace
@@ -24,6 +25,7 @@ public sealed class GPT2Tokenizer : ITextTokenizer
     /// <inheritdoc />
     public IReadOnlyList<string> GetTokens(string text)
     {
-        return s_tokenizer.Encode(text).Tokens;
+        var tokens = s_tokenizer.Encode(text, out var normalizedString);
+        return tokens.Select(t => t.Value).ToArray();
     }
 }

--- a/extensions/OpenAI/OpenAI/Tokenizers/GPT2Tokenizer.cs
+++ b/extensions/OpenAI/OpenAI/Tokenizers/GPT2Tokenizer.cs
@@ -25,7 +25,6 @@ public sealed class GPT2Tokenizer : ITextTokenizer
     /// <inheritdoc />
     public IReadOnlyList<string> GetTokens(string text)
     {
-        var tokens = s_tokenizer.Encode(text, out var normalizedString);
-        return tokens.Select(t => t.Value).ToArray();
+        return s_tokenizer.Encode(text, out string? _).Select(t => t.Value).ToList();
     }
 }

--- a/extensions/OpenAI/OpenAI/Tokenizers/GPT3Tokenizer.cs
+++ b/extensions/OpenAI/OpenAI/Tokenizers/GPT3Tokenizer.cs
@@ -25,7 +25,6 @@ public sealed class GPT3Tokenizer : ITextTokenizer
     /// <inheritdoc />
     public IReadOnlyList<string> GetTokens(string text)
     {
-        var tokens = s_tokenizer.Encode(text, out var normalizedString);
-        return tokens.Select(t => t.Value).ToArray();
+        return s_tokenizer.Encode(text, out string? _).Select(t => t.Value).ToList();
     }
 }

--- a/extensions/OpenAI/OpenAI/Tokenizers/GPT3Tokenizer.cs
+++ b/extensions/OpenAI/OpenAI/Tokenizers/GPT3Tokenizer.cs
@@ -1,7 +1,8 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.ML.Tokenizers;
 
 // ReSharper disable once CheckNamespace
@@ -24,6 +25,7 @@ public sealed class GPT3Tokenizer : ITextTokenizer
     /// <inheritdoc />
     public IReadOnlyList<string> GetTokens(string text)
     {
-        return s_tokenizer.Encode(text).Tokens;
+        var tokens = s_tokenizer.Encode(text, out var normalizedString);
+        return tokens.Select(t => t.Value).ToArray();
     }
 }

--- a/extensions/OpenAI/OpenAI/Tokenizers/GPT4Tokenizer.cs
+++ b/extensions/OpenAI/OpenAI/Tokenizers/GPT4Tokenizer.cs
@@ -1,7 +1,8 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.ML.Tokenizers;
 
 // ReSharper disable once CheckNamespace
@@ -24,6 +25,7 @@ public sealed class GPT4Tokenizer : ITextTokenizer
     /// <inheritdoc />
     public IReadOnlyList<string> GetTokens(string text)
     {
-        return s_tokenizer.Encode(text).Tokens;
+        var tokens = s_tokenizer.Encode(text, out var normalizedString);
+        return tokens.Select(t => t.Value).ToArray();
     }
 }

--- a/extensions/OpenAI/OpenAI/Tokenizers/GPT4Tokenizer.cs
+++ b/extensions/OpenAI/OpenAI/Tokenizers/GPT4Tokenizer.cs
@@ -25,7 +25,6 @@ public sealed class GPT4Tokenizer : ITextTokenizer
     /// <inheritdoc />
     public IReadOnlyList<string> GetTokens(string text)
     {
-        var tokens = s_tokenizer.Encode(text, out var normalizedString);
-        return tokens.Select(t => t.Value).ToArray();
+        return s_tokenizer.Encode(text, out string? _).Select(t => t.Value).ToList();
     }
 }


### PR DESCRIPTION
## Motivation 

Microsoft ML Tokenizer library is still in beta and undergone lots of modifications, so it is better to always use the latest version. Also in my project where I 'm using Microsoft.ML.Tokenizer I'm actually using some of the feature of the latest beta, and this prevents me to using newest version of Kernel Memory tue to errors.


## High level description (Approach, Design)

Simply updated the reference, then updated a couple of classes and wrote a unit test to verify I didn't break anything.

