### PR TITLE
Support Request Context in Ollama and Anthropic generators

### DIFF
--- a/examples/210-KM-without-builder/Program.cs
+++ b/examples/210-KM-without-builder/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.KernelMemory.AI;
 using Microsoft.KernelMemory.AI.AzureOpenAI;
 using Microsoft.KernelMemory.AI.OpenAI;
 using Microsoft.KernelMemory.Configuration;
+using Microsoft.KernelMemory.Context;
 using Microsoft.KernelMemory.DataFormats;
 using Microsoft.KernelMemory.DataFormats.AzureAIDocIntel;
 using Microsoft.KernelMemory.DataFormats.Image;
@@ -73,6 +74,7 @@ public static class Program
         LoggerFactory? loggerFactory = null; // Alternative: app.Services.GetService<ILoggerFactory>();
 
         // Generic dependencies
+        var requestContextProvider = new RequestContextProvider();
         var mimeTypeDetection = new MimeTypesDetection();
         var promptProvider = new EmbeddedPromptProvider();
 
@@ -121,7 +123,7 @@ public static class Program
 
         // Create memory instance
         var searchClient = new SearchClient(memoryDb, textGenerator, searchClientConfig, promptProvider, contentModeration, loggerFactory);
-        var memory = new MemoryServerless(orchestrator, searchClient, kernelMemoryConfig);
+        var memory = new MemoryServerless(orchestrator, searchClient, requestContextProvider, kernelMemoryConfig);
 
         // End-to-end test
         await memory.ImportTextAsync("I'm waiting for Godot", documentId: "tg01");

--- a/examples/212-dotnet-ollama/Program.cs
+++ b/examples/212-dotnet-ollama/Program.cs
@@ -70,8 +70,8 @@ public static class Program
 
         // How to override config with Request Context
         var context = new RequestContext();
-        context.SetArg("custom_ollama_text_model_name", "llama2:70b");
-        // context.SetArg("custom_ollama_embedding_model_name", "...");
+        context.SetArg("custom_text_generation_model_name", "llama2:70b");
+        // context.SetArg("custom_embedding_generation_model_name", "...");
 
         answer = await memory.AskAsync("What's the current date (don't check for validity)?", context: context);
         Console.WriteLine("-------------------");

--- a/examples/212-dotnet-ollama/Program.cs
+++ b/examples/212-dotnet-ollama/Program.cs
@@ -3,6 +3,7 @@
 using Microsoft.KernelMemory;
 using Microsoft.KernelMemory.AI.Ollama;
 using Microsoft.KernelMemory.AI.OpenAI;
+using Microsoft.KernelMemory.Context;
 using Microsoft.KernelMemory.Diagnostics;
 
 /* This example shows how to use KM with Ollama
@@ -49,19 +50,46 @@ public static class Program
 
         // Generate an answer - This uses OpenAI for embeddings and finding relevant data, and LM Studio to generate an answer
         var answer = await memory.AskAsync("What's the current date (don't check for validity)?");
+        Console.WriteLine("-------------------");
         Console.WriteLine(answer.Question);
         Console.WriteLine(answer.Result);
+        Console.WriteLine("-------------------");
 
         /*
 
         -- Output using phi3:medium-128k:
 
         What's the current date (don't check for validity)?
+
         The given fact states that "Today is October 32nd, 2476." However, it appears to be an incorrect statement as
         there are never more than 31 days in any month. If we consider this date without checking its validity and accept
         the stated day of October as being 32, then the current date would be "October 32nd, 2476." However, it is important
         to note that this date does not align with our calendar system.
 
+        */
+
+        // How to override config with Request Context
+        var context = new RequestContext();
+        context.SetArg("custom_ollama_text_model_name", "llama2:70b");
+        // context.SetArg("custom_ollama_embedding_model_name", "...");
+
+        answer = await memory.AskAsync("What's the current date (don't check for validity)?", context: context);
+        Console.WriteLine("-------------------");
+        Console.WriteLine(answer.Question);
+        Console.WriteLine(answer.Result);
+        Console.WriteLine("-------------------");
+
+        /*
+
+        -- Output using llama2:70b:
+
+        What's the current date (don't check for validity)?
+
+        The provided facts state that "Today is October 32nd, 2476." However, considering the Gregorian calendar system
+        commonly used today, this information appears to be incorrect as there are no such dates. This could
+        potentially refer to a different calendar or timekeeping system in use in your fictional world, but based on our
+        current understanding of calendars and dates, an "October 32nd" does not exist. Therefore, the answer is
+        'INFO NOT FOUND'.
         */
     }
 }

