### PR TITLE
Support Azure OpenAI on Sovereign clouds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
     <PropertyGroup>
         <!-- Central version prefix - applies to all nuget packages. -->
-        <Version>0.94.0</Version>
+        <Version>0.95.0</Version>
 
         <!-- C# lang version, https://learn.microsoft.com/dotnet/csharp/whats-new -->
         <LangVersion>12</LangVersion>

--- a/applications/tests/Evaluation.Tests/appsettings.json
+++ b/applications/tests/Evaluation.Tests/appsettings.json
@@ -14,27 +14,14 @@
   },
   "KernelMemory": {
     "Services": {
-      "AzureOpenAIText": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 16384,
-        // "ChatCompletion" or "TextCompletion"
-        "APIType": "ChatCompletion",
-        // How many times to retry in case of throttling.
-        "MaxRetries": 10
-      },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -52,10 +39,31 @@
         // How many times to retry in case of throttling.
         "MaxRetries": 10
       },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
+        // How many times to retry in case of throttling.
+        "MaxRetries": 10
+      },
       "AzureAIDocIntel": {
         // "APIKey" or "AzureIdentity".
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Required when Auth == APIKey
         "APIKey": "",
@@ -63,8 +71,10 @@
       },
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": "",

--- a/examples/001-dotnet-WebClient/file9-settings.json
+++ b/examples/001-dotnet-WebClient/file9-settings.json
@@ -14,11 +14,29 @@
   },
   "KernelMemory": {
     "Services": {
+      "AzureOpenAIEmbedding": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 8191
+      },
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -28,18 +46,6 @@
         // "ChatCompletion" or "TextCompletion"
         "APIType": "ChatCompletion",
         "MaxRetries": 10
-      },
-      "AzureOpenAIEmbedding": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 8191
       },
       "OpenAI": {
         // Name of the model used to generate text (text completion or chat completion)
@@ -84,8 +90,10 @@
       },
       "AzureAIDocIntel": {
         // "APIKey" or "AzureIdentity".
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Required when Auth == APIKey
         "APIKey": "",
@@ -93,8 +101,10 @@
       },
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": ""

--- a/examples/002-dotnet-Serverless/appsettings.json
+++ b/examples/002-dotnet-Serverless/appsettings.json
@@ -3,8 +3,10 @@
     "Services": {
       "AzureAIContentSafety": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAIContentSafetyConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": "",
@@ -13,8 +15,10 @@
       },
       "AzureAIDocIntel": {
         // "APIKey" or "AzureIdentity".
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Required when Auth == APIKey
         "APIKey": "",
@@ -22,8 +26,10 @@
       },
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": "",
@@ -44,8 +50,10 @@
       },
       "AzureBlobs": {
         // "ConnectionString" or "AzureIdentity". For other options see <AzureBlobConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Azure Storage account name, required when using AzureIdentity auth
         // Note: you can use an env var 'KernelMemory__Services__AzureBlobs__Account' to set this
@@ -60,9 +68,12 @@
       },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         // Your Azure Deployment name
@@ -92,9 +103,12 @@
       },
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",

--- a/examples/002-dotnet-Serverless/file9-settings.json
+++ b/examples/002-dotnet-Serverless/file9-settings.json
@@ -14,11 +14,29 @@
   },
   "KernelMemory": {
     "Services": {
+      "AzureOpenAIEmbedding": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 8191
+      },
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -28,18 +46,6 @@
         // "ChatCompletion" or "TextCompletion"
         "APIType": "ChatCompletion",
         "MaxRetries": 10
-      },
-      "AzureOpenAIEmbedding": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 8191
       },
       "OpenAI": {
         // Name of the model used to generate text (text completion or chat completion)
@@ -84,8 +90,10 @@
       },
       "AzureAIDocIntel": {
         // "APIKey" or "AzureIdentity".
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Required when Auth == APIKey
         "APIKey": "",
@@ -93,8 +101,10 @@
       },
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": ""

