### PR TITLE
Add disposal of NpgsqlDataSource after opening connection

### DIFF
--- a/extensions/Postgres/Postgres.FunctionalTests/ConcurrencyTests.cs
+++ b/extensions/Postgres/Postgres.FunctionalTests/ConcurrencyTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.KernelMemory;
 using Microsoft.KernelMemory.MemoryStorage;
@@ -71,7 +71,7 @@ public class ConcurrencyTests : BaseFunctionalTestCase
         var indexName = "create_index_test";
         var vectorSize = 1536;
 
-        using var target = new PostgresMemory(config, new FakeEmbeddingGenerator());
+        var target = new PostgresMemory(config, new FakeEmbeddingGenerator());
 
         var tasks = new List<Task>();
         for (int i = 0; i < concurrency; i++)
@@ -98,7 +98,7 @@ public class ConcurrencyTests : BaseFunctionalTestCase
         var vectorSize = 4;
         var indexName = "upsert_test" + Guid.NewGuid().ToString("D");
 
-        using var target = new PostgresMemory(this.PostgresConfig, new FakeEmbeddingGenerator());
+        var target = new PostgresMemory(this.PostgresConfig, new FakeEmbeddingGenerator());
 
         await target.CreateIndexAsync(indexName, vectorSize);
 

--- a/extensions/Postgres/Postgres/Internals/PostgresDbClient.cs
+++ b/extensions/Postgres/Postgres/Internals/PostgresDbClient.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.Collections.Generic;
@@ -28,7 +28,7 @@ internal sealed class PostgresDbClient : IDisposable
     private const string PgErrDatabaseDoesNotExist = "3D000"; // invalid_catalog_name
 
     private readonly ILogger _log;
-    private readonly NpgsqlDataSource _dataSource;
+    private readonly NpgsqlDataSourceBuilder _dataSourceBuilder;
 
     private readonly string _schema;
     private readonly string _tableNamePrefix;
@@ -52,10 +52,10 @@ internal sealed class PostgresDbClient : IDisposable
         config.Validate();
         this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<PostgresDbClient>();
 
-        NpgsqlDataSourceBuilder dataSourceBuilder = new(config.ConnectionString);
+        this._dataSourceBuilder = new(config.ConnectionString);
+        this._dataSourceBuilder.UseVector();
+
         this._dbNamePresent = config.ConnectionString.Contains("Database=", StringComparison.OrdinalIgnoreCase);
-        dataSourceBuilder.UseVector();
-        this._dataSource = dataSourceBuilder.Build();
         this._schema = config.Schema;
         this._tableNamePrefix = config.TableNamePrefix;
 
