### PR TITLE
Add functional test for MSSQL

### DIFF
--- a/extensions/SQLServer/SQLServer.FunctionalTests/DefaultTests.cs
+++ b/extensions/SQLServer/SQLServer.FunctionalTests/DefaultTests.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.KernelMemory;
 using Microsoft.KernelMemory.MemoryDb.SQLServer;
+using Microsoft.KernelMemory.MemoryStorage;
 using Microsoft.KM.Core.FunctionalTests.DefaultTestCases;
 using Microsoft.KM.TestHelpers;
 
@@ -10,6 +11,7 @@ namespace Microsoft.SQLServer.FunctionalTests;
 public class DefaultTests : BaseFunctionalTestCase
 {
     private readonly MemoryServerless _memory;
+    private readonly IMemoryDb _memoryDb;
 
     public DefaultTests(IConfiguration cfg, ITestOutputHelper output) : base(cfg, output)
     {
@@ -17,7 +19,9 @@ public class DefaultTests : BaseFunctionalTestCase
 
         SqlServerConfig sqlServerConfig = cfg.GetSection("KernelMemory:Services:SqlServer").Get<SqlServerConfig>()!;
 
-        this._memory = new KernelMemoryBuilder()
+        var builder = new KernelMemoryBuilder();
+
+        this._memory = builder
             .With(new KernelMemoryConfig { DefaultIndexName = "default4tests" })
             .WithSearchClientConfig(new SearchClientConfig { EmptyAnswer = NotFound })
             .WithOpenAI(this.OpenAiConfig)
@@ -25,6 +29,9 @@ public class DefaultTests : BaseFunctionalTestCase
             // .WithAzureOpenAITextEmbeddingGeneration(this.AzureOpenAIEmbeddingConfiguration)
             .WithSqlServerMemoryDb(sqlServerConfig)
             .Build<MemoryServerless>();
+
+        var serviceProvider = builder.Services.BuildServiceProvider();
+        this._memoryDb = serviceProvider.GetService<IMemoryDb>()!;
     }
 
     [Fact]
@@ -102,6 +109,13 @@ public class DefaultTests : BaseFunctionalTestCase
     public async Task ItSupportsTags()
     {
         await DocumentUploadTest.ItSupportsTags(this._memory, this.Log);
+    }
+
+    [Fact]
+    [Trait("Category", "SQLServer")]
+    public async Task ItDeletesRecords()
+    {
+        await RecordDeletionTest.ItDeletesRecords(this._memory, this._memoryDb, this.Log);
     }
 
     [Fact]

--- a/extensions/SQLServer/SQLServer.FunctionalTests/DefaultTests.cs
+++ b/extensions/SQLServer/SQLServer.FunctionalTests/DefaultTests.cs
@@ -23,6 +23,7 @@ public class DefaultTests : BaseFunctionalTestCase
 
         this._memory = builder
             .With(new KernelMemoryConfig { DefaultIndexName = "default4tests" })
+            .Configure(kmb => kmb.Services.AddLogging(b => { b.AddConsole().SetMinimumLevel(LogLevel.Trace); }))
             .WithSearchClientConfig(new SearchClientConfig { EmptyAnswer = NotFound })
             .WithOpenAI(this.OpenAiConfig)
             // .WithAzureOpenAITextGeneration(this.AzureOpenAITextConfiguration)

--- a/extensions/SQLServer/SQLServer.FunctionalTests/appsettings.json
+++ b/extensions/SQLServer/SQLServer.FunctionalTests/appsettings.json
@@ -73,7 +73,14 @@
         // Change this to use proxies or services compatible with OpenAI HTTP protocol like LM Studio.
         "Endpoint": "",
         // How many times to retry in case of throttling
-        "MaxRetries": 10
+        "MaxRetries": 10,
+        // The number of dimensions output embeddings should have.
+        // Only supported in "text-embedding-3" and later models developed with
+        // MRL, see https://arxiv.org/abs/2205.13147
+        "EmbeddingDimensions": null,
+        // How many embeddings to calculate in parallel.
+        // See https://platform.openai.com/docs/api-reference/embeddings/create
+        "MaxEmbeddingBatchSize": 64
       }
     }
   }

