### PR TITLE
fix: Resolve streaming bug in MemoryWebClient

### DIFF
--- a/clients/dotnet/WebClient/MemoryWebClient.cs
+++ b/clients/dotnet/WebClient/MemoryWebClient.cs
@@ -368,7 +368,14 @@ public sealed class MemoryWebClient : IKernelMemory
         using StringContent content = new(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
 
         var url = Constants.HttpAskEndpoint.CleanUrlPath();
-        HttpResponseMessage response = await this._client.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
+        using HttpRequestMessage requestMessage = new(HttpMethod.Post, url)
+        {
+            Content = content
+        };
+        HttpCompletionOption completionOption = useStreaming
+            ? HttpCompletionOption.ResponseHeadersRead
+            : HttpCompletionOption.ResponseContentRead;
+        HttpResponseMessage response = await this._client.SendAsync(requestMessage, completionOption, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         if (useStreaming)

--- a/clients/dotnet/WebClient/MemoryWebClient.cs
+++ b/clients/dotnet/WebClient/MemoryWebClient.cs
@@ -368,13 +368,12 @@ public sealed class MemoryWebClient : IKernelMemory
         using StringContent content = new(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
 
         var url = Constants.HttpAskEndpoint.CleanUrlPath();
-        using HttpRequestMessage requestMessage = new(HttpMethod.Post, url)
-        {
-            Content = content
-        };
+        using var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Content = content;
         HttpCompletionOption completionOption = useStreaming
             ? HttpCompletionOption.ResponseHeadersRead
             : HttpCompletionOption.ResponseContentRead;
+
         HttpResponseMessage response = await this._client.SendAsync(requestMessage, completionOption, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 

--- a/clients/dotnet/WebClient/MemoryWebClient.cs
+++ b/clients/dotnet/WebClient/MemoryWebClient.cs
@@ -368,8 +368,8 @@ public sealed class MemoryWebClient : IKernelMemory
         using StringContent content = new(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
 
         var url = Constants.HttpAskEndpoint.CleanUrlPath();
-        using var request = new HttpRequestMessage(HttpMethod.Post, url);
-        request.Content = content;
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, url);
+        requestMessage.Content = content;
         HttpCompletionOption completionOption = useStreaming
             ? HttpCompletionOption.ResponseHeadersRead
             : HttpCompletionOption.ResponseContentRead;

--- a/extensions/AzureQueues/AzureQueuesPipeline.cs
+++ b/extensions/AzureQueues/AzureQueuesPipeline.cs
@@ -41,7 +41,7 @@ public sealed class AzureQueuesPipeline : IQueue
     // Queue client builder, requiring the queue name in input
     private readonly Func<string, QueueClient> _clientBuilder;
 
-    // Queue confirguration
+    // Queue configuration
     private readonly AzureQueuesConfig _config;
 
     // Queue client, once connected


### PR DESCRIPTION
- Changed from PostAsync to SendAsync for correct request handling.
- Adjusted HttpCompletionOption for proper streaming behavior.

## Motivation and Context (Why the change? What's the scenario?)
Resolves issue with previous streaming setup.

## High level description (Approach, Design)

Changed from PostAsync to SendAsync for correct request handling and added the HttpCompletionOption so the operation completes as soon as the initial headers are sent. 