### PR TITLE
Bugfix SQLServerMemory semaphore not released properly

### DIFF
--- a/extensions/SQLServer/SQLServer/SqlServerMemory.cs
+++ b/extensions/SQLServer/SQLServer/SqlServerMemory.cs
@@ -397,10 +397,11 @@ public sealed class SqlServerMemory : IMemoryDb, IMemoryDbUpsertBatch, IDisposab
         if (this._isReady) { return; }
 
         await this._initSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-        if (this._isReady) { return; }
 
         try
         {
+            if (this._isReady) { return; }
+
             await this.CacheSqlServerMajorVersionNumberAsync(cancellationToken).ConfigureAwait(false);
             await this.CreateTablesIfNotExistsAsync(cancellationToken).ConfigureAwait(false);
             this._isReady = true;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

A simple bugfix for SQLServerMemory. The semaphore wasn't released when "is ready" changes from "false" to "true" while the code was waiting for the semaphore. Meaning if specifically 3 or more tasks run into that code at the same time, the third task as well as all others are gonna be stuck in a deadlock waiting for the semaphore. This only happens during the first initialization, since subsequent calls will leave before waiting for the semaphore.
