### PR TITLE
RabbitMQ pipeline improvements

### DIFF
--- a/extensions/RabbitMQ/RabbitMQ.TestApplication/Program.cs
+++ b/extensions/RabbitMQ/RabbitMQ.TestApplication/Program.cs
@@ -45,7 +45,12 @@ internal static class Program
 
         ListenToDeadLetterQueue(rabbitMQConfig);
 
-        await pipeline.EnqueueAsync($"test {DateTimeOffset.Now:T}");
+        // Change ConcurrentThreads and PrefetchCount to 1 to see
+        // how they affect total execution time
+        for (int i = 1; i <= 3; i++)
+        {
+            await pipeline.EnqueueAsync($"test #{i} {DateTimeOffset.Now:T}");
+        }
 
         while (true)
         {

--- a/extensions/RabbitMQ/RabbitMQ.TestApplication/appsettings.json
+++ b/extensions/RabbitMQ/RabbitMQ.TestApplication/appsettings.json
@@ -14,8 +14,14 @@
         "VirtualHost": "/",
         "MessageTTLSecs": 3600,
         "SslEnabled": false,
+        // How many messages to process asynchronously at a time, in each queue
+        "ConcurrentThreads": 3,
+        // How many messages to fetch at a time from each queue
+        // The value should be higher than ConcurrentThreads
+        "PrefetchCount": 6,
         // How many times to dequeue a messages and process before moving it to a poison queue
         "MaxRetriesBeforePoisonQueue": 5,
+        "DelayBeforeRetryingMsecs": 750,
         // Suffix used for the poison queues.
         "PoisonQueueSuffix": "-poison"
       }

--- a/extensions/RabbitMQ/RabbitMQ/RabbitMQPipeline.cs
+++ b/extensions/RabbitMQ/RabbitMQ/RabbitMQPipeline.cs
@@ -24,6 +24,8 @@ public sealed class RabbitMQPipeline : IQueue
     private readonly AsyncEventingBasicConsumer _consumer;
     private readonly RabbitMQConfig _config;
     private readonly int _messageTTLMsecs;
+    private readonly int _delayBeforeRetryingMsecs;
+    private readonly int _maxAttempts;
     private string _queueName = string.Empty;
     private string _poisonQueueName = string.Empty;
 