--- a/examples/007-dotnet-serverless-azure/appsettings.json
+++ b/examples/007-dotnet-serverless-azure/appsettings.json
@@ -9,8 +9,10 @@
     "Services": {
       "AzureAIContentSafety": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAIContentSafetyConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": "",
@@ -19,8 +21,10 @@
       },
       "AzureAIDocIntel": {
         // "APIKey" or "AzureIdentity".
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Required when Auth == APIKey
         "APIKey": "",
@@ -28,8 +32,10 @@
       },
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": "",
@@ -50,8 +56,10 @@
       },
       "AzureBlobs": {
         // "ConnectionString" or "AzureIdentity". For other options see <AzureBlobConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Azure Storage account name, required when using AzureIdentity auth
         // Note: you can use an env var 'KernelMemory__Services__AzureBlobs__Account' to set this
@@ -66,9 +74,12 @@
       },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -88,9 +99,12 @@
       },
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",

--- a/examples/101-dotnet-custom-Prompts/appsettings.json
+++ b/examples/101-dotnet-custom-Prompts/appsettings.json
@@ -14,27 +14,14 @@
   },
   "KernelMemory": {
     "Services": {
-      "AzureOpenAIText": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 16384,
-        // "ChatCompletion" or "TextCompletion"
-        "APIType": "ChatCompletion",
-        // How many times to retry in case of throttling.
-        "MaxRetries": 10
-      },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -49,6 +36,25 @@
         // the model and deployment in use.
         // See also hhttps://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
         "MaxEmbeddingBatchSize": 1,
+        // How many times to retry in case of throttling.
+        "MaxRetries": 10
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
         // How many times to retry in case of throttling.
         "MaxRetries": 10
       },

--- a/examples/103-dotnet-custom-EmbeddingGenerator/appsettings.json
+++ b/examples/103-dotnet-custom-EmbeddingGenerator/appsettings.json
@@ -16,9 +16,14 @@
     "Services": {
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this setting to change the client audience. See:
+        // - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/README.md
+        // - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIAudience.cs
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",

--- a/examples/104-dotnet-custom-LLM/appsettings.json
+++ b/examples/104-dotnet-custom-LLM/appsettings.json
@@ -16,9 +16,12 @@
     "Services": {
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",

--- a/examples/105-dotnet-serverless-llamasharp/appsettings.json
+++ b/examples/105-dotnet-serverless-llamasharp/appsettings.json
@@ -34,9 +34,12 @@
       },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",

--- a/examples/106-dotnet-retrieve-synthetics/appsettings.json
+++ b/examples/106-dotnet-retrieve-synthetics/appsettings.json
@@ -21,27 +21,14 @@
   },
   "KernelMemory": {
     "Services": {
-      "AzureOpenAIText": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 16384,
-        // "ChatCompletion" or "TextCompletion"
-        "APIType": "ChatCompletion",
-        // How many times to retry in case of throttling.
-        "MaxRetries": 10
-      },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -56,6 +43,25 @@
         // the model and deployment in use.
         // See also hhttps://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
         "MaxEmbeddingBatchSize": 1,
+        // How many times to retry in case of throttling.
+        "MaxRetries": 10
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
         // How many times to retry in case of throttling.
         "MaxRetries": 10
       },

--- a/examples/108-dotnet-custom-content-decoders/appsettings.json
+++ b/examples/108-dotnet-custom-content-decoders/appsettings.json
@@ -14,27 +14,14 @@
   },
   "KernelMemory": {
     "Services": {
-      "AzureOpenAIText": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 16384,
-        // "ChatCompletion" or "TextCompletion"
-        "APIType": "ChatCompletion",
-        // How many times to retry in case of throttling.
-        "MaxRetries": 10
-      },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -49,6 +36,25 @@
         // the model and deployment in use.
         // See also hhttps://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
         "MaxEmbeddingBatchSize": 1,
+        // How many times to retry in case of throttling.
+        "MaxRetries": 10
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
         // How many times to retry in case of throttling.
         "MaxRetries": 10
       },

