### PR TITLE
Add TryGetFileType method to MimeTypesDetection

### DIFF
--- a/service/Abstractions/Pipeline/MimeTypes.cs
+++ b/service/Abstractions/Pipeline/MimeTypes.cs
@@ -141,6 +141,7 @@ public static class FileExtensions
 public interface IMimeTypeDetection
 {
     public string GetFileType(string filename);
+    public bool TryGetFileType(string filename, out string? mimeType);
 }
 
 public class MimeTypesDetection : IMimeTypeDetection
@@ -221,5 +222,10 @@ public class MimeTypesDetection : IMimeTypeDetection
         }
 
         throw new NotSupportedException($"File type not supported: {filename}");
+    }
+
+    public bool TryGetFileType(string filename, out string? mimeType)
+    {
+        return s_extensionTypes.TryGetValue(Path.GetExtension(filename), out mimeType);
     }
 }


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)
TryGetFileType allows to check file type support before using ImportDocumentAsync, enabling a fallback to ImportTextAsync without relying on try-catch blocks.