@@ -32,10 +34,10 @@ public sealed class RabbitMQPipeline : IQueue
     /// </summary>
     public RabbitMQPipeline(RabbitMQConfig config, ILoggerFactory? loggerFactory = null)
     {
-        this._config = config;
-        this._config.Validate();
-
         this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<RabbitMQPipeline>();
+
+        this._config = config;
+        this._config.Validate(this._log);
 
         // see https://www.rabbitmq.com/dotnet-api-guide.html#consuming-async
         var factory = new ConnectionFactory
@@ -46,6 +48,7 @@ public sealed class RabbitMQPipeline : IQueue
             Password = config.Password,
             VirtualHost = !string.IsNullOrWhiteSpace(config.VirtualHost) ? config.VirtualHost : "/",
             DispatchConsumersAsync = true,
+            ConsumerDispatchConcurrency = config.ConcurrentThreads,
             Ssl = new SslOption
             {
                 Enabled = config.SslEnabled,
@@ -56,8 +59,11 @@ public sealed class RabbitMQPipeline : IQueue
         this._messageTTLMsecs = config.MessageTTLSecs * 1000;
         this._connection = factory.CreateConnection();
         this._channel = this._connection.CreateModel();
-        this._channel.BasicQos(prefetchSize: 0, prefetchCount: 1, global: false);
+        this._channel.BasicQos(prefetchSize: 0, prefetchCount: config.PrefetchCount, global: false);
         this._consumer = new AsyncEventingBasicConsumer(this._channel);
+
+        this._delayBeforeRetryingMsecs = Math.Max(0, this._config.DelayBeforeRetryingMsecs);
+        this._maxAttempts = Math.Max(0, this._config.MaxRetriesBeforePoisonQueue) + 1;
     }
 
     /// <inheritdoc />
@@ -171,7 +177,6 @@ public sealed class RabbitMQPipeline : IQueue
         this._consumer.Received += async (object sender, BasicDeliverEventArgs args) =>
         {
             // Just for logging, extract the attempt number from the message headers
-            var maxAttempts = this._config.MaxRetriesBeforePoisonQueue + 1;
             var attemptNumber = 1;
             if (args.BasicProperties?.Headers != null && args.BasicProperties.Headers.TryGetValue("x-delivery-count", out object? value))
             {
@@ -181,7 +186,7 @@ public sealed class RabbitMQPipeline : IQueue
             try
             {
                 this._log.LogDebug("Message '{0}' received, expires after {1}ms, attempt {2} of {3}",
-                    args.BasicProperties?.MessageId, args.BasicProperties?.Expiration, attemptNumber, maxAttempts);
+                    args.BasicProperties?.MessageId, args.BasicProperties?.Expiration, attemptNumber, this._maxAttempts);
 
                 byte[] body = args.Body.ToArray();
                 string message = Encoding.UTF8.GetString(body);
@@ -194,15 +199,19 @@ public sealed class RabbitMQPipeline : IQueue
                 }
                 else
                 {
-                    if (attemptNumber < maxAttempts)
+                    if (attemptNumber < this._maxAttempts)
                     {
                         this._log.LogWarning("Message '{0}' failed to process (attempt {1} of {2}), putting message back in the queue",
-                            args.BasicProperties?.MessageId, attemptNumber, maxAttempts);
+                            args.BasicProperties?.MessageId, attemptNumber, this._maxAttempts);
+                        if (this._delayBeforeRetryingMsecs > 0)
+                        {
+                            await Task.Delay(TimeSpan.FromMilliseconds(this._delayBeforeRetryingMsecs)).ConfigureAwait(false);
+                        }
                     }
                     else
                     {
                         this._log.LogError("Message '{0}' failed to process (attempt {1} of {2}), moving message to dead letter queue",
-                            args.BasicProperties?.MessageId, attemptNumber, maxAttempts);
+                            args.BasicProperties?.MessageId, attemptNumber, this._maxAttempts);
                     }
 
                     // Note: if "requeue == false" the message would be moved to the dead letter exchange
@@ -217,8 +226,20 @@ public sealed class RabbitMQPipeline : IQueue
                 // - failed to delete message from queue
                 // - failed to unlock message in the queue
 
-                this._log.LogWarning(e, "Message '{0}' processing failed with exception (attempt {1} of {2}), putting message back in the queue",
-                    args.BasicProperties?.MessageId, attemptNumber, maxAttempts);
+                if (attemptNumber < this._maxAttempts)
+                {
+                    this._log.LogWarning(e, "Message '{0}' processing failed with exception (attempt {1} of {2}), putting message back in the queue",
+                        args.BasicProperties?.MessageId, attemptNumber, this._maxAttempts);
+                    if (this._delayBeforeRetryingMsecs > 0)
+                    {
+                        await Task.Delay(TimeSpan.FromMilliseconds(this._delayBeforeRetryingMsecs)).ConfigureAwait(false);
+                    }
+                }
+                else
+                {
+                    this._log.LogError(e, "Message '{0}' processing failed with exception (attempt {1} of {2}), putting message back in the queue",
+                        args.BasicProperties?.MessageId, attemptNumber, this._maxAttempts);
+                }
 
                 // TODO: verify and document what happens if this fails. RabbitMQ should automatically unlock messages.
                 // Note: if "requeue == false" the message would be moved to the dead letter exchange

--- a/extensions/RabbitMQ/RabbitMQ/RabbitMQPipeline.cs
+++ b/extensions/RabbitMQ/RabbitMQ/RabbitMQPipeline.cs
@@ -42,6 +42,7 @@ public sealed class RabbitMQPipeline : IQueue
         // see https://www.rabbitmq.com/dotnet-api-guide.html#consuming-async
         var factory = new ConnectionFactory
         {
+            ClientProvidedName = "KernelMemory",
             HostName = config.Host,
             Port = config.Port,
             UserName = config.Username,

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -539,10 +539,17 @@
         "VirtualHost": "/",
         "MessageTTLSecs": 3600,
         "SslEnabled": false,
+        // How many messages to process asynchronously at a time, in each queue
+        "ConcurrentThreads": 4,
+        // How many messages to fetch at a time from each queue
+        // The value should be higher than ConcurrentThreads
+        "PrefetchCount": 8,
         // How many times to dequeue a messages and process before moving it to a poison queue
         // Note: this value cannot be changed after queues have been created. In such case
         //       you might need to drain all queues, delete them, and restart the ingestion service(s).
         "MaxRetriesBeforePoisonQueue": 20,
+        // How long to wait before putting a message back to the queue in case of failure
+        "DelayBeforeRetryingMsecs": 500,
         // Suffix used for the poison queues.
         "PoisonQueueSuffix": "-poison"
       },


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

Allow to configure the RabbitMQ pipeline threads usage and the delay between failures.
Add "KernelMemory" application name to RabbitMQ logs.

## High level description (Approach, Design)

New configuration settings:

* ConcurrentThreads: how many threads to use for each queue to process messages.
* PrefetchCount: how many messages to prefetch from each queue. The value is recommended to be greater than ConcurrentThreads.
* DelayBeforeRetryingMsecs: how long to wait before retrying to process a message that failed. The delay is applied in the client code, not using delayed exchanges.