### PR TITLE
KM web service: fix max upload size logic

### DIFF
--- a/service/Core/Configuration/ServiceConfig.cs
+++ b/service/Core/Configuration/ServiceConfig.cs
@@ -30,16 +30,20 @@ public class ServiceConfig
     public Dictionary<string, HandlerConfig> Handlers { get; set; } = new();
 
     /// <summary>
-    /// The maximum allowed size in megabytes for a request body posted to the upload endpoint.
+    /// The maximum allowed size in megabytes for an HTTP request body posted to the upload endpoint.
     /// If not set the solution defaults to 30,000,000 bytes (~28.6 MB) (ASP.NET default).
+    /// Note: this applies only to KM HTTP service.
     /// </summary>
     public long? MaxUploadSizeMb { get; set; } = null;
+}
 
-    public long? GetMaxUploadSizeInBytes()
+public static partial class ServiceConfigExtensions
+{
+    public static long? GetMaxUploadSizeInBytes(this ServiceConfig config)
     {
-        if (this.MaxUploadSizeMb.HasValue)
+        if (config.MaxUploadSizeMb.HasValue)
         {
-            return Math.Min(10, this.MaxUploadSizeMb.Value) * 1024 * 1024;
+            return Math.Max(1, config.MaxUploadSizeMb.Value) * 1024 * 1024;
         }
 
         return null;

--- a/service/Service.AspNetCore/WebAPIEndpoints.cs
+++ b/service/Service.AspNetCore/WebAPIEndpoints.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
+using Microsoft.KernelMemory.Configuration;
 using Microsoft.KernelMemory.Context;
 using Microsoft.KernelMemory.DocumentStorage;
 using Microsoft.KernelMemory.Service.AspNetCore.Models;

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -44,8 +44,9 @@
       "RunWebService": true,
       // Whether to expose OpenAPI swagger UI at http://127.0.0.1:9001/swagger/index.html
       "OpenApiEnabled": false,
-      // The maximum allowed size in MB for the payload posted to the upload endpoint
+      // The maximum allowed size in MB for the HTTP payload sent to the upload endpoint
       // If not set the solution defaults to 30,000,000 bytes (~28.6 MB)
+      // Note: this applies only to KM HTTP service.
       "MaxUploadSizeMb": null,
       // Whether to run the asynchronous pipeline handlers
       // Use these booleans to deploy the web service and the handlers on same/different VMs


### PR DESCRIPTION
Fix typo in max HTTP upload size logic used by the web service.
Change range, allowing to set the max HTTP upload size to 1Mb.

