### PR TITLE
Support configuring the MaxRequestBodySize for the upload endpoint

### DIFF
--- a/service/Core/Configuration/ServiceConfig.cs
+++ b/service/Core/Configuration/ServiceConfig.cs
@@ -13,6 +13,12 @@ public class ServiceConfig
     public bool RunWebService { get; set; } = true;
 
     /// <summary>
+    /// The maximum allowed size in bytes for a request body posted to the upload endpoint.
+    /// If not set, the default ASP.NET Core limit of 30 MB (~28.6 MiB) is applied.
+    /// </summary>
+    public long? MaxUploadRequestBodySize { get; set; } = null;
+
+    /// <summary>
     /// Whether to run the asynchronous pipeline handlers
     /// Use these booleans to deploy the web service and the handlers on same/different VMs
     /// </summary>

--- a/service/Core/Configuration/ServiceConfig.cs
+++ b/service/Core/Configuration/ServiceConfig.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.KernelMemory.Configuration;
@@ -11,12 +12,6 @@ public class ServiceConfig
     /// Use these booleans to deploy the web service and the handlers on same/different VMs
     /// </summary>
     public bool RunWebService { get; set; } = true;
-
-    /// <summary>
-    /// The maximum allowed size in bytes for a request body posted to the upload endpoint.
-    /// If not set, the default ASP.NET Core limit of 30 MB (~28.6 MiB) is applied.
-    /// </summary>
-    public long? MaxUploadRequestBodySize { get; set; } = null;
 
     /// <summary>
     /// Whether to run the asynchronous pipeline handlers
@@ -33,4 +28,20 @@ public class ServiceConfig
     /// List of handlers to enable
     /// </summary>
     public Dictionary<string, HandlerConfig> Handlers { get; set; } = new();
+
+    /// <summary>
+    /// The maximum allowed size in megabytes for a request body posted to the upload endpoint.
+    /// If not set the solution defaults to 30,000,000 bytes (~28.6 MB) (ASP.NET default).
+    /// </summary>
+    public long? MaxUploadSizeMb { get; set; } = null;
+
+    public long? GetMaxUploadSizeInBytes()
+    {
+        if (this.MaxUploadSizeMb.HasValue)
+        {
+            return Math.Min(10, this.MaxUploadSizeMb.Value) * 1024 * 1024;
+        }
+
+        return null;
+    }
 }

--- a/service/Service.AspNetCore/WebApplicationBuilderExtensions.cs
+++ b/service/Service.AspNetCore/WebApplicationBuilderExtensions.cs
@@ -19,20 +19,25 @@ public static partial class WebApplicationBuilderExtensions
     /// <param name="appBuilder">Hosting application builder</param>
     /// <param name="configureMemoryBuilder">Optional configuration steps for the memory builder</param>
     /// <param name="configureMemory">Optional configuration steps for the memory instance</param>
+    /// <param name="configureServices">Optional configuration for the internal dependencies</param>
     public static WebApplicationBuilder AddKernelMemory(
         this WebApplicationBuilder appBuilder,
         Action<IKernelMemoryBuilder>? configureMemoryBuilder = null,
-        Action<IKernelMemory>? configureMemory = null)
+        Action<IKernelMemory>? configureMemory = null,
+        Action<IServiceCollection>? configureServices = null)
     {
         // Prepare memory builder, sharing the service collection used by the hosting service
         var memoryBuilder = new KernelMemoryBuilder(appBuilder.Services);
+
+        // Optional services configuration provided by the user
+        configureServices?.Invoke(appBuilder.Services);
 
         // Optional configuration provided by the user
         configureMemoryBuilder?.Invoke(memoryBuilder);
 
         var memory = memoryBuilder.Build();
 
-        // Optional configuration provided by the user
+        // Optional memory configuration provided by the user
         configureMemory?.Invoke(memory);
 
         appBuilder.Services.AddSingleton<IKernelMemory>(memory);

--- a/service/Service/Program.cs
+++ b/service/Service/Program.cs
@@ -138,7 +138,7 @@ internal static class Program
                 .Produces<ProblemDetails>(StatusCodes.Status403Forbidden);
 
             // Add HTTP endpoints using minimal API (https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis)
-            app.AddKernelMemoryEndpoints("/", authFilter);
+            app.AddKernelMemoryEndpoints(config.Service, "/", authFilter);
 
             // Health probe
             app.MapGet("/health", () => Results.Ok("Service is running."))

--- a/service/Service/Program.cs
+++ b/service/Service/Program.cs
@@ -5,7 +5,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -97,6 +99,19 @@ internal static class Program
                 syncHandlersCount = AddHandlersToServerlessMemory(config, memory);
 
                 memoryType = ((memory is MemoryServerless) ? "Sync - " : "Async - ") + memory.GetType().FullName;
+            },
+            services =>
+            {
+                long? maxSize = config.Service.GetMaxUploadSizeInBytes();
+                if (!maxSize.HasValue) { return; }
+
+                services.Configure<IISServerOptions>(x => { x.MaxRequestBodySize = maxSize.Value; });
+                services.Configure<KestrelServerOptions>(x => { x.Limits.MaxRequestBodySize = maxSize.Value; });
+                services.Configure<FormOptions>(x =>
+                {
+                    x.MultipartBodyLengthLimit = maxSize.Value;
+                    x.ValueLengthLimit = int.MaxValue;
+                });
             });
 
         // CORS
