### PR TITLE
Make SK text and embedding generator wrappers public

### DIFF
--- a/service/Core/SemanticKernel/SemanticKernelTextEmbeddingGenerator.cs
+++ b/service/Core/SemanticKernel/SemanticKernelTextEmbeddingGenerator.cs
@@ -12,7 +12,7 @@ using Microsoft.SemanticKernel.Embeddings;
 
 namespace Microsoft.KernelMemory.SemanticKernel;
 
-internal sealed class SemanticKernelTextEmbeddingGenerator : ITextEmbeddingGenerator
+public sealed class SemanticKernelTextEmbeddingGenerator : ITextEmbeddingGenerator
 {
     private readonly ITextEmbeddingGenerationService _service;
     private readonly ITextTokenizer _tokenizer;

--- a/service/Core/SemanticKernel/SemanticKernelTextGenerator.cs
+++ b/service/Core/SemanticKernel/SemanticKernelTextGenerator.cs
@@ -13,7 +13,7 @@ using Microsoft.SemanticKernel.TextGeneration;
 
 namespace Microsoft.KernelMemory.SemanticKernel;
 
-internal sealed class SemanticKernelTextGenerator : ITextGenerator
+public sealed class SemanticKernelTextGenerator : ITextGenerator
 {
     private readonly ITextGenerationService _service;
     private readonly ITextTokenizer _tokenizer;


### PR DESCRIPTION
Currently it's possible to inject Semantic Kernel classes into KM only using 

- IKernelMemoryBuilder.WithSemanticKernelTextGenerationService
- IKernelMemoryBuilder.WithSemanticKernelTextEmbeddingGenerationService
- IServiceCollection.AddSingleton<ITextGenerator>(instance)
- IServiceCollection.AddSingleton<ITextEmbeddingGenerator>(instance)

However, it's not possible to create an instance of Semantic Kernel classes directly without writing a custom wrapper class first. Since the project already includes such wrapper, as internal classes, this PR changes them to public classes, to reduce the amount of code to write.

Classes:
- SemanticKernelTextGenerator
- SemanticKernelTextEmbeddingGenerator
