### PR TITLE
PosgreSQL hybrid search

### DIFF
--- a/extensions/Postgres/Postgres/PostgresConfig.cs
+++ b/extensions/Postgres/Postgres/PostgresConfig.cs
@@ -108,6 +108,12 @@ public class PostgresConfig
     public List<string> CreateTableSql { get; set; } = [];
 
     /// <summary>
+    /// Important: when using hybrid search, relevance scores
+    /// are very different from when using just vector search.
+    /// </summary>
+    public bool UseHybridSearch { get; set; } = false;
+
+    /// <summary>
     /// Create a new instance of the configuration
     /// </summary>
     public PostgresConfig()

--- a/extensions/Postgres/Postgres/PostgresMemory.cs
+++ b/extensions/Postgres/Postgres/PostgresMemory.cs
@@ -27,6 +27,7 @@ public sealed class PostgresMemory : IMemoryDb, IDisposable, IAsyncDisposable
     private readonly PostgresDbClient _db;
     private readonly ITextEmbeddingGenerator _embeddingGenerator;
     private readonly ILogger<PostgresMemory> _log;
+    private readonly bool _useHybridSearch;
 
     /// <summary>
     /// Create a new instance of Postgres KM connector
@@ -40,6 +41,7 @@ public sealed class PostgresMemory : IMemoryDb, IDisposable, IAsyncDisposable
         ILoggerFactory? loggerFactory = null)
     {
         this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<PostgresMemory>();
+        this._useHybridSearch = config.UseHybridSearch;
 
         this._embeddingGenerator = embeddingGenerator;
         if (this._embeddingGenerator == null)
@@ -159,12 +161,14 @@ public sealed class PostgresMemory : IMemoryDb, IDisposable, IAsyncDisposable
 
         var records = this._db.GetSimilarAsync(
             index,
+            query: text,
             target: new Vector(textEmbedding.Data),
             minSimilarity: minRelevance,
             filterSql: sql,
             sqlUserValues: unsafeSqlUserValues,
             limit: limit,
             withEmbeddings: withEmbeddings,
+            useHybridSearch: this._useHybridSearch,
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
         await foreach ((PostgresMemoryRecord record, double similarity) result in records)


### PR DESCRIPTION
This PR Includes:
- Text search index
- Hybrid Search configuration
- Vector or hybrid search

<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
Vector search do not provide the best results in an important number of scenarios. Hybrid search provides better results.

## High level description (Approach, Design)
This change includes a new parameter for activate hybrid search on PostgreSQL extension. This parameters defaults to the previous implementation (vector search).
The search will use vector search or hybrid search depending on the parameter.