--- a/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
+++ b/extensions/AzureOpenAI/AzureOpenAITextEmbeddingGenerator.cs
@@ -17,6 +17,12 @@ using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 
 namespace Microsoft.KernelMemory.AI.AzureOpenAI;
 
+/// <summary>
+/// Azure OpenAI connector
+///
+/// Note: does not support model name override via request context
+///       see https://github.com/microsoft/semantic-kernel/issues/9337
+/// </summary>
 [Experimental("KMEXP01")]
 public sealed class AzureOpenAITextEmbeddingGenerator : ITextEmbeddingGenerator, ITextEmbeddingBatchGenerator
 {

--- a/extensions/AzureOpenAI/AzureOpenAITextGenerator.cs
+++ b/extensions/AzureOpenAI/AzureOpenAITextGenerator.cs
@@ -15,6 +15,12 @@ using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 
 namespace Microsoft.KernelMemory.AI.AzureOpenAI;
 
+/// <summary>
+/// Azure OpenAI connector
+///
+/// Note: does not support model name override via request context
+///       see https://github.com/microsoft/semantic-kernel/issues/9337
+/// </summary>
 [Experimental("KMEXP01")]
 public sealed class AzureOpenAITextGenerator : ITextGenerator
 {

--- a/extensions/ONNX/Onnx/OnnxTextGenerator.cs
+++ b/extensions/ONNX/Onnx/OnnxTextGenerator.cs
@@ -19,6 +19,8 @@ namespace Microsoft.KernelMemory.AI.Onnx;
 /// <summary>
 /// Text generator based on ONNX models, via OnnxRuntimeGenAi
 /// See https://github.com/microsoft/onnxruntime-genai
+///
+/// Note: does not support model name override via request context
 /// </summary>
 [Experimental("KMEXP01")]
 public sealed class OnnxTextGenerator : ITextGenerator, IDisposable

--- a/extensions/Ollama/Ollama/DependencyInjection.cs
+++ b/extensions/Ollama/Ollama/DependencyInjection.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.AI;
 using Microsoft.KernelMemory.AI.Ollama;
+using Microsoft.KernelMemory.Context;
 using OllamaSharp;
 
 #pragma warning disable IDE0130 // reduce number of "using" statements
@@ -72,6 +73,7 @@ public static partial class DependencyInjection
                     new OllamaApiClient(new Uri(endpoint), modelName),
                     new OllamaModelConfig { ModelName = modelName },
                     textTokenizer,
+                    serviceProvider.GetService<IContextProvider>(),
                     serviceProvider.GetService<ILoggerFactory>()));
     }
 
@@ -86,6 +88,7 @@ public static partial class DependencyInjection
                     new OllamaApiClient(new Uri(config.Endpoint), config.TextModel.ModelName),
                     config.TextModel,
                     textTokenizer,
+                    serviceProvider.GetService<IContextProvider>(),
                     serviceProvider.GetService<ILoggerFactory>()));
     }
 
@@ -101,6 +104,7 @@ public static partial class DependencyInjection
                     new OllamaApiClient(new Uri(endpoint), modelName),
                     new OllamaModelConfig { ModelName = modelName },
                     textTokenizer,
+                    serviceProvider.GetService<IContextProvider>(),
                     serviceProvider.GetService<ILoggerFactory>()));
     }
 
@@ -115,6 +119,7 @@ public static partial class DependencyInjection
                     new OllamaApiClient(new Uri(config.Endpoint), config.EmbeddingModel.ModelName),
                     config.EmbeddingModel,
                     textTokenizer,
+                    serviceProvider.GetService<IContextProvider>(),
                     serviceProvider.GetService<ILoggerFactory>()));
     }
 }

