### PR TITLE
Fixing dockerization for ARM64

### DIFF
--- a/.github/workflows/docker-amd64.yml
+++ b/.github/workflows/docker-amd64.yml
@@ -1,6 +1,6 @@
 # Build Docker image and push it to docker hub
 
-name: Docker Image Build and Push to DockerHub
+name: Dockerize amd64
 
 on: workflow_dispatch
 
@@ -8,20 +8,9 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     steps:
+
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            ${{ vars.DOCKERHUB_USERNAME }}/service
-          # Docker tags to generate
-          tags: |
-            type=raw,value=latest
-            type=sha
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -35,10 +24,26 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v5
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
         with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ vars.DOCKERHUB_USERNAME }}/service
+          # Docker tags to generate
+          tags: |
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          # See https://github.com/dotnet/dotnet-docker/blob/main/README.sdk.md#full-tag-listing
+          build-args: |
+            BUILD_IMAGE_TAG=8.0-jammy-amd64
+            RUN_IMAGE_TAG=8.0-alpine-amd64
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-armd64.yml
+++ b/.github/workflows/docker-armd64.yml
@@ -1,0 +1,57 @@
+# Build Docker image and push it to docker hub
+
+name: Dockerize arm64
+
+on: workflow_dispatch
+
+jobs:
+  build-and-push-image:
+    runs-on: macos-latest
+    steps:
+
+      # https://github.com/actions/runner/issues/1456
+      - name: Setup docker (missing on MacOS)
+        if: runner.os == 'macos'
+        run: |
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          brew install docker colima
+          colima start
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ vars.DOCKERHUB_USERNAME }}/service
+          # Docker tags to generate
+          tags: |
+            type=raw,value=latest-arm64
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          # See https://github.com/dotnet/dotnet-docker/blob/main/README.sdk.md#full-tag-listing
+          build-args: |
+            BUILD_IMAGE_TAG=8.0-jammy-arm64v8
+            RUN_IMAGE_TAG=8.0-alpine-arm64v8
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
-# Usage: docker buildx build .
+# Usage: docker buildx build --platform linux/amd64 .
+# Usage: docker buildx build --platform linux/arm64 .
 
+# See https://github.com/dotnet/dotnet-docker/blob/main/README.sdk.md#full-tag-listing
 ARG BUILD_IMAGE_TAG="8.0-jammy"
 ARG RUN_IMAGE_TAG="8.0-alpine"
-
-#ARG PLATFORM=$BUILDPLATFORM
-ARG PLATFORM=$TARGETPLATFORM
 
 #########################################################################
 # .NET build
 #########################################################################
 
-# ARG BUILDPLATFORM
-FROM --platform=$PLATFORM mcr.microsoft.com/dotnet/sdk:$BUILD_IMAGE_TAG AS build
+FROM mcr.microsoft.com/dotnet/sdk:$BUILD_IMAGE_TAG AS build
 
 ARG BUILD_CONFIGURATION=Release
 
 COPY . /src/
 WORKDIR "/src/service/Service"
+
 RUN dotnet build Service.csproj -c $BUILD_CONFIGURATION -o /app/build /p:RepoRoot=/src/
 RUN dotnet publish "./Service.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false /p:RepoRoot=/src/
 
@@ -24,8 +23,7 @@ RUN dotnet publish "./Service.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p
 # prepare final content
 #########################################################################
 
-#ARG PLATFORM
-FROM --platform=$PLATFORM mcr.microsoft.com/dotnet/aspnet:$RUN_IMAGE_TAG AS base
+FROM mcr.microsoft.com/dotnet/aspnet:$RUN_IMAGE_TAG AS base
 
 # Non-root user that will run the service
 ARG USER=km
@@ -46,15 +44,14 @@ COPY --from=build --chown=km:km --chmod=0550 /app/publish .
 #########################################################################
 
 LABEL org.opencontainers.image.authors="Devis Lucato, https://github.com/dluc"
