### PR TITLE
Throw exception when mixing volatile and persistent data

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
     <PropertyGroup>
         <!-- Central version prefix - applies to all nuget packages. -->
-        <Version>0.95.0</Version>
+        <Version>0.96.0</Version>
 
         <!-- C# lang version, https://learn.microsoft.com/dotnet/csharp/whats-new -->
         <LangVersion>12</LangVersion>

--- a/examples/001-dotnet-WebClient/Properties/launchSettings.json
+++ b/examples/001-dotnet-WebClient/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "console": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/examples/002-dotnet-Serverless/Properties/launchSettings.json
+++ b/examples/002-dotnet-Serverless/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "console": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/examples/007-dotnet-serverless-azure/Properties/launchSettings.json
+++ b/examples/007-dotnet-serverless-azure/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "console": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/service/Abstractions/IKernelMemoryBuilder.cs
+++ b/service/Abstractions/IKernelMemoryBuilder.cs
@@ -26,17 +26,20 @@ public interface IKernelMemoryBuilder
     /// <summary>
     /// Build the memory instance, using defaults and the provided dependencies
     /// and overrides. Depending on the dependencies provided, the resulting
-    /// memory might use either an synchronous or asynchronous pipeline.
+    /// memory might use either a synchronous or asynchronous pipeline.
     /// </summary>
-    public IKernelMemory Build();
+    /// <param name="options">Options for the build process</param>
+    /// <returns>A memory instance</returns>
+    public IKernelMemory Build(KernelMemoryBuilderBuildOptions? options = null);
 
     /// <summary>
     /// Build a specific type of memory instance, e.g. explicitly choosing
     /// between synchronous or asynchronous (queue based) pipeline.
     /// </summary>
     /// <typeparam name="T">Type of memory derived from IKernelMemory</typeparam>
+    /// <param name="options">Options for the build process</param>
     /// <returns>A memory instance</returns>
-    public T Build<T>() where T : class, IKernelMemory;
+    public T Build<T>(KernelMemoryBuilderBuildOptions? options = null) where T : class, IKernelMemory;
 
     /// <summary>
     /// Add a singleton to the builder service collection pool.

--- a/service/Abstractions/KernelMemoryBuilderBuildOptions.cs
+++ b/service/Abstractions/KernelMemoryBuilderBuildOptions.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.KernelMemory;
+
+public sealed class KernelMemoryBuilderBuildOptions
+{
+    public bool AllowMixingVolatileAndPersistentData { get; set; } = false;
+}

--- a/service/Core/KernelMemoryBuilder.cs
+++ b/service/Core/KernelMemoryBuilder.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.KernelMemory.AI;
 using Microsoft.KernelMemory.AppBuilders;
@@ -116,21 +117,21 @@ public sealed class KernelMemoryBuilder : IKernelMemoryBuilder
     }
 
     ///<inheritdoc />