@@ -228,8 +228,8 @@ internal sealed class PostgresDbClient : IDisposable
             if (await this.DoesTableExistAsync(origInputTableName, cancellationToken).ConfigureAwait(false))
             {
                 // Check if the custom SQL contains the lock placeholder (assuming it's not commented out)
-                bool missingLockStatement = (!string.IsNullOrEmpty(this._createTableSql)
-                                             && !this._createTableSql.Contains(PostgresConfig.SqlPlaceholdersLockId, StringComparison.Ordinal));
+                bool missingLockStatement = !string.IsNullOrEmpty(this._createTableSql)
+                                             && !this._createTableSql.Contains(PostgresConfig.SqlPlaceholdersLockId, StringComparison.Ordinal);
 
                 if (missingLockStatement)
                 {
@@ -672,7 +672,6 @@ internal sealed class PostgresDbClient : IDisposable
     {
         if (disposing)
         {
-            (this._dataSource as IDisposable)?.Dispose();
         }
     }
 
@@ -685,7 +684,8 @@ internal sealed class PostgresDbClient : IDisposable
     {
         try
         {
-            return await this._dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            using var dataSource = this._dataSourceBuilder.Build();
+            return await dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (Npgsql.PostgresException e) when (IsDbNotFoundException(e))
         {
@@ -750,20 +750,20 @@ internal sealed class PostgresDbClient : IDisposable
 
     private static bool IsDbNotFoundException(Npgsql.PostgresException e)
     {
-        return (e.SqlState == PgErrDatabaseDoesNotExist);
+        return e.SqlState == PgErrDatabaseDoesNotExist;
     }
 
     private static bool IsTableNotFoundException(Npgsql.PostgresException e)
     {
-        return (e.SqlState == PgErrUndefinedTable || e.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase));
+        return e.SqlState == PgErrUndefinedTable || e.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsVectorTypeDoesNotExistException(Npgsql.PostgresException e)
     {
-        return (e.SqlState == PgErrTypeDoesNotExist
+        return e.SqlState == PgErrTypeDoesNotExist
                 && e.Message.Contains("type", StringComparison.OrdinalIgnoreCase)
                 && e.Message.Contains("vector", StringComparison.OrdinalIgnoreCase)
-                && e.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase));
+                && e.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/extensions/Postgres/Postgres/Internals/PostgresDbClient.cs
+++ b/extensions/Postgres/Postgres/Internals/PostgresDbClient.cs
@@ -229,7 +229,7 @@ internal sealed class PostgresDbClient
             {
                 // Check if the custom SQL contains the lock placeholder (assuming it's not commented out)
                 bool missingLockStatement = !string.IsNullOrEmpty(this._createTableSql)
-                    && !this._createTableSql.Contains(PostgresConfig.SqlPlaceholdersLockId, StringComparison.Ordinal);
+                                            && !this._createTableSql.Contains(PostgresConfig.SqlPlaceholdersLockId, StringComparison.Ordinal);
 
                 if (missingLockStatement)
                 {
@@ -747,9 +747,9 @@ internal sealed class PostgresDbClient
     private static bool IsVectorTypeDoesNotExistException(Npgsql.PostgresException e)
     {
         return e.SqlState == PgErrTypeDoesNotExist
-            && e.Message.Contains("type", StringComparison.OrdinalIgnoreCase)
-            && e.Message.Contains("vector", StringComparison.OrdinalIgnoreCase)
-            && e.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase);
+               && e.Message.Contains("type", StringComparison.OrdinalIgnoreCase)
+               && e.Message.Contains("vector", StringComparison.OrdinalIgnoreCase)
+               && e.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/extensions/Postgres/Postgres/PostgresMemory.cs
+++ b/extensions/Postgres/Postgres/PostgresMemory.cs
@@ -21,7 +21,7 @@ namespace Microsoft.KernelMemory.Postgres;
 /// Postgres connector for Kernel Memory.
 /// </summary>
 [Experimental("KMEXP03")]
-public sealed class PostgresMemory : IMemoryDb, IDisposable
+public sealed class PostgresMemory : IMemoryDb
 {
     private readonly ILogger<PostgresMemory> _log;
     private readonly ITextEmbeddingGenerator _embeddingGenerator;
@@ -207,24 +207,6 @@ public sealed class PostgresMemory : IMemoryDb, IDisposable
         index = NormalizeIndexName(index);
 
         return this._db.DeleteAsync(tableName: index, id: record.Id, cancellationToken);
-    }
-
-    /// <inheritdoc/>
-    public void Dispose()
-    {
-        this.Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
-    /// <summary>
-    /// Disposes the managed resources.
-    /// </summary>
-    private void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            (this._db as IDisposable)?.Dispose();
-        }
     }
 
     #region private ================================================================================


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
See https://github.com/microsoft/kernel-memory/issues/679.

## High level description (Approach, Design)
If I call `ImportDocumentAsync` and then `AskAsync`, after the execution I see that two sessions are still in the list:

![image](https://github.com/user-attachments/assets/a8c396bd-ef6c-49ca-ac03-97c816ac67d4)

This PR adds the disposal the **NpgsqlDataSource** after each connection. In this way, no pending sessions remain when the execution completes.

~~NOTE: for the moment, I have left the `IDisposable` interface on **PostgresDbClient.cs** (with an empty implementation for reference), but actually it is no longer necessary, as explained in https://github.com/microsoft/kernel-memory/issues/679#issuecomment-2202303865. So, I think it could be safely removed.~~