### PR TITLE
Add health probe only when web service is running

### DIFF
--- a/service/Service/Program.cs
+++ b/service/Service/Program.cs
@@ -138,6 +138,12 @@ internal static class Program
             // Add HTTP endpoints using minimal API (https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis)
             app.AddKernelMemoryEndpoints("/", authFilter);
 
+            // Health probe
+            app.MapGet("/health", () => Results.Ok("Service is running."))
+                .Produces<string>(StatusCodes.Status200OK)
+                .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized)
+                .Produces<ProblemDetails>(StatusCodes.Status403Forbidden);
+
             if (config.ServiceAuthorization.Enabled && config.ServiceAuthorization.AccessKey1 == config.ServiceAuthorization.AccessKey2)
             {
                 app.Logger.LogError("KM Web Service: Access keys 1 and 2 have the same value. Keys should be different to allow rotation.");
@@ -165,12 +171,6 @@ internal static class Program
         Console.WriteLine("* Text generation     : " + app.Services.GetService<ITextGenerator>()?.GetType().FullName);
         Console.WriteLine("* Log level           : " + app.Logger.GetLogLevelName());
         Console.WriteLine("***************************************************************************************************************************");
-
-        // health probe
-        app.MapGet("/health", () => Results.Ok("Service is running."))
-                        .Produces<string>(StatusCodes.Status200OK)
-                        .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized)
-                        .Produces<ProblemDetails>(StatusCodes.Status403Forbidden);
 
         app.Logger.LogInformation(
             "Starting Kernel Memory service, .NET Env: {0}, Log Level: {1}, Web service: {2}, Auth: {3}, Pipeline handlers: {4}",


### PR DESCRIPTION
Fix: the new health probe endpoint should be added only when the web service is enabled.