--- a/extensions/SQLServer/SQLServer/DependencyInjection.cs
+++ b/extensions/SQLServer/SQLServer/DependencyInjection.cs
@@ -63,7 +63,7 @@ public static partial class DependencyInjection
     /// Inject SqlServer as the default implementation of IMemoryDb
     /// </summary>
     /// <param name="services">Service collection</param>
-    /// <param name="connString">Postgres connection string</param>
+    /// <param name="connString">SQL Server connection string</param>
     public static IServiceCollection AddSqlServerAsMemoryDb(
         this IServiceCollection services,
         string connString)

--- a/extensions/SQLServer/SQLServer/SqlServerMemory.cs
+++ b/extensions/SQLServer/SQLServer/SqlServerMemory.cs
@@ -78,14 +78,7 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
             return;
         }
 
-        var connection = new SqlConnection(this._config.ConnectionString);
-        await using var disposableConnection = connection.ConfigureAwait(false);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-
-        SqlCommand command = connection.CreateCommand();
-        await using var disposableCommand = command.ConfigureAwait(false);
-
-        command.CommandText = $@"
+        var sql = $@"
             BEGIN TRANSACTION;
 
             INSERT INTO {this.GetFullTableName(this._config.MemoryCollectionTableName)}([id])
@@ -116,9 +109,21 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
 
             COMMIT;";
 
-        command.Parameters.AddWithValue("@index", index);
-
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        var connection = new SqlConnection(this._config.ConnectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            SqlCommand command = connection.CreateCommand();
+            command.CommandText = sql;
+            command.Parameters.AddWithValue("@index", index);
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            command.Dispose();
+        }
+        finally
+        {
+            await connection.CloseAsync().ConfigureAwait(false);
+            connection.Dispose();
+        }
     }
 
     /// <inheritdoc/>
@@ -134,14 +139,7 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
             return;
         }
 
-        var connection = new SqlConnection(this._config.ConnectionString);
-        await using var disposableConnection = connection.ConfigureAwait(false);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-
-        SqlCommand command = connection.CreateCommand();
-        await using var disposableCommand = command.ConfigureAwait(false);
-
-        command.CommandText = $@"
+        var sql = $@"
             BEGIN TRANSACTION;
 
             DELETE [embeddings]
@@ -162,10 +160,23 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
 
             COMMIT;";
 
-        command.Parameters.AddWithValue("@index", index);
-        command.Parameters.AddWithValue("@key", record.Id);
+        var connection = new SqlConnection(this._config.ConnectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            SqlCommand command = connection.CreateCommand();
+            command.CommandText = sql;
+            command.Parameters.AddWithValue("@index", index);
+            command.Parameters.AddWithValue("@key", record.Id);
 
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            command.Dispose();
+        }
+        finally
+        {
+            await connection.CloseAsync().ConfigureAwait(false);
+            connection.Dispose();
+        }
     }
 
     /// <inheritdoc/>
@@ -181,14 +192,7 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
             return;
         }
 
