### PR TITLE
Update AzureOpenAIConfig validation to cater for reverse proxy endpoint

### DIFF
--- a/extensions/AzureOpenAI/AzureOpenAIConfig.cs
+++ b/extensions/AzureOpenAI/AzureOpenAIConfig.cs
@@ -122,9 +122,21 @@ public class AzureOpenAIConfig
             throw new ConfigurationException($"Azure OpenAI: {nameof(this.Endpoint)} is empty");
         }
 
-        if (!this.Endpoint.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        if (!Uri.TryCreate(this.Endpoint, UriKind.Absolute, out var endpoint))
         {
-            throw new ConfigurationException($"Azure OpenAI: {nameof(this.Endpoint)} must start with https://");
+            throw new ConfigurationException($"Azure OpenAI: {nameof(this.Endpoint)} must be a valid absolute URI");
+        }
+
+        if (endpoint.Host.EndsWith(".openai.azure.com", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(endpoint.Scheme, "https", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ConfigurationException($"Azure OpenAI: {nameof(this.Endpoint)} must start with https:// when the host is a subdomain of openai.azure.com");
+        }
+
+        if (!string.Equals(endpoint.Scheme, "http", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(endpoint.Scheme, "https", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ConfigurationException($"Azure OpenAI: {nameof(this.Endpoint)} must start with http:// or https://");
         }
 
         if (string.IsNullOrWhiteSpace(this.Deployment))


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

We are calling Azure OpenAI through a reverse proxy that routes requests to different service instances based on available quota. The reverse proxy sits alongside KM behind a load balancer with TLS termination. The validation on the `AzureOpenAIconfig` class enforces the use of HTTPS for the `Endpoint` property which does not allow the use of HTTP for this east-west traffic scenario.

## High level description (Approach, Design)

Update the validation in the `AzureOpenAIConfig` class:

- First ensure the `Endpoint` value is a valid `Uri` and throw a `ConfigurationException` when invalid
- If the host domain ends with `.openai.azure.com` and requests are going directly to the Azure OpenAI endpoints ensure that the scheme is `https`
- If the host domain is not the public Azure OpenAI endpoints ensure that the schema is either `http` or `https`