--- a/extensions/Ollama/Ollama/OllamaTextEmbeddingGenerator.cs
+++ b/extensions/Ollama/Ollama/OllamaTextEmbeddingGenerator.cs
@@ -113,7 +113,7 @@ public class OllamaTextEmbeddingGenerator : ITextEmbeddingGenerator, ITextEmbedd
     {
         var list = textList.ToList();
 
-        string modelName = this._contextProvider.GetContext().GetCustomOllamaEmbeddingModelNameOrDefault(this._client.SelectedModel);
+        string modelName = this._contextProvider.GetContext().GetCustomEmbeddingGenerationModelNameOrDefault(this._client.SelectedModel);
         this._log.LogTrace("Generating embeddings batch, size {0} texts, with model {1}", list.Count, modelName);
 
         var request = new EmbedRequest

--- a/extensions/Ollama/Ollama/OllamaTextGenerator.cs
+++ b/extensions/Ollama/Ollama/OllamaTextGenerator.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.AI.OpenAI;
+using Microsoft.KernelMemory.Context;
 using Microsoft.KernelMemory.Diagnostics;
 using OllamaSharp;
 using OllamaSharp.Models;
@@ -19,8 +20,9 @@ public class OllamaTextGenerator : ITextGenerator
 
     private readonly IOllamaApiClient _client;
     private readonly OllamaModelConfig _modelConfig;
-    private readonly ILogger<OllamaTextGenerator> _log;
     private readonly ITextTokenizer _textTokenizer;
+    private readonly IContextProvider _contextProvider;
+    private readonly ILogger<OllamaTextGenerator> _log;
 
     public int MaxTokenTotal { get; }
 
@@ -28,6 +30,7 @@ public class OllamaTextGenerator : ITextGenerator
         IOllamaApiClient ollamaClient,
         OllamaModelConfig modelConfig,
         ITextTokenizer? textTokenizer = null,
+        IContextProvider? contextProvider = null,
         ILoggerFactory? loggerFactory = null)
     {
         this._client = ollamaClient;
@@ -43,6 +46,7 @@ public class OllamaTextGenerator : ITextGenerator
         }
 
         this._textTokenizer = textTokenizer;
+        this._contextProvider = contextProvider ?? new RequestContextProvider();
 
         this.MaxTokenTotal = modelConfig.MaxTokenTotal ?? MaxTokensIfUndefined;
     }
@@ -50,11 +54,13 @@ public class OllamaTextGenerator : ITextGenerator
     public OllamaTextGenerator(
         OllamaConfig config,
         ITextTokenizer? textTokenizer = null,
+        IContextProvider? contextProvider = null,
         ILoggerFactory? loggerFactory = null)
         : this(
             new OllamaApiClient(new Uri(config.Endpoint), config.TextModel.ModelName),
             config.TextModel,
             textTokenizer,
+            contextProvider,
             loggerFactory)
     {
     }
@@ -63,11 +69,13 @@ public class OllamaTextGenerator : ITextGenerator
         HttpClient httpClient,
         OllamaConfig config,
         ITextTokenizer? textTokenizer = null,
+        IContextProvider? contextProvider = null,
         ILoggerFactory? loggerFactory = null)
         : this(
             new OllamaApiClient(httpClient, config.TextModel.ModelName),
             config.TextModel,
             textTokenizer,
+            contextProvider,
             loggerFactory)
     {
     }
@@ -87,9 +95,12 @@ public class OllamaTextGenerator : ITextGenerator
         TextGenerationOptions options,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        string modelName = this._contextProvider.GetContext().GetCustomOllamaTextModelNameOrDefault(this._client.SelectedModel);