-MAINTAINER Devis Lucato "https://github.com/dluc"
 
 # Define current user
 USER $USER
 
 # Used by .NET and KM to load appsettings.Production.json
-ENV ASPNETCORE_ENVIRONMENT Production
-ENV ASPNETCORE_URLS http://+:9001
-ENV ASPNETCORE_HTTP_PORTS 9001
+ENV ASPNETCORE_ENVIRONMENT=Production
+ENV ASPNETCORE_URLS=http://+:9001
+ENV ASPNETCORE_HTTP_PORTS=9001
 
 EXPOSE 9001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 ARG BUILD_IMAGE_TAG="8.0-jammy"
 ARG RUN_IMAGE_TAG="8.0-alpine"
 
-ARG PLATFORM=$BUILDPLATFORM
-#ARG PLATFORM=$TARGETPLATFORM
+#ARG PLATFORM=$BUILDPLATFORM
+ARG PLATFORM=$TARGETPLATFORM
 
 #########################################################################
 # .NET build
@@ -24,7 +24,7 @@ RUN dotnet publish "./Service.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p
 # prepare final content
 #########################################################################
 
-ARG PLATFORM
+#ARG PLATFORM
 FROM --platform=$PLATFORM mcr.microsoft.com/dotnet/aspnet:$RUN_IMAGE_TAG AS base
 
 # Non-root user that will run the service

--- a/tools/dockerize-amd64.sh
+++ b/tools/dockerize-amd64.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/"
+cd "$HERE"
+
+USR=kernelmemory
+IMG=${USR}/service
+TAG=:latest
+
+set +e
+docker rmi ${IMG}${TAG} >/dev/null 2>&1
+set -e
+
+if [ -z "$(docker images -q ${IMG}${TAG})" ]; then
+  echo "All ${IMG}${TAG} images have been deleted."
+else
+  echo "Some ${IMG}${TAG} images are still present:"
+  docker images ${IMG}${TAG}
+  exit -1
+fi
+
+# See https://github.com/dotnet/dotnet-docker/blob/main/README.sdk.md#full-tag-listing
+docker buildx build --no-cache --load \
+    --platform=linux/amd64 \
+    --build-arg BUILD_IMAGE_TAG=8.0-jammy-amd64 \
+    --build-arg RUN_IMAGE_TAG=8.0-alpine-amd64 \
+    -t ${IMG}${TAG} .
+
+docker login -u ${USR} --password-stdin
+
+docker push ${IMG}${TAG}

--- a/tools/dockerize-arm64.sh
+++ b/tools/dockerize-arm64.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/"
+cd "$HERE"
+
+USR=kernelmemory
+IMG=${USR}/service
+TAG=:latest-arm64
+
+set +e
+docker rmi ${IMG}${TAG} >/dev/null 2>&1
+set -e
+
+if [ -z "$(docker images -q ${IMG}${TAG})" ]; then
+  echo "All ${IMG}${TAG} images have been deleted."
+else
+  echo "Some ${IMG}${TAG} images are still present:"
+  docker images ${IMG}${TAG}
+  exit -1
+fi
+
+# See https://github.com/dotnet/dotnet-docker/blob/main/README.sdk.md#full-tag-listing
+docker buildx build --no-cache --load \
+    --platform=linux/arm64 \
+    --build-arg BUILD_IMAGE_TAG=8.0-jammy-arm64v8 \
+    --build-arg RUN_IMAGE_TAG=8.0-alpine-arm64v8 \
+    -t ${IMG}${TAG} .
+
+docker login -u ${USR} --password-stdin
+
+docker push ${IMG}${TAG}


### PR DESCRIPTION
* Remove multi-arch builds, which are not working correctly on ARM (segmentation fault)
* Split github workflow by arch. ARM arch dockerization to be run manually for now, until fixed.
* Deprecate "sha" labels to avoid confusion)