-    public IKernelMemory Build()
+    public IKernelMemory Build(KernelMemoryBuilderBuildOptions? options = null)
     {
         var type = this.GetBuildType();
         switch (type)
         {
             case ClientTypes.SyncServerless:
-                return this.BuildServerlessClient();
+                return this.BuildServerlessClient(options);
 
             case ClientTypes.AsyncService:
-                return this.BuildAsyncClient();
+                return this.BuildAsyncClient(options);
 
             case ClientTypes.Undefined:
-                throw new KernelMemoryException("Missing dependencies or insufficient configuration provided. " +
-                                                "Try using With...() methods " +
-                                                $"and other configuration methods before calling {nameof(this.Build)}(...)");
+                throw new ConfigurationException("Missing dependencies or insufficient configuration provided. " +
+                                                 "Try using With...() methods " +
+                                                 $"and other configuration methods before calling {nameof(this.Build)}(...)");
 
             default:
                 throw new ArgumentOutOfRangeException(nameof(type), $"Unsupported memory type '{type}'");
@@ -138,11 +139,11 @@ public sealed class KernelMemoryBuilder : IKernelMemoryBuilder
     }
 
     ///<inheritdoc />
-    public T Build<T>() where T : class, IKernelMemory
+    public T Build<T>(KernelMemoryBuilderBuildOptions? options = null) where T : class, IKernelMemory
     {
         if (typeof(T) == typeof(MemoryServerless))
         {
-            if (this.BuildServerlessClient() is not T result)
+            if (this.BuildServerlessClient(options) is not T result)
             {
                 throw new InvalidOperationException($"Unable to instantiate '{typeof(MemoryServerless)}'. The instance is NULL.");
             }
@@ -152,7 +153,7 @@ public sealed class KernelMemoryBuilder : IKernelMemoryBuilder
 
         if (typeof(T) == typeof(MemoryService))
         {
-            if (this.BuildAsyncClient() is not T result)
+            if (this.BuildAsyncClient(options) is not T result)
             {
                 throw new InvalidOperationException($"Unable to instantiate '{typeof(MemoryService)}'. The instance is NULL.");
             }
@@ -226,7 +227,7 @@ public sealed class KernelMemoryBuilder : IKernelMemoryBuilder
         }
     }
 
-    private MemoryServerless BuildServerlessClient()
+    private MemoryServerless BuildServerlessClient(KernelMemoryBuilderBuildOptions? options)
     {
         try
         {
@@ -240,6 +241,7 @@ public sealed class KernelMemoryBuilder : IKernelMemoryBuilder
 
             // Recreate the service provider, in order to have the latest dependencies just configured
             serviceProvider = this._memoryServiceCollection.BuildServiceProvider();
+            this.CheckStoragePersistence(options, serviceProvider);
             var memoryClientInstance = ActivatorUtilities.CreateInstance<MemoryServerless>(serviceProvider);
 
             // Load handlers in the memory client
@@ -257,7 +259,7 @@ public sealed class KernelMemoryBuilder : IKernelMemoryBuilder
         }
     }
 
-    private MemoryService BuildAsyncClient()
+    private MemoryService BuildAsyncClient(KernelMemoryBuilderBuildOptions? options)
     {
         // Add handlers to DI service collection
         if (this._useDefaultHandlers)
@@ -282,7 +284,60 @@ public sealed class KernelMemoryBuilder : IKernelMemoryBuilder
 
         // Recreate the service provider, in order to have the latest dependencies just configured
         serviceProvider = this._memoryServiceCollection.BuildServiceProvider();
+        this.CheckStoragePersistence(options, serviceProvider);
         return ActivatorUtilities.CreateInstance<MemoryService>(serviceProvider);
+    }
+
+    private void CheckStoragePersistence(KernelMemoryBuilderBuildOptions? options, ServiceProvider serviceProvider)
+    {
+        if (options is { AllowMixingVolatileAndPersistentData: true }) { return; }
+
+        ServiceDescriptor docStoreType = this._memoryServiceCollection.Last<ServiceDescriptor>(x => x.ServiceType == typeof(IDocumentStorage));
+        ServiceDescriptor memStoreType = this._memoryServiceCollection.Last<ServiceDescriptor>(x => x.ServiceType == typeof(IMemoryDb));
+        SimpleFileStorageConfig? simpleFileStorageConfig = serviceProvider.GetService<SimpleFileStorageConfig>();
+        SimpleVectorDbConfig? simpleVectorDbConfig = serviceProvider.GetService<SimpleVectorDbConfig>();
+        SimpleTextDbConfig? simpleTextDbConfig = serviceProvider.GetService<SimpleTextDbConfig>();
+
+        bool persistentDocStore = docStoreType.ImplementationType != typeof(SimpleFileStorage) || simpleFileStorageConfig?.StorageType == FileSystemTypes.Disk;
+        bool persistentMemStore = memStoreType.ImplementationType != typeof(SimpleVectorDb) && memStoreType.ImplementationType != typeof(SimpleTextDb)
+                                  || (memStoreType.ImplementationType == typeof(SimpleVectorDb) && simpleVectorDbConfig?.StorageType == FileSystemTypes.Disk)
+                                  || (memStoreType.ImplementationType == typeof(SimpleTextDb) && simpleTextDbConfig?.StorageType == FileSystemTypes.Disk);
+
+        // No error if both services are volatile or persistent,
+        if (persistentMemStore == persistentDocStore)
+        {
+            return;
+        }
+
+        // Show a service name for a helpful error message
+        var docStoreName = docStoreType.ImplementationType != typeof(SimpleFileStorage)
+            ? docStoreType.ImplementationType?.Name
+            : $"{nameof(SimpleFileStorage)} {simpleFileStorageConfig?.StorageType}";
+
+        var memStoreName = memStoreType.ImplementationType != typeof(SimpleVectorDb) && memStoreType.ImplementationType != typeof(SimpleTextDb)
+            ? memStoreType.ImplementationType?.Name
+            : memStoreType.ImplementationType == typeof(SimpleVectorDb)
+                ? $"{nameof(SimpleVectorDb)} {simpleVectorDbConfig?.StorageType}"
+                : $"{nameof(SimpleTextDb)} {simpleTextDbConfig?.StorageType}";
+
+        // Different error message depending on which service is volatile
+        if (persistentMemStore && !persistentDocStore)
+        {
+            throw new ConfigurationException(
+                $"Using a persistent memory store ({memStoreName}) with a volatile document store ({docStoreName}) will lead to duplicate memory records over multiple executions. " +
+                $"Set up Kernel Memory to use a persistent document store like Azure Blobs, AWS S3, {nameof(SimpleFileStorage)} on disk, etc. " +
+                $"Otherwise, use {nameof(KernelMemoryBuilderBuildOptions)}.{nameof(KernelMemoryBuilderBuildOptions.AllowMixingVolatileAndPersistentData)} " +
+                "to suppress this exception when invoking kernelMemoryBuilder.Build(<options here>). ");
+        }
+
+        if (persistentDocStore && !persistentMemStore)
+        {
+            throw new ConfigurationException(
+                $"Using a volatile memory store ({memStoreName}) with a persistent document store ({docStoreName}) will lead to missing memory records over multiple executions. " +
+                $"Set up Kernel Memory to use a persistent memory store like Azure AI Search, Postgres, Qdrant, {nameof(SimpleVectorDb)} on disk, etc. " +
+                $"Otherwise, use {nameof(KernelMemoryBuilderBuildOptions)}.{nameof(KernelMemoryBuilderBuildOptions.AllowMixingVolatileAndPersistentData)} " +
+                "to suppress this exception when invoking kernelMemoryBuilder.Build(<options here>). ");
+        }
     }
 
     private KernelMemoryBuilder CompleteServerlessClient(ServiceProvider serviceProvider)

--- a/service/Service/Program.cs
+++ b/service/Service/Program.cs
@@ -60,7 +60,7 @@ internal static class Program
         // Run `dotnet run setup` to run this code and set up the service
         if (new[] { "setup", "-setup", "config" }.Contains(args.FirstOrDefault(), StringComparer.OrdinalIgnoreCase))
         {
-            InteractiveSetup.Main.InteractiveSetup(args.Skip(1).ToArray());
+            InteractiveSetup.Program.Main(args.Skip(1).ToArray());
         }
 
         // *************************** APP BUILD *******************************

--- a/tools/InteractiveSetup/AppSettings.cs
+++ b/tools/InteractiveSetup/AppSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -35,6 +36,11 @@ internal static class AppSettings
 
         json = JsonConvert.SerializeObject(data, s_jsonOptions);
         File.WriteAllText(DevelopmentSettingsFile, json);
+    }
+
+    public static void AddService(string serviceName, Dictionary<string, object> config)
+    {
+        Change(x => { x.Services.Add(serviceName, config); });
     }
 
     public static void GlobalChange(Action<JObject> configChanges)

--- a/tools/InteractiveSetup/Context.cs
+++ b/tools/InteractiveSetup/Context.cs
@@ -27,8 +27,10 @@ internal sealed class Context
     public readonly BoundedBoolean CfgAzureOpenAIText = new();
     public readonly BoundedBoolean CfgAzureOpenAIEmbedding = new();
     public readonly BoundedBoolean CfgOpenAI = new();
-    public readonly BoundedBoolean CfgLlamaSharp = new();
-    public readonly BoundedBoolean CfgOllama = new();
+    public readonly BoundedBoolean CfgLlamaSharpEmbedding = new();
+    public readonly BoundedBoolean CfgLlamaSharpText = new();
+    public readonly BoundedBoolean CfgOllamaEmbedding = new();
+    public readonly BoundedBoolean CfgOllamaText = new();
     public readonly BoundedBoolean CfgAzureAIDocIntel = new();
 
     // Vectors

--- a/tools/InteractiveSetup/InteractiveSetup.csproj
+++ b/tools/InteractiveSetup/InteractiveSetup.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
+        <OutputType>Exe</OutputType>
         <AssemblyName>Microsoft.KernelMemory.InteractiveSetup</AssemblyName>
         <RootNamespace>Microsoft.KernelMemory.InteractiveSetup</RootNamespace>
         <NoWarn>$(NoWarn);CA1031;CA1303;CA1724;</NoWarn>

--- a/tools/InteractiveSetup/Program.cs
+++ b/tools/InteractiveSetup/Program.cs
@@ -7,9 +7,9 @@ using Microsoft.KernelMemory.InteractiveSetup.UI;
 
 namespace Microsoft.KernelMemory.InteractiveSetup;
 
-public static class Main
+public static class Program
 {
-    public static void InteractiveSetup(string[] args)
+    public static void Main(string[] args)
     {
         var ctx = new Context();
 
@@ -207,7 +207,19 @@ public static class Main
                             ? [x.Retrieval.EmbeddingGeneratorType]
                             : [];
                     });
-                    ctx.CfgOllama.Value = true;
+                    ctx.CfgOllamaEmbedding.Value = true;
+                }),
+
+                new("LlamaSharp library", config.Retrieval.EmbeddingGeneratorType == "LlamaSharp", () =>
+                {
+                    AppSettings.Change(x =>
+                    {
+                        x.Retrieval.EmbeddingGeneratorType = "LlamaSharp";
+                        x.DataIngestion.EmbeddingGeneratorTypes = ctx.CfgEmbeddingGenerationEnabled.Value
+                            ? [x.Retrieval.EmbeddingGeneratorType]
+                            : [];
+                    });
+                    ctx.CfgLlamaSharpEmbedding.Value = true;
                 }),
 
                 new("None/Custom (manually set with code)", string.IsNullOrEmpty(config.Retrieval.EmbeddingGeneratorType), () =>
@@ -248,13 +260,13 @@ public static class Main
                 new("Ollama service", config.TextGeneratorType == "Ollama", () =>
                 {
                     AppSettings.Change(x => { x.TextGeneratorType = "Ollama"; });
-                    ctx.CfgOllama.Value = true;
+                    ctx.CfgOllamaText.Value = true;
                 }),
 
                 new("LlamaSharp library", config.TextGeneratorType == "LlamaSharp", () =>
                 {
                     AppSettings.Change(x => { x.TextGeneratorType = "LlamaSharp"; });
-                    ctx.CfgLlamaSharp.Value = true;
+                    ctx.CfgLlamaSharpText.Value = true;
                 }),
 
                 new("None/Custom (manually set with code)", string.IsNullOrEmpty(config.TextGeneratorType), () =>

--- a/tools/InteractiveSetup/Properties/launchSettings.json
+++ b/tools/InteractiveSetup/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "console": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/tools/InteractiveSetup/Services/AWSS3.cs
+++ b/tools/InteractiveSetup/Services/AWSS3.cs
@@ -24,6 +24,7 @@ internal static class AWSS3
                 { "BucketName", "" },
                 { "Endpoint", "https://s3.amazonaws.com" },
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         // Required to avoid exceptions. "Endpoint" is optional and not defined in appsettings.json

--- a/tools/InteractiveSetup/Services/AzureAIDocIntel.cs
+++ b/tools/InteractiveSetup/Services/AzureAIDocIntel.cs
@@ -22,6 +22,7 @@ internal static class AzureAIDocIntel
                 { "Auth", "ApiKey" },
                 { "APIKey", "" },
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         SetupUI.AskQuestionWithOptions(new QuestionWithOptions

--- a/tools/InteractiveSetup/Services/AzureAISearch.cs
+++ b/tools/InteractiveSetup/Services/AzureAISearch.cs
@@ -24,6 +24,7 @@ internal static class AzureAISearch
                 { "UseHybridSearch", false },
                 { "UseStickySessions", false }
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         SetupUI.AskQuestionWithOptions(new QuestionWithOptions

--- a/tools/InteractiveSetup/Services/AzureBlobs.cs
+++ b/tools/InteractiveSetup/Services/AzureBlobs.cs
@@ -23,6 +23,7 @@ internal static class AzureBlobs
                 { "Auth", "ConnectionString" },
                 { "ConnectionString", "" },
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         SetupUI.AskQuestionWithOptions(new QuestionWithOptions

--- a/tools/InteractiveSetup/Services/AzureOpenAIEmbedding.cs
+++ b/tools/InteractiveSetup/Services/AzureOpenAIEmbedding.cs
@@ -25,6 +25,7 @@ internal static class AzureOpenAIEmbedding
                 { "Auth", "ApiKey" },
                 { "APIKey", "" },
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         SetupUI.AskQuestionWithOptions(new QuestionWithOptions

--- a/tools/InteractiveSetup/Services/AzureOpenAIText.cs
+++ b/tools/InteractiveSetup/Services/AzureOpenAIText.cs
@@ -25,6 +25,7 @@ internal static class AzureOpenAIText
                 { "Auth", "ApiKey" },
                 { "APIKey", "" },
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         SetupUI.AskQuestionWithOptions(new QuestionWithOptions

--- a/tools/InteractiveSetup/Services/AzureQueue.cs
+++ b/tools/InteractiveSetup/Services/AzureQueue.cs
@@ -18,10 +18,11 @@ internal static class AzureQueue
         {
             config = new Dictionary<string, object>
             {
-                { "Account", "" },
                 { "Auth", "ConnectionString" },
                 { "ConnectionString", "" },
+                { "Account", "" },
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         SetupUI.AskQuestionWithOptions(new QuestionWithOptions

--- a/tools/InteractiveSetup/Services/MongoDbAtlasDocumentStorage.cs
+++ b/tools/InteractiveSetup/Services/MongoDbAtlasDocumentStorage.cs
@@ -18,8 +18,9 @@ internal static class MongoDbAtlasDocumentStorage
         {
             config = new Dictionary<string, object>
             {
-                { "ConnectionString", "" },
+                { "ConnectionString", "" }
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>

--- a/tools/InteractiveSetup/Services/MongoDbAtlasMemoryDb.cs
+++ b/tools/InteractiveSetup/Services/MongoDbAtlasMemoryDb.cs
@@ -20,6 +20,7 @@ internal static class MongoDbAtlasMemoryDb
             {
                 { "ConnectionString", "" },
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>

--- a/tools/InteractiveSetup/Services/Ollama.cs
+++ b/tools/InteractiveSetup/Services/Ollama.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.KernelMemory.InteractiveSetup.UI;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.KernelMemory.InteractiveSetup.Services;
 
@@ -10,15 +11,26 @@ internal static class Ollama
 {
     public static void Setup(Context ctx, bool force = false)
     {
-        if (!ctx.CfgOllama.Value && !force) { return; }
+        if (!ctx.CfgOllamaText.Value && !ctx.CfgOllamaEmbedding.Value && !force) { return; }
 
-        ctx.CfgOllama.Value = false;
         const string ServiceName = "Ollama";
 
         Dictionary<string, object> textModel = [];
         Dictionary<string, object> embeddingModel = [];
 
-        if (!AppSettings.GetCurrentConfig().Services.TryGetValue(ServiceName, out var config))
+        if (AppSettings.GetCurrentConfig().Services.TryGetValue(ServiceName, out var config))
+        {
+            if (config.TryGetValue("TextModel", out object? tm) && tm is JObject jtm)
+            {
+                textModel = jtm.ToObject<Dictionary<string, object>>() ?? [];
+            }
+
+            if (config.TryGetValue("EmbeddingModel", out object? em) && em is JObject jem)
+            {
+                embeddingModel = jem.ToObject<Dictionary<string, object>>() ?? [];
+            }
+        }
+        else
         {
             textModel = new Dictionary<string, object>
             {
@@ -38,6 +50,7 @@ internal static class Ollama
                 { "TextModel", textModel },
                 { "EmbeddingModel", embeddingModel },
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>
@@ -45,17 +58,26 @@ internal static class Ollama
             { "Endpoint", SetupUI.AskOpenQuestion("Ollama endpoint", config.TryGet("Endpoint")) }
         });
 
-        AppSettings.Change(x => x.Services[ServiceName]["TextModel"] = new Dictionary<string, object>
+        if (ctx.CfgOllamaText.Value)
         {
-            { "ModelName", SetupUI.AskOpenQuestion("Ollama text model name", textModel.TryGet("ModelName")) },
-            { "MaxTokenTotal", SetupUI.AskOpenQuestionInt("Ollama text model max tokens", StrToInt(textModel.TryGet("MaxTokenTotal"))) },
-        });
+            AppSettings.Change(x => x.Services[ServiceName]["TextModel"] = new Dictionary<string, object>
+            {
+                { "ModelName", SetupUI.AskOpenQuestion("Ollama text model name", textModel.TryGet("ModelName")) },
+                { "MaxTokenTotal", SetupUI.AskOpenQuestionInt("Ollama text model max tokens", StrToInt(textModel.TryGet("MaxTokenTotal"))) },
+            });
+        }
 
-        AppSettings.Change(x => x.Services[ServiceName]["EmbeddingModel"] = new Dictionary<string, object>
+        if (ctx.CfgOllamaEmbedding.Value)
         {
-            { "ModelName", SetupUI.AskOpenQuestion("Ollama text embedding model name", embeddingModel.TryGet("ModelName")) },
-            { "MaxTokenTotal", SetupUI.AskOpenQuestionInt("Ollama text embedding model max tokens", StrToInt(embeddingModel.TryGet("MaxTokenTotal"))) },
-        });
+            AppSettings.Change(x => x.Services[ServiceName]["EmbeddingModel"] = new Dictionary<string, object>
+            {
+                { "ModelName", SetupUI.AskOpenQuestion("Ollama text embedding model name", embeddingModel.TryGet("ModelName")) },
+                { "MaxTokenTotal", SetupUI.AskOpenQuestionInt("Ollama text embedding model max tokens", StrToInt(embeddingModel.TryGet("MaxTokenTotal"))) },
+            });
+        }
+
+        ctx.CfgOllamaText.Value = false;
+        ctx.CfgOllamaEmbedding.Value = false;
     }
 
     private static int StrToInt(string s)

--- a/tools/InteractiveSetup/Services/OpenAI.cs
+++ b/tools/InteractiveSetup/Services/OpenAI.cs
@@ -24,6 +24,7 @@ internal static class OpenAI
                 { "OrgId", "" },
                 { "MaxRetries", 10 },
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>

--- a/tools/InteractiveSetup/Services/Postgres.cs
+++ b/tools/InteractiveSetup/Services/Postgres.cs
@@ -20,6 +20,7 @@ internal static class Postgres
             {
                 { "ConnectionString", "" },
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>

--- a/tools/InteractiveSetup/Services/Qdrant.cs
+++ b/tools/InteractiveSetup/Services/Qdrant.cs
@@ -21,6 +21,7 @@ internal static class Qdrant
                 { "Endpoint", "http://127.0.0.1:6333" },
                 { "APIKey", "" },
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>

--- a/tools/InteractiveSetup/Services/RabbitMQ.cs
+++ b/tools/InteractiveSetup/Services/RabbitMQ.cs
@@ -25,6 +25,7 @@ internal static class RabbitMQ
                 { "VirtualHost", "/" },
                 { "SslEnabled", false },
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>

--- a/tools/InteractiveSetup/Services/Redis.cs
+++ b/tools/InteractiveSetup/Services/Redis.cs
@@ -21,6 +21,7 @@ internal static class Redis
             {
                 ["ConnectionString"] = ""
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         var connectionString = SetupUI.AskPassword("Redis connection string (e.g. 'localhost:6379,password=..')", config["ConnectionString"].ToString(), optional: true);

--- a/tools/InteractiveSetup/Services/SimpleFileStorage.cs
+++ b/tools/InteractiveSetup/Services/SimpleFileStorage.cs
@@ -21,8 +21,10 @@ internal static class SimpleFileStorage
         {
             config = new Dictionary<string, object>
             {
-                { "Directory", "" }
+                { "Directory", "" },
+                { "StorageType", "Disk" }
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>

--- a/tools/InteractiveSetup/Services/SimpleQueues.cs
+++ b/tools/InteractiveSetup/Services/SimpleQueues.cs
@@ -23,6 +23,7 @@ internal static class SimpleQueues
             {
                 { "Directory", "" }
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>

--- a/tools/InteractiveSetup/Services/SimpleVectorDb.cs
+++ b/tools/InteractiveSetup/Services/SimpleVectorDb.cs
@@ -22,7 +22,9 @@ internal static class SimpleVectorDb
             config = new Dictionary<string, object>
             {
                 { "Directory", "" },
+                { "StorageType", "Disk" }
             };
+            AppSettings.AddService(ServiceName, config);
         }
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>


### PR DESCRIPTION
Multiple customers are reporting duplicate records or missing answers, most times because of an incorrect KM setup such as using a volatile document storage with a persistent vector store (or viceversa).

This PR changes the memory builder behavior to detect these setups and throw an exception in such cases. The exception can be suppressed if the user needs such a setup, e.g. for testing purposes.