--- a/examples/110-dotnet-anthropic/appsettings.json
+++ b/examples/110-dotnet-anthropic/appsettings.json
@@ -28,9 +28,12 @@
       },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",

--- a/examples/111-dotnet-azure-ai-hybrid-search/appsettings.json
+++ b/examples/111-dotnet-azure-ai-hybrid-search/appsettings.json
@@ -16,33 +16,22 @@
     "Services": {
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": ""
       },
-      "AzureOpenAIText": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 16384,
-        // "ChatCompletion" or "TextCompletion"
-        "APIType": "ChatCompletion",
-        // How many times to retry in case of throttling.
-        "MaxRetries": 10
-      },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -57,6 +46,25 @@
         // the model and deployment in use.
         // See also hhttps://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
         "MaxEmbeddingBatchSize": 1,
+        // How many times to retry in case of throttling.
+        "MaxRetries": 10
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
         // How many times to retry in case of throttling.
         "MaxRetries": 10
       },

--- a/examples/210-KM-without-builder/appsettings.json
+++ b/examples/210-KM-without-builder/appsettings.json
@@ -243,8 +243,10 @@
       },
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": "",
@@ -265,8 +267,10 @@
       },
       "AzureAIDocIntel": {
         // "APIKey" or "AzureIdentity".
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Required when Auth == APIKey
         "APIKey": "",
@@ -274,8 +278,10 @@
       },
       "AzureBlobs": {
         // "ConnectionString" or "AzureIdentity". For other options see <AzureBlobConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Azure Storage account name, required when using AzureIdentity auth
         // Note: you can use an env var 'KernelMemory__Services__AzureBlobs__Account' to set this
@@ -290,9 +296,12 @@
       },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -318,9 +327,12 @@
       },
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -340,8 +352,10 @@
       },
       "AzureQueues": {
         // "ConnectionString" or "AzureIdentity". For other options see <AzureQueueConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Azure Storage account name, required when using AzureIdentity auth
         // Note: you can use an env var 'KernelMemory__Services__AzureQueue__Account' to set this

--- a/examples/401-evaluation/appsettings.json
+++ b/examples/401-evaluation/appsettings.json
@@ -14,48 +14,12 @@
   },
   "KernelMemory": {
     "Services": {
-      "AzureOpenAIText": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 16384,
-        // "ChatCompletion" or "TextCompletion"
-        "APIType": "ChatCompletion",
-        // How many times to retry in case of throttling.
-        "MaxRetries": 10
-      },
-      "AzureOpenAIEmbedding": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 8191,
-        // The number of dimensions output embeddings should have.
-        // Only supported in "text-embedding-3" and later models developed with
-        // MRL, see https://arxiv.org/abs/2205.13147
-        "EmbeddingDimensions": null,
-        // How many embeddings to calculate in parallel. The max value depends on
-        // the model and deployment in use.
-        // See also hhttps://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
-        "MaxEmbeddingBatchSize": 1,
-        // How many times to retry in case of throttling.
-        "MaxRetries": 10
-      },
       "AzureAIDocIntel": {
         // "APIKey" or "AzureIdentity".
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Required when Auth == APIKey
         "APIKey": "",
@@ -63,8 +27,10 @@
       },
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": "",
@@ -82,6 +48,50 @@
         //
         // See https://learn.microsoft.com/rest/api/searchservice/documents/search-post?view=rest-searchservice-2024-07-01&tabs=HTTP#request-body
         "UseStickySessions": false
