### PR TITLE
Optimize empty check for BinaryData

### DIFF
--- a/service/Core/Handlers/TextPartitioningHandler.cs
+++ b/service/Core/Handlers/TextPartitioningHandler.cs
@@ -120,7 +120,7 @@ public sealed class TextPartitioningHandler : IPipelineStepHandler
                 string partitionsMimeType = MimeTypes.PlainText;
 
                 // Skip empty partitions. Also: partitionContent.ToString() throws an exception if there are no bytes.
-                if (partitionContent.ToArray().Length == 0) { continue; }
+                if (partitionContent.IsEmpty) { continue; }
 
                 switch (file.MimeType)
                 {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
See https://github.com/microsoft/kernel-memory/discussions/886#discussioncomment-11229562

## High level description (Approach, Design)
Updated the condition to check if `partitionContent` is empty by using the `IsEmpty` property instead of converting it to a byte array and checking its length. This change improves efficiency and readability.
