### PR TITLE
Refactor DataPipelineStatus and DataPipeline classes

### DIFF
--- a/service/Abstractions/Models/DataPipelineStatus.cs
+++ b/service/Abstractions/Models/DataPipelineStatus.cs
@@ -15,7 +15,7 @@ public class DataPipelineStatus
     /// <summary>
     /// Currently used to track deleted documents.
     /// </summary>
-    [JsonPropertyOrder(1)]
+    [JsonPropertyOrder(2)]
     [JsonPropertyName("empty")]
     public bool Empty { get; set; } = false;
 

--- a/service/Abstractions/Models/DataPipelineStatus.cs
+++ b/service/Abstractions/Models/DataPipelineStatus.cs
@@ -12,15 +12,10 @@ public class DataPipelineStatus
     [JsonPropertyName("completed")]
     public bool Completed { get; set; } = false;
 
-    [JsonPropertyOrder(1)]
-    [JsonPropertyName("failed")]
-    public bool Failed { get; set; } = false;
-
     /// <summary>
     /// Currently used to track deleted documents.
-    /// TODO: replace with "isDeleting" and "Deleted"
     /// </summary>
-    [JsonPropertyOrder(2)]
+    [JsonPropertyOrder(1)]
     [JsonPropertyName("empty")]
     public bool Empty { get; set; } = false;
 

--- a/service/Abstractions/Pipeline/DataPipeline.cs
+++ b/service/Abstractions/Pipeline/DataPipeline.cs
@@ -154,11 +154,7 @@ public sealed class DataPipeline
         /// <param name="text">Text to store for the end user</param>
         public void Log(IPipelineStepHandler handler, string text)
         {
-            if (this.LogEntries == null)
-            {
-                this.LogEntries = new List<PipelineLogEntry>();
-            }
-
+            this.LogEntries ??= [];
             this.LogEntries.Add(new PipelineLogEntry(source: handler.StepName, text: text));
         }
     }
@@ -438,7 +434,6 @@ public sealed class DataPipeline
         return new DataPipelineStatus
         {
             Completed = this.Complete,
-            Failed = false, // TODO
             Empty = this.Files.Count == 0,
             Index = this.Index,
             DocumentId = this.DocumentId,


### PR DESCRIPTION
Removed the `Failed` property from `DataPipelineStatus` and reordered the `Empty` property with `JsonPropertyOrder` of 1. Updated `DataPipeline` class: refactored `Log` method to use null-coalescing assignment and adjusted `ToDataPipelineStatus` method to reflect the removal of the `Failed` property.

<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
See https://github.com/microsoft/kernel-memory/discussions/709