+      },
+      "AzureOpenAIEmbedding": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 8191,
+        // The number of dimensions output embeddings should have.
+        // Only supported in "text-embedding-3" and later models developed with
+        // MRL, see https://arxiv.org/abs/2205.13147
+        "EmbeddingDimensions": null,
+        // How many embeddings to calculate in parallel. The max value depends on
+        // the model and deployment in use.
+        // See also hhttps://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
+        "MaxEmbeddingBatchSize": 1,
+        // How many times to retry in case of throttling.
+        "MaxRetries": 10
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
+        // How many times to retry in case of throttling.
+        "MaxRetries": 10
       },
       "OpenAI": {
         // Name of the model used to generate text (text completion or chat completion)

--- a/extensions/AzureAIContentSafety/AzureAIContentSafety/AzureAIContentSafetyConfig.cs
+++ b/extensions/AzureAIContentSafety/AzureAIContentSafety/AzureAIContentSafetyConfig.cs
@@ -15,7 +15,13 @@ public class AzureAIContentSafetyConfig
     public enum AuthTypes
     {
         Unknown = -1,
+
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         AzureIdentity,
+
         APIKey,
         ManualTokenCredential,
     }

--- a/extensions/AzureAIDocIntel/AzureAIDocIntelConfig.cs
+++ b/extensions/AzureAIDocIntel/AzureAIDocIntelConfig.cs
@@ -13,7 +13,13 @@ public class AzureAIDocIntelConfig
     public enum AuthTypes
     {
         Unknown = -1,
+
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         AzureIdentity,
+
         APIKey,
     }
 

--- a/extensions/AzureAISearch/AzureAISearch.FunctionalTests/appsettings.json
+++ b/extensions/AzureAISearch/AzureAISearch.FunctionalTests/appsettings.json
@@ -7,8 +7,10 @@
     "Services": {
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": "",

--- a/extensions/AzureAISearch/AzureAISearch.TestApplication/appsettings.json
+++ b/extensions/AzureAISearch/AzureAISearch.TestApplication/appsettings.json
@@ -9,32 +9,22 @@
     "Services": {
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": ""
       },
-      "AzureOpenAIText": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 8191,
-        // "ChatCompletion" or "TextCompletion"
-        "APIType": "ChatCompletion",
-        "MaxRetries": 3
-      },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -50,6 +40,24 @@
         // See also hhttps://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
         "MaxEmbeddingBatchSize": 1,
         // How many times to retry in case of throttling.
+        "MaxRetries": 3
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        /// AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 8191,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
         "MaxRetries": 3
       },
       "OpenAI": {

--- a/extensions/AzureAISearch/AzureAISearch/AzureAISearchConfig.cs
+++ b/extensions/AzureAISearch/AzureAISearch/AzureAISearchConfig.cs
@@ -16,7 +16,13 @@ public class AzureAISearchConfig
     public enum AuthTypes
     {
         Unknown = -1,
+
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         AzureIdentity,
+
         APIKey,
         ManualTokenCredential,
     }

--- a/extensions/AzureBlobs/AzureBlobsConfig.cs
+++ b/extensions/AzureBlobs/AzureBlobsConfig.cs
@@ -20,7 +20,13 @@ public class AzureBlobsConfig
     public enum AuthTypes
     {
         Unknown = -1,
+
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         AzureIdentity,
+
         ConnectionString,
         AccountKey,
         ManualStorageSharedKeyCredential,

--- a/extensions/AzureOpenAI/AzureOpenAI/AzureOpenAIConfig.cs
+++ b/extensions/AzureOpenAI/AzureOpenAI/AzureOpenAIConfig.cs
@@ -44,6 +44,13 @@ public class AzureOpenAIConfig
     public AuthTypes Auth { get; set; }
 
     /// <summary>
+    /// Optional custom audience for sovereign clouds
+    /// See https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/README.md
+    /// See https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIAudience.cs
+    /// </summary>
+    public string? AzureOpenAIAudience { get; set; } = null;
+
+    /// <summary>
     /// API key, required if Auth == APIKey
     /// </summary>
     public string APIKey { get; set; } = string.Empty;

--- a/extensions/AzureOpenAI/AzureOpenAI/Internals/AzureOpenAIClientBuilder.cs
+++ b/extensions/AzureOpenAI/AzureOpenAI/Internals/AzureOpenAIClientBuilder.cs
@@ -32,6 +32,14 @@ internal static class AzureOpenAIClientBuilder
             UserAgentApplicationId = Telemetry.HttpUserAgent,
         };
 
+        // Custom audience for sovereign clouds. See:
+        // - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/README.md
+        // - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIAudience.cs
+        if (config.Auth == AzureOpenAIConfig.AuthTypes.AzureIdentity && !string.IsNullOrEmpty(config.AzureOpenAIAudience))
+        {
+            options.Audience = new AzureOpenAIAudience(config.AzureOpenAIAudience);
+        }
+
         // See https://github.com/Azure/azure-sdk-for-net/issues/46109
         options.AddPolicy(new SingleAuthorizationHeaderPolicy(), PipelinePosition.PerTry);
 

--- a/extensions/AzureQueues/AzureQueuesConfig.cs
+++ b/extensions/AzureQueues/AzureQueuesConfig.cs
@@ -23,7 +23,13 @@ public class AzureQueuesConfig
     public enum AuthTypes
     {
         Unknown = -1,
+
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         AzureIdentity,
+
         ConnectionString,
         AccountKey,
         ManualStorageSharedKeyCredential,

--- a/extensions/Elasticsearch/Elasticsearch.FunctionalTests/appsettings.json
+++ b/extensions/Elasticsearch/Elasticsearch.FunctionalTests/appsettings.json
@@ -19,27 +19,14 @@
         "ShardCount": 1,
         "Replicas": 0
       },
-      "AzureOpenAIText": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 16384,
-        // "ChatCompletion" or "TextCompletion"
-        "APIType": "ChatCompletion",
-        // How many times to retry in case of throttling.
-        "MaxRetries": 10
-      },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -54,6 +41,25 @@
         // the model and deployment in use.
         // See also hhttps://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
         "MaxEmbeddingBatchSize": 1,