-        var connection = new SqlConnection(this._config.ConnectionString);
-        await using var disposableConnection = connection.ConfigureAwait(false);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-
-        SqlCommand command = connection.CreateCommand();
-        await using var disposableCommand = command.ConfigureAwait(false);
-
-        command.CommandText = $@"
+        var sql = $@"
             BEGIN TRANSACTION;
 
             DROP TABLE {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")};
@@ -199,9 +203,21 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
 
             COMMIT;";
 
-        command.Parameters.AddWithValue("@index", index);
-
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        var connection = new SqlConnection(this._config.ConnectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        SqlCommand command = connection.CreateCommand();
+        try
+        {
+            command.CommandText = sql;
+            command.Parameters.AddWithValue("@index", index);
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            command.Dispose();
+            await connection.CloseAsync().ConfigureAwait(false);
+            connection.Dispose();
+        }
     }
 
     /// <inheritdoc/>
@@ -211,28 +227,39 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
 
         List<string> indexes = new();
 
+        var sql = $"SELECT [id] FROM {this.GetFullTableName(this._config.MemoryCollectionTableName)}";
+
         var connection = new SqlConnection(this._config.ConnectionString);
-        await using var disposableConnection = connection.ConfigureAwait(false);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-
         SqlCommand command = connection.CreateCommand();
-        await using var disposableCommand = command.ConfigureAwait(false);
-
-        command.CommandText = $"SELECT [id] FROM {this.GetFullTableName(this._config.MemoryCollectionTableName)}";
-
-        var dataReader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        await using var disposableReader = dataReader.ConfigureAwait(false);
-
-        while (await dataReader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        try
         {
-            indexes.Add(dataReader.GetString(dataReader.GetOrdinal("id")));
+            command.CommandText = sql;
+            var dataReader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await dataReader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                indexes.Add(dataReader.GetString(dataReader.GetOrdinal("id")));
+            }
+
+            await dataReader.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            command.Dispose();
+            await connection.CloseAsync().ConfigureAwait(false);
+            connection.Dispose();
         }
 
         return indexes;
     }
 
     /// <inheritdoc/>
