### PR TITLE
Add ability to control MaxMatchesCount for Ask via IContext

### DIFF
--- a/service/Abstractions/Constants.cs
+++ b/service/Abstractions/Constants.cs
@@ -73,6 +73,9 @@ public static class Constants
             // Used to override the max tokens to generate when using the RAG prompt
             public const string MaxTokens = "custom_rag_max_tokens_int";
 
+            // Used to override the max matches count used with the RAG prompt
+            public const string MaxMatchesCount = "custom_rag_max_matches_count_int";
+
             // Used to override the temperature (default 0) used with the RAG prompt
             public const string Temperature = "custom_rag_temperature_float";
 

--- a/service/Abstractions/Context/IContext.cs
+++ b/service/Abstractions/Context/IContext.cs
@@ -130,6 +130,16 @@ public static class CustomContextExtensions
         return defaultValue;
     }
 
+    public static int GetCustomRagMaxMatchesCountOrDefault(this IContext? context, int defaultValue)
+    {
+        if (context.TryGetArg<int>(Constants.CustomContext.Rag.MaxMatchesCount, out var customValue))
+        {
+            return customValue;
+        }
+
+        return defaultValue;
+    }
+
     public static double GetCustomRagTemperatureOrDefault(this IContext? context, double defaultValue)
     {
         if (context.TryGetArg<double>(Constants.CustomContext.Rag.Temperature, out var customValue))

--- a/service/Core/Search/SearchClient.cs
+++ b/service/Core/Search/SearchClient.cs
@@ -199,6 +199,8 @@ public sealed class SearchClient : ISearchClient
         string emptyAnswer = context.GetCustomEmptyAnswerTextOrDefault(this._config.EmptyAnswer);
         string answerPrompt = context.GetCustomRagPromptOrDefault(this._answerPrompt);
         string factTemplate = context.GetCustomRagFactTemplateOrDefault(this._config.FactTemplate);
+        int limit = context.GetCustomRagMaxMatchesCountOrDefault(this._config.MaxMatchesCount);
+
         if (!factTemplate.EndsWith('\n')) { factTemplate += "\n"; }
 
         var noAnswerFound = new MemoryAnswer
@@ -234,7 +236,7 @@ public sealed class SearchClient : ISearchClient
             text: question,
             filters: filters,
             minRelevance: minRelevance,
-            limit: this._config.MaxMatchesCount,
+            limit: limit,
             withEmbeddings: false,
             cancellationToken: cancellationToken);
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
Need the ability to control the MaxMatchesCount per Ask request instead of always defaulting to the configuration value.


## High level description (Approach, Design)
Add  MaxMatchesCount constant and extensions.