+        // How many times to retry in case of throttling.
+        "MaxRetries": 10
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
         // How many times to retry in case of throttling.
         "MaxRetries": 10
       },

--- a/extensions/LlamaSharp/LlamaSharp.FunctionalTests/appsettings.json
+++ b/extensions/LlamaSharp/LlamaSharp.FunctionalTests/appsettings.json
@@ -31,8 +31,10 @@
       },
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": ""

--- a/extensions/MongoDbAtlas/MongoDbAtlas.FunctionalTests/appsettings.json
+++ b/extensions/MongoDbAtlas/MongoDbAtlas.FunctionalTests/appsettings.json
@@ -10,27 +10,14 @@
         "ConnectionString": "mongodb://root:root@localhost:27777/?authSource=admin",
         "DatabaseName": "TestKernelMemory"
       },
-      "AzureOpenAIText": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 16384,
-        // "ChatCompletion" or "TextCompletion"
-        "APIType": "ChatCompletion",
-        // How many times to retry in case of throttling.
-        "MaxRetries": 10
-      },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -45,6 +32,25 @@
         // the model and deployment in use.
         // See also hhttps://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
         "MaxEmbeddingBatchSize": 1,
+        // How many times to retry in case of throttling.
+        "MaxRetries": 10
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
         // How many times to retry in case of throttling.
         "MaxRetries": 10
       },

--- a/extensions/ONNX/Onnx.FunctionalTests/appsettings.json
+++ b/extensions/ONNX/Onnx.FunctionalTests/appsettings.json
@@ -19,8 +19,10 @@
       },
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": ""

--- a/extensions/Postgres/Postgres.FunctionalTests/appsettings.json
+++ b/extensions/Postgres/Postgres.FunctionalTests/appsettings.json
@@ -13,27 +13,14 @@
         // e.g. to exclude other tables in the same schema.
         "TableNamePrefix": "tests-"
       },
-      "AzureOpenAIText": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 16384,
-        // "ChatCompletion" or "TextCompletion"
-        "APIType": "ChatCompletion",
-        // How many times to retry in case of throttling.
-        "MaxRetries": 10
-      },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -48,6 +35,25 @@
         // the model and deployment in use.
         // See also hhttps://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
         "MaxEmbeddingBatchSize": 1,