-    public async IAsyncEnumerable<MemoryRecord> GetListAsync(string index, ICollection<MemoryFilter>? filters = null, int limit = 1, bool withEmbeddings = false, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<MemoryRecord> GetListAsync(
+        string index,
+        ICollection<MemoryFilter>? filters = null,
+        int limit = 1,
+        bool withEmbeddings = false,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         if (!this._isReady) { await this.InitAsync(cancellationToken).ConfigureAwait(false); }
 
@@ -257,15 +284,13 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
         }
 
         var connection = new SqlConnection(this._config.ConnectionString);
-        await using var disposableConnection = connection.ConfigureAwait(false);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-
         SqlCommand command = connection.CreateCommand();
-        await using var disposableCommand = command.ConfigureAwait(false);
+        try
+        {
+            var tagFilters = new TagCollection();
 
-        var tagFilters = new TagCollection();
-
-        command.CommandText = $@"
+            command.CommandText = $@"
             WITH [filters] AS
 		    (
 			    SELECT
@@ -281,16 +306,22 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
             AND {this.GetFullTableName(this._config.MemoryTableName)}.[collection] = @index
             {this.GenerateFilters(index, command.Parameters, filters)};";
 
-        command.Parameters.AddWithValue("@index", index);
-        command.Parameters.AddWithValue("@limit", limit);
-        command.Parameters.AddWithValue("@filters", JsonSerializer.Serialize(tagFilters));
+            command.Parameters.AddWithValue("@index", index);
+            command.Parameters.AddWithValue("@limit", limit);
+            command.Parameters.AddWithValue("@filters", JsonSerializer.Serialize(tagFilters));
 
-        var dataReader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        await using var disposableReader = dataReader.ConfigureAwait(false);
+            var dataReader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await dataReader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                yield return await this.ReadEntryAsync(dataReader, withEmbeddings, cancellationToken).ConfigureAwait(false);
+            }
 
-        while (await dataReader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            await dataReader.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
         {
-            yield return await this.ReadEntryAsync(dataReader, withEmbeddings, cancellationToken).ConfigureAwait(false);
+            command.Dispose();
+            connection.Dispose();
         }
     }
 
@@ -321,72 +352,76 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
         }
 
         var connection = new SqlConnection(this._config.ConnectionString);
-        await using var disposableConnection = connection.ConfigureAwait(false);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-
         SqlCommand command = connection.CreateCommand();
-        await using var disposableCommand = command.ConfigureAwait(false);
-
-        var generatedFilters = this.GenerateFilters(index, command.Parameters, filters);
-
-        command.CommandText = $@"
-        WITH
-        [embedding] as
-        (
-            SELECT
-                cast([key] AS INT) AS [vector_value_id],
-                cast([value] AS FLOAT) AS [vector_value]
-            FROM
-                openjson(@vector)
-        ),
-        [similarity] AS
-        (
-            SELECT TOP (@limit)
-            {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[memory_id],
-            SUM([embedding].[vector_value] * {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[vector_value]) /
-            (
-                SQRT(SUM([embedding].[vector_value] * [embedding].[vector_value]))
-                *
-                SQRT(SUM({this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[vector_value] * {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[vector_value]))
-            ) AS cosine_similarity
-            -- sum([embedding].[vector_value] * {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[vector_value]) as cosine_distance -- Optimized as per https://platform.openai.com/docs/guides/embeddings/which-distance-function-should-i-use
-        FROM
-            [embedding]
-        INNER JOIN
-            {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")} ON [embedding].vector_value_id = {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.vector_value_id
-        INNER JOIN
-            {this.GetFullTableName(this._config.MemoryTableName)} ON {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[memory_id] = {this.GetFullTableName(this._config.MemoryTableName)}.[id]
-        WHERE 1=1
-        {generatedFilters}
-        GROUP BY
-            {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[memory_id]
-        ORDER BY
-            cosine_similarity DESC
-        )
-        SELECT DISTINCT
-            {queryColumns},
-            [similarity].[cosine_similarity]
-        FROM
-            [similarity]
-        INNER JOIN
-            {this.GetFullTableName(this._config.MemoryTableName)} ON [similarity].[memory_id] = {this.GetFullTableName(this._config.MemoryTableName)}.[id]
-        WHERE 1=1
-        AND [cosine_similarity] >= @min_relevance_score
-        {generatedFilters}
-        ORDER BY [cosine_similarity] desc";
-
-        command.Parameters.AddWithValue("@vector", JsonSerializer.Serialize(embedding.Data.ToArray()));
-        command.Parameters.AddWithValue("@index", index);
-        command.Parameters.AddWithValue("@min_relevance_score", minRelevance);
-        command.Parameters.AddWithValue("@limit", limit);
-
-        var dataReader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        await using var disposableReader = dataReader.ConfigureAwait(false);
-
-        while (await dataReader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        try
         {
-            double cosineSimilarity = dataReader.GetDouble(dataReader.GetOrdinal("cosine_similarity"));
-            yield return (await this.ReadEntryAsync(dataReader, withEmbeddings, cancellationToken).ConfigureAwait(false), cosineSimilarity);
+            var generatedFilters = this.GenerateFilters(index, command.Parameters, filters);
+            command.CommandText = $@"
+                WITH
+                [embedding] as
+                (
+                    SELECT
+                        cast([key] AS INT) AS [vector_value_id],
+                        cast([value] AS FLOAT) AS [vector_value]
+                    FROM
+                        openjson(@vector)
+                ),
+                [similarity] AS
+                (
+                    SELECT TOP (@limit)
+                    {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[memory_id],
+                    SUM([embedding].[vector_value] * {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[vector_value]) /
+                    (
+                        SQRT(SUM([embedding].[vector_value] * [embedding].[vector_value]))
+                        *
+                        SQRT(SUM({this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[vector_value] * {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[vector_value]))
+                    ) AS cosine_similarity
+                    -- sum([embedding].[vector_value] * {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[vector_value]) as cosine_distance -- Optimized as per https://platform.openai.com/docs/guides/embeddings/which-distance-function-should-i-use
+                FROM
+                    [embedding]
+                INNER JOIN
+                    {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")} ON [embedding].vector_value_id = {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.vector_value_id
+                INNER JOIN
+                    {this.GetFullTableName(this._config.MemoryTableName)} ON {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[memory_id] = {this.GetFullTableName(this._config.MemoryTableName)}.[id]
+                WHERE 1=1
+                {generatedFilters}
+                GROUP BY
+                    {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}.[memory_id]
+                ORDER BY
+                    cosine_similarity DESC
+                )
+                SELECT DISTINCT
+                    {queryColumns},
+                    [similarity].[cosine_similarity]
+                FROM
+                    [similarity]
+                INNER JOIN
+                    {this.GetFullTableName(this._config.MemoryTableName)} ON [similarity].[memory_id] = {this.GetFullTableName(this._config.MemoryTableName)}.[id]
+                WHERE 1=1
+                AND [cosine_similarity] >= @min_relevance_score
+                {generatedFilters}
+                ORDER BY [cosine_similarity] desc";
+
+            command.Parameters.AddWithValue("@vector", JsonSerializer.Serialize(embedding.Data.ToArray()));
+            command.Parameters.AddWithValue("@index", index);
+            command.Parameters.AddWithValue("@min_relevance_score", minRelevance);
+            command.Parameters.AddWithValue("@limit", limit);
+
+            var dataReader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await dataReader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                double cosineSimilarity = dataReader.GetDouble(dataReader.GetOrdinal("cosine_similarity"));
+                yield return (await this.ReadEntryAsync(dataReader, withEmbeddings, cancellationToken).ConfigureAwait(false), cosineSimilarity);
+            }
+
+            await dataReader.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            command.Dispose();
+            await connection.CloseAsync().ConfigureAwait(false);
+            connection.Dispose();
         }
     }
 
@@ -406,6 +441,9 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
     /// <inheritdoc/>
     public async IAsyncEnumerable<string> UpsertBatchAsync(string index, IEnumerable<MemoryRecord> records, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        List<MemoryRecord> list = records.ToList();
+        this._log.LogDebug("Upserting records, batch size {0}", list.Count);
+
         if (!this._isReady) { await this.InitAsync(cancellationToken).ConfigureAwait(false); }
 
         index = NormalizeIndexName(index);
@@ -415,16 +453,7 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
             throw new IndexNotFoundException($"The index '{index}' does not exist.");
         }
 
-        var connection = new SqlConnection(this._config.ConnectionString);
-        await using var disposableConnection = connection.ConfigureAwait(false);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-
-        foreach (var record in records)
-        {
-            SqlCommand command = connection.CreateCommand();
-            await using var disposableCommand = command.ConfigureAwait(false);
-
-            command.CommandText = $@"
+        var sql = $@"
                 BEGIN TRANSACTION;
 
                 MERGE INTO {this.GetFullTableName(this._config.MemoryTableName)}
@@ -486,15 +515,29 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
 
                 COMMIT;";
 
-            command.Parameters.AddWithValue("@index", index);
-            command.Parameters.AddWithValue("@key", record.Id);
-            command.Parameters.AddWithValue("@payload", JsonSerializer.Serialize(record.Payload) ?? (object)DBNull.Value);
-            command.Parameters.AddWithValue("@tags", JsonSerializer.Serialize(record.Tags) ?? (object)DBNull.Value);
-            command.Parameters.AddWithValue("@embedding", JsonSerializer.Serialize(record.Vector.Data.ToArray()));
+        var connection = new SqlConnection(this._config.ConnectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            foreach (var record in list)
+            {
+                SqlCommand command = connection.CreateCommand();
+                command.CommandText = sql;
+                command.Parameters.AddWithValue("@index", index);
+                command.Parameters.AddWithValue("@key", record.Id);
+                command.Parameters.AddWithValue("@payload", JsonSerializer.Serialize(record.Payload) ?? (object)DBNull.Value);
+                command.Parameters.AddWithValue("@tags", JsonSerializer.Serialize(record.Tags) ?? (object)DBNull.Value);
+                command.Parameters.AddWithValue("@embedding", JsonSerializer.Serialize(record.Vector.Data.ToArray()));
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                command.Dispose();
 
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-
-            yield return record.Id;
+                yield return record.Id;
+            }
+        }
+        finally
+        {
+            await connection.CloseAsync().ConfigureAwait(false);
+            connection.Dispose();
         }
     }
 
@@ -538,17 +581,21 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
     private async Task CacheSqlServerMajorVersionNumberAsync(CancellationToken cancellationToken)
     {
         var connection = new SqlConnection(this._config.ConnectionString);
-        await using var disposableConnection = connection.ConfigureAwait(false);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-
         SqlCommand command = connection.CreateCommand();
-        await using var disposableCommand = command.ConfigureAwait(false);
 
-        command.CommandText = "SELECT SERVERPROPERTY('ProductMajorVersion')";
-
-        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-
-        this._cachedServerVersion = Convert.ToInt32(result, CultureInfo.InvariantCulture);
+        try
+        {
+            command.CommandText = "SELECT SERVERPROPERTY('ProductMajorVersion')";
+            var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            this._cachedServerVersion = Convert.ToInt32(result, CultureInfo.InvariantCulture);
+        }
+        finally
+        {
+            command.Dispose();
+            await connection.CloseAsync().ConfigureAwait(false);
+            connection.Dispose();
+        }
     }
 
     /// <summary>
@@ -581,14 +628,19 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
                     );";
 
         var connection = new SqlConnection(this._config.ConnectionString);
-        await using var disposableConnection = connection.ConfigureAwait(false);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-
         SqlCommand command = connection.CreateCommand();
-        await using var disposableCommand = command.ConfigureAwait(false);
-
-        command.CommandText = sql;
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            command.CommandText = sql;
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            command.Dispose();
+            await connection.CloseAsync().ConfigureAwait(false);
+            connection.Dispose();
+        }
     }
 
     /// <summary>
@@ -621,7 +673,10 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
     /// <param name="parameters">The SQL parameters to populate.</param>
     /// <param name="filters">The filters to apply</param>
     /// <returns></returns>
-    private string GenerateFilters(string index, SqlParameterCollection parameters, ICollection<MemoryFilter>? filters = null)
+    private string GenerateFilters(
+        string index,
+        SqlParameterCollection parameters,
+        ICollection<MemoryFilter>? filters = null)
     {
         var filterBuilder = new StringBuilder();
 

--- a/service/tests/Core.FunctionalTests/DefaultTestCases/RecordDeletionTest.cs
+++ b/service/tests/Core.FunctionalTests/DefaultTestCases/RecordDeletionTest.cs
@@ -9,34 +9,62 @@ public static class RecordDeletionTest
 {
     public static async Task ItDeletesRecords(IKernelMemory memory, IMemoryDb db, Action<string> log)
     {
+        async Task WaitForImport(string indexName, string docId1)
+        {
+            var count = 0;
+            while (!await memory.IsDocumentReadyAsync(index: indexName, documentId: docId1))
+            {
+                Assert.True(count++ <= 30, "Document import timed out");
+                log("Waiting for memory ingestion to complete...");
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+        }
+
         // Arrange
-        const string DocId = "ItDeletesRecords-file2-largePDF.pdf";
+        const string DocId1 = "ItDeletesRecords-file2-largePDF.pdf";
+        const string DocId2 = "ItDeletesRecords-file2-largePDF.pdf";
+        const string DocId3 = "ItDeletesRecords-file2-largePDF.pdf";
         const string IndexName = "default";
 
-        log("Uploading document");
+        log("Uploading doc1");
         await memory.ImportDocumentAsync(
             "file2-largePDF.pdf",
-            documentId: DocId,
+            documentId: DocId1,
             index: IndexName,
             steps: Constants.PipelineWithoutSummary);
 
-        var count = 0;
-        while (!await memory.IsDocumentReadyAsync(index: IndexName, documentId: DocId))
-        {
-            Assert.True(count++ <= 30, "Document import timed out");
-            log("Waiting for memory ingestion to complete...");
-            await Task.Delay(TimeSpan.FromSeconds(1));
-        }
+        log("Uploading doc2");
+        await memory.ImportDocumentAsync(
+            "file2-largePDF.pdf",
+            documentId: DocId2,
+            index: IndexName,
+            steps: Constants.PipelineWithoutSummary);
+
+        log("Uploading doc3");
+        await memory.ImportDocumentAsync(
+            "file2-largePDF.pdf",
+            documentId: DocId3,
+            index: IndexName,
+            steps: Constants.PipelineWithoutSummary);
+
+        await WaitForImport(IndexName, DocId1);
+        await WaitForImport(IndexName, DocId2);
+        await WaitForImport(IndexName, DocId3);
 
         // Act: Load and delete records
         log("Fetching records to delete");
         IAsyncEnumerable<MemoryRecord> records = db.GetListAsync(
             index: IndexName,
             limit: -1,
-            filters: new List<MemoryFilter> { MemoryFilters.ByDocument(DocId) });
+            filters: new List<MemoryFilter>
+            {
+                MemoryFilters.ByDocument(DocId3),
+                MemoryFilters.ByDocument(DocId2),
+                MemoryFilters.ByDocument(DocId1),
+            });
 
         log("Deleting records");
-        count = 0;
+        var count = 0;
         await foreach (var record in records.ConfigureAwait(false))
         {
             count++;
@@ -47,6 +75,8 @@ public static class RecordDeletionTest
 
         // Cleanup
         log("Deleting test document");
-        await memory.DeleteDocumentAsync(DocId);
+        await memory.DeleteDocumentAsync(DocId3);
+        await memory.DeleteDocumentAsync(DocId2);
+        await memory.DeleteDocumentAsync(DocId1);
     }
 }

--- a/service/tests/Core.FunctionalTests/DefaultTestCases/RecordDeletionTest.cs
+++ b/service/tests/Core.FunctionalTests/DefaultTestCases/RecordDeletionTest.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.KernelMemory;
+using Microsoft.KernelMemory.MemoryStorage;
+
+namespace Microsoft.KM.Core.FunctionalTests.DefaultTestCases;
+
+public static class RecordDeletionTest
+{
+    public static async Task ItDeletesRecords(IKernelMemory memory, IMemoryDb db, Action<string> log)
+    {
+        // Arrange
+        const string DocId = "ItDeletesRecords-file2-largePDF.pdf";
+        const string IndexName = "default";
+
+        log("Uploading document");
+        await memory.ImportDocumentAsync(
+            "file2-largePDF.pdf",
+            documentId: DocId,
+            index: IndexName,
+            steps: Constants.PipelineWithoutSummary);
+
+        var count = 0;
+        while (!await memory.IsDocumentReadyAsync(index: IndexName, documentId: DocId))
+        {
+            Assert.True(count++ <= 30, "Document import timed out");
+            log("Waiting for memory ingestion to complete...");
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+
+        // Act: Load and delete records
+        log("Fetching records to delete");
+        IAsyncEnumerable<MemoryRecord> records = db.GetListAsync(
+            index: IndexName,
+            limit: -1,
+            filters: new List<MemoryFilter> { MemoryFilters.ByDocument(DocId) });
+
+        log("Deleting records");
+        count = 0;
+        await foreach (var record in records.ConfigureAwait(false))
+        {
+            count++;
+            await db.DeleteAsync(index: IndexName, record).ConfigureAwait(false);
+        }
+
+        log($"{count} records deleted");
+
+        // Cleanup
+        log("Deleting test document");
+        await memory.DeleteDocumentAsync(DocId);
+    }
+}


### PR DESCRIPTION
* Add a new functional test, currently used only for MSSQL, to test memory record deletion. See #712 
* Refactor MSSQL .NET object disposal to be more explicit