+        this._log.LogTrace("Generating text with model {0}", modelName);
+
         var request = new GenerateRequest
         {
-            Model = this._client.SelectedModel,
+            Model = modelName,
             Prompt = prompt,
             Stream = true,
             Options = new RequestOptions

--- a/extensions/Ollama/Ollama/OllamaTextGenerator.cs
+++ b/extensions/Ollama/Ollama/OllamaTextGenerator.cs
@@ -95,7 +95,7 @@ public class OllamaTextGenerator : ITextGenerator
         TextGenerationOptions options,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        string modelName = this._contextProvider.GetContext().GetCustomOllamaTextModelNameOrDefault(this._client.SelectedModel);
+        string modelName = this._contextProvider.GetContext().GetCustomTextGenerationModelNameOrDefault(this._client.SelectedModel);
         this._log.LogTrace("Generating text with model {0}", modelName);
 
         var request = new GenerateRequest

--- a/extensions/OpenAI/OpenAI/OpenAITextEmbeddingGenerator.cs
+++ b/extensions/OpenAI/OpenAI/OpenAITextEmbeddingGenerator.cs
@@ -18,6 +18,9 @@ namespace Microsoft.KernelMemory.AI.OpenAI;
 /// <summary>
 /// Text embedding generator. The class can be used with any service
 /// supporting OpenAI HTTP schema.
+///
+/// Note: does not support model name override via request context
+///       see https://github.com/microsoft/semantic-kernel/issues/9337
 /// </summary>
 [Experimental("KMEXP01")]
 public sealed class OpenAITextEmbeddingGenerator : ITextEmbeddingGenerator, ITextEmbeddingBatchGenerator

--- a/extensions/OpenAI/OpenAI/OpenAITextGenerator.cs
+++ b/extensions/OpenAI/OpenAI/OpenAITextGenerator.cs
@@ -17,6 +17,9 @@ namespace Microsoft.KernelMemory.AI.OpenAI;
 /// <summary>
 /// Text generator, supporting OpenAI text and chat completion. The class can be used with any service
 /// supporting OpenAI HTTP schema, such as LM Studio HTTP API.
+///
+/// Note: does not support model name override via request context
+///       see https://github.com/microsoft/semantic-kernel/issues/9337
 /// </summary>
 [Experimental("KMEXP01")]
 public sealed class OpenAITextGenerator : ITextGenerator

--- a/service/Abstractions/Constants.cs
+++ b/service/Abstractions/Constants.cs
@@ -45,12 +45,16 @@ public static class Constants
             public const string BatchSize = "custom_embedding_generation_batch_size_int";
 
             // Used to override the name of the model used to generate embeddings
+            // Supported only by Ollama and Anthropic connectors
+            // See https://github.com/microsoft/semantic-kernel/issues/9337
             public const string ModelName = "custom_embedding_generation_model_name";
         }
 
         public static class TextGeneration
         {
             // Used to override the name of the model used to generate text
+            // Supported only by Ollama and Anthropic connectors
+            // See https://github.com/microsoft/semantic-kernel/issues/9337
             public const string ModelName = "custom_text_generation_model_name";
         }
 

--- a/service/Abstractions/Constants.cs
+++ b/service/Abstractions/Constants.cs
@@ -78,6 +78,15 @@ public static class Constants
             // Used to override the number of overlapping tokens
             public const string OverlappingTokens = "custom_summary_overlapping_tokens_int";
         }
+
+        public static class Ollama
+        {
+            // Used to override the name of the model used to generate text
+            public const string TextModelName = "custom_ollama_text_model_name";
+
+            // Used to override the name of the model used to generate embeddings
+            public const string EmbeddingModelName = "custom_ollama_embedding_model_name";
+        }
     }
 
     // // Default User ID owning documents uploaded without specifying a user

--- a/service/Abstractions/Constants.cs
+++ b/service/Abstractions/Constants.cs
@@ -43,6 +43,15 @@ public static class Constants
         {
             // Used to override MaxBatchSize embedding generators config
             public const string BatchSize = "custom_embedding_generation_batch_size_int";
+
+            // Used to override the name of the model used to generate embeddings
+            public const string ModelName = "custom_embedding_generation_model_name";
+        }
+
+        public static class TextGeneration
+        {
+            // Used to override the name of the model used to generate text
+            public const string ModelName = "custom_text_generation_model_name";
         }
 
         public static class Rag
@@ -77,15 +86,6 @@ public static class Constants
 
             // Used to override the number of overlapping tokens
             public const string OverlappingTokens = "custom_summary_overlapping_tokens_int";
-        }
-
-        public static class Ollama
-        {
-            // Used to override the name of the model used to generate text
-            public const string TextModelName = "custom_ollama_text_model_name";
-
-            // Used to override the name of the model used to generate embeddings
-            public const string EmbeddingModelName = "custom_ollama_embedding_model_name";
         }
     }
 

--- a/service/Abstractions/Context/IContext.cs
+++ b/service/Abstractions/Context/IContext.cs
@@ -220,9 +220,9 @@ public static class CustomContextExtensions
         return defaultValue;
     }
 