+        // How many times to retry in case of throttling.
+        "MaxRetries": 10
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
         // How many times to retry in case of throttling.
         "MaxRetries": 10
       },

--- a/extensions/Postgres/Postgres.TestApplication/appsettings.json
+++ b/extensions/Postgres/Postgres.TestApplication/appsettings.json
@@ -12,26 +12,14 @@
         // e.g. to exclude other tables in the same schema.
         "TableNamePrefix": "km-"
       },
-      "AzureOpenAIText": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 8191,
-        // "ChatCompletion" or "TextCompletion"
-        "APIType": "ChatCompletion",
-        "MaxRetries": 3
-      },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -47,6 +35,24 @@
         // See also hhttps://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
         "MaxEmbeddingBatchSize": 1,
         // How many times to retry in case of throttling.
+        "MaxRetries": 3
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 8191,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
         "MaxRetries": 3
       },
       "OpenAI": {

--- a/extensions/Redis/Redis.FunctionalTests/appsettings.json
+++ b/extensions/Redis/Redis.FunctionalTests/appsettings.json
@@ -21,27 +21,14 @@
           "ext": "|"
         }
       },
-      "AzureOpenAIText": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 16384,
-        // "ChatCompletion" or "TextCompletion"
-        "APIType": "ChatCompletion",
-        // How many times to retry in case of throttling.
-        "MaxRetries": 10
-      },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -56,6 +43,25 @@
         // the model and deployment in use.
         // See also hhttps://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
         "MaxEmbeddingBatchSize": 1,
+        // How many times to retry in case of throttling.
+        "MaxRetries": 10
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
         // How many times to retry in case of throttling.
         "MaxRetries": 10
       },

--- a/extensions/SQLServer/SQLServer.FunctionalTests/appsettings.json
+++ b/extensions/SQLServer/SQLServer.FunctionalTests/appsettings.json
@@ -14,27 +14,14 @@
         // - https://devblogs.microsoft.com/azure-sql/development-with-sql-in-containers-on-macos
         "ConnectionString": ""
       },
-      "AzureOpenAIText": {
-        // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
-        "Auth": "AzureIdentity",
-        "Endpoint": "https://<...>.openai.azure.com/",
-        "APIKey": "",
-        "Deployment": "",
-        // The max number of tokens supported by model deployed
-        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
-        "MaxTokenTotal": 16384,
-        // "ChatCompletion" or "TextCompletion"
-        "APIType": "ChatCompletion",
-        // How many times to retry in case of throttling.
-        "MaxRetries": 10
-      },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -49,6 +36,25 @@
         // the model and deployment in use.
         // See also hhttps://learn.microsoft.com/azure/ai-services/openai/reference#embeddings
         "MaxEmbeddingBatchSize": 1,
+        // How many times to retry in case of throttling.
+        "MaxRetries": 10
+      },
+      "AzureOpenAIText": {
+        // "ApiKey" or "AzureIdentity"
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
+        "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this to change the client audience.
+        "AzureOpenAIAudience": null,
+        "Endpoint": "https://<...>.openai.azure.com/",
+        "APIKey": "",
+        "Deployment": "",
+        // The max number of tokens supported by model deployed
+        // See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+        "MaxTokenTotal": 16384,
+        // "ChatCompletion" or "TextCompletion"
+        "APIType": "ChatCompletion",
         // How many times to retry in case of throttling.
         "MaxRetries": 10
       },

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -258,8 +258,10 @@
       },
       "AzureAIContentSafety": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAIContentSafetyConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": "",
@@ -268,8 +270,10 @@
       },
       "AzureAIDocIntel": {
         // "APIKey" or "AzureIdentity".
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Required when Auth == APIKey
         "APIKey": "",
@@ -277,8 +281,10 @@
       },
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": "",
@@ -299,8 +305,10 @@
       },
       "AzureBlobs": {
         // "ConnectionString" or "AzureIdentity". For other options see <AzureBlobConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Azure Storage account name, required when using AzureIdentity auth
         // Note: you can use an env var 'KernelMemory__Services__AzureBlobs__Account' to set this
@@ -315,9 +323,14 @@
       },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this setting to change the client audience. See:
+        // - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/README.md
+        // - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIAudience.cs
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         // Your Azure Deployment name
@@ -347,9 +360,14 @@
       },
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this setting to change the client audience. See:
+        // - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/README.md
+        // - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIAudience.cs
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -372,8 +390,10 @@
       },
       "AzureQueues": {
         // "ConnectionString" or "AzureIdentity". For other options see <AzureQueueConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Azure Storage account name, required when using AzureIdentity auth
         // Note: you can use an env var 'KernelMemory__Services__AzureQueue__Account' to set this

--- a/service/tests/Core.FunctionalTests/appsettings.json
+++ b/service/tests/Core.FunctionalTests/appsettings.json
@@ -7,8 +7,10 @@
     "Services": {
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": "",

--- a/service/tests/Service.FunctionalTests/appsettings.json
+++ b/service/tests/Service.FunctionalTests/appsettings.json
@@ -12,8 +12,10 @@
       },
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": ""
@@ -24,8 +26,10 @@
       },
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",

--- a/tools/aspire/all-azure/appsettings.json
+++ b/tools/aspire/all-azure/appsettings.json
@@ -10,8 +10,10 @@
     "Services": {
       "AzureAIContentSafety": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAIContentSafetyConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   change the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": "",
@@ -20,8 +22,10 @@
       },
       "AzureAISearch": {
         // "ApiKey" or "AzureIdentity". For other options see <AzureAISearchConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         "Endpoint": "https://<...>",
         "APIKey": "",
@@ -42,8 +46,10 @@
       },
       "AzureAIDocIntel": {
         // "APIKey" or "AzureIdentity".
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Required when Auth == APIKey
         "APIKey": "",
@@ -51,8 +57,10 @@
       },
       "AzureBlobs": {
         // "ConnectionString" or "AzureIdentity". For other options see <AzureBlobConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Azure Storage account name, required when using AzureIdentity auth
         // Note: you can use an env var 'KernelMemory__Services__AzureBlobs__Account' to set this
@@ -67,9 +75,14 @@
       },
       "AzureOpenAIEmbedding": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this setting to change the client audience. See:
+        // - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/README.md
+        // - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIAudience.cs
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         // Your Azure Deployment name
@@ -99,9 +112,14 @@
       },
       "AzureOpenAIText": {
         // "ApiKey" or "AzureIdentity"
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
+        // When the service is on sovereign clouds the AZURE_AUTHORITY_HOST env var might not work,
+        // in which case use this setting to change the client audience. See:
+        // - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/README.md
+        // - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIAudience.cs
+        "AzureOpenAIAudience": null,
         "Endpoint": "https://<...>.openai.azure.com/",
         "APIKey": "",
         "Deployment": "",
@@ -124,8 +142,10 @@
       },
       "AzureQueues": {
         // "ConnectionString" or "AzureIdentity". For other options see <AzureQueueConfig>.
-        // AzureIdentity: use automatic AAD authentication mechanism. You can test locally
-        //   using the env vars AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET.
+        // AzureIdentity: use automatic Entra (AAD) authentication mechanism.
+        //   When the service is on sovereign clouds you can use the AZURE_AUTHORITY_HOST env var to
+        //   set the authority host. See https://learn.microsoft.com/dotnet/api/overview/azure/identity-readme
+        //   You can test locally using the AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET env vars.
         "Auth": "AzureIdentity",
         // Azure Storage account name, required when using AzureIdentity auth
         // Note: you can use an env var 'KernelMemory__Services__AzureQueue__Account' to set this


### PR DESCRIPTION
Azure OpenAI SDK does not support changing token authority/audience via environment variables.
Added new option for Azure OpenAI config, to allow setting the token audience.

See:
- https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/README.md
- https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIAudience.cs

See also https://github.com/microsoft/kernel-memory/issues/943