@@ -138,7 +153,7 @@ internal static class Program
                 .Produces<ProblemDetails>(StatusCodes.Status403Forbidden);
 
             // Add HTTP endpoints using minimal API (https://learn.microsoft.com/aspnet/core/fundamentals/minimal-apis)
-            app.AddKernelMemoryEndpoints(config.Service, "/", authFilter);
+            app.AddKernelMemoryEndpoints("/", config, authFilter);
 
             // Health probe
             app.MapGet("/health", () => Results.Ok("Service is running."))

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -42,6 +42,9 @@
       // Whether to run the web service that allows to upload files and search memory
       // Use these booleans to deploy the web service and the handlers on same/different VMs
       "RunWebService": true,
+      // The maximum allowed size in bytes for a request body posted to the upload endpoint
+      // If not set, the default ASP.NET Core limit of 30 MB (~28.6 MiB) is applied
+      "MaxUploadRequestBodySize": null,
       // Whether to expose OpenAPI swagger UI at http://127.0.0.1:9001/swagger/index.html
       "OpenApiEnabled": false,
       // Whether to run the asynchronous pipeline handlers

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -42,11 +42,11 @@
       // Whether to run the web service that allows to upload files and search memory
       // Use these booleans to deploy the web service and the handlers on same/different VMs
       "RunWebService": true,
-      // The maximum allowed size in bytes for a request body posted to the upload endpoint
-      // If not set, the default ASP.NET Core limit of 30 MB (~28.6 MiB) is applied
-      "MaxUploadRequestBodySize": null,
       // Whether to expose OpenAPI swagger UI at http://127.0.0.1:9001/swagger/index.html
       "OpenApiEnabled": false,
+      // The maximum allowed size in MB for the payload posted to the upload endpoint
+      // If not set the solution defaults to 30,000,000 bytes (~28.6 MB)
+      "MaxUploadSizeMb": null,
       // Whether to run the asynchronous pipeline handlers
       // Use these booleans to deploy the web service and the handlers on same/different VMs
       "RunHandlers": true,


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

We have some important documents that need to be imported to Kermel Memory that are larger than the current ASP.NET Core default maximum request body size limit of 30 MB (~28.6 MiB).

https://github.com/aspnet/Announcements/issues/267

It is not currently possible to set the `MaxRequestBodySize` from configuration making it impossible to override this limit when running Kernel Memory from the Docker container image.

https://github.com/dotnet/aspnetcore/issues/4765

## High level description (Approach, Design)

This PR adds a new `MaxUploadRequestBodySize` property to the `ServiceConfig` class that defaults to `null`. 

- When the setting is `null` the default ASP.NET Core `MaxRequestBodySize` continues to be applied as is currently the case
- When a value is provided it will be configured on the upload endpoint using the `IHttpMaxRequestBodySizeFeature` feature

This allows for an explicit limit to be configured that may be less than or greater than the default ASP.NET Core limit.