### PR TITLE
Reduce Docker build context by fixing errors in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,8 +6,13 @@
 .vscode
 docker-compose.yml
 docker-compose.*.yml
-*/bin
-*/obj
+**/bin
+**/obj
+
+# Exclude folders not required for compile
+docs
+examples
+infra
 
 # To make sure that the local appsettings files are not copied when building the image locally.
 # These files are not in GitHub thanks to .gitignore


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

When building the container image locally after building the Visual Studio solution, a total of 3.62 GB of data is transferred in the Docker build context, slowing down the container build duration.

## High level description (Approach, Design)

Fix a mistake in the `.dockerignore` file that results in the `bin` and `obj` folders being included in the build context.

Ignore the `docs`, `examples`, and `infra` folders as these are not required to build the service project.

Results in the build context being reduced to 7.6 MB.