-    public static string GetCustomOllamaTextModelNameOrDefault(this IContext? context, string defaultValue)
+    public static string GetCustomTextGenerationModelNameOrDefault(this IContext? context, string defaultValue)
     {
-        if (context.TryGetArg<string>(Constants.CustomContext.Ollama.TextModelName, out var customValue))
+        if (context.TryGetArg<string>(Constants.CustomContext.TextGeneration.ModelName, out var customValue))
         {
             return customValue;
         }
@@ -230,9 +230,9 @@ public static class CustomContextExtensions
         return defaultValue;
     }
 
-    public static string GetCustomOllamaEmbeddingModelNameOrDefault(this IContext? context, string defaultValue)
+    public static string GetCustomEmbeddingGenerationModelNameOrDefault(this IContext? context, string defaultValue)
     {
-        if (context.TryGetArg<string>(Constants.CustomContext.Ollama.EmbeddingModelName, out var customValue))
+        if (context.TryGetArg<string>(Constants.CustomContext.EmbeddingGeneration.ModelName, out var customValue))
         {
             return customValue;
         }

--- a/service/Abstractions/Context/IContext.cs
+++ b/service/Abstractions/Context/IContext.cs
@@ -219,4 +219,24 @@ public static class CustomContextExtensions
 
         return defaultValue;
     }
+
+    public static string GetCustomOllamaTextModelNameOrDefault(this IContext? context, string defaultValue)
+    {
+        if (context.TryGetArg<string>(Constants.CustomContext.Ollama.TextModelName, out var customValue))
+        {
+            return customValue;
+        }
+
+        return defaultValue;
+    }
+
+    public static string GetCustomOllamaEmbeddingModelNameOrDefault(this IContext? context, string defaultValue)
+    {
+        if (context.TryGetArg<string>(Constants.CustomContext.Ollama.EmbeddingModelName, out var customValue))
+        {
+            return customValue;
+        }
+
+        return defaultValue;
+    }
 }

--- a/service/Abstractions/Context/IContext.cs
+++ b/service/Abstractions/Context/IContext.cs
@@ -220,6 +220,15 @@ public static class CustomContextExtensions
         return defaultValue;
     }
 
+    /// <summary>
+    /// Extensions supported:
+    /// - Ollama
+    /// - Anthropic
+    /// Extensions not supported:
+    /// - Azure OpenAI
+    /// - ONNX
+    /// - OpenAI
+    /// </summary>
     public static string GetCustomTextGenerationModelNameOrDefault(this IContext? context, string defaultValue)
     {
         if (context.TryGetArg<string>(Constants.CustomContext.TextGeneration.ModelName, out var customValue))
@@ -230,6 +239,15 @@ public static class CustomContextExtensions
         return defaultValue;
     }
 
+    /// <summary>
+    /// Extensions supported:
+    /// - Ollama
+    /// - Anthropic
+    /// Extensions not supported:
+    /// - Azure OpenAI
+    /// - ONNX
+    /// - OpenAI
+    /// </summary>
     public static string GetCustomEmbeddingGenerationModelNameOrDefault(this IContext? context, string defaultValue)
     {
         if (context.TryGetArg<string>(Constants.CustomContext.EmbeddingGeneration.ModelName, out var customValue))

--- a/service/Abstractions/Context/IContextProvider.cs
+++ b/service/Abstractions/Context/IContextProvider.cs
@@ -23,6 +23,14 @@ public static class ContextProviderExtensions
         return provider;
     }
 
+    public static IContextProvider? InitContext(this IContextProvider? provider, IContext? context)
+    {
+        if (provider == null) { return null; }
+
+        provider.GetContext().InitArgs(context?.Arguments ?? new Dictionary<string, object?>());
+        return provider;
+    }
+
     public static IContextProvider? SetContextArgs(this IContextProvider? provider, IDictionary<string, object?> args)
     {
         if (provider == null) { return null; }


### PR DESCRIPTION
Allow to override the model name during a request, using request context arguments.

The feature is available only for Anthropic and Ollama. Updated example 212 showing how to override Ollama settings at runtime.

The feature is not supported when using OpenAI/Azure OpenAI, because the underlying connectors hard code the model name in client instances and would require a considerable amount of refactoring, plus memory overhead, to support this feature. See https://github.com/microsoft/semantic-kernel/issues/9337