### PR TITLE
Update AWS S3 Extension to allow for use of credential chain.

### DIFF
--- a/extensions/AWS/S3/AWSS3Config.cs
+++ b/extensions/AWS/S3/AWSS3Config.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Text.Json.Serialization;
 
@@ -13,6 +13,7 @@ public class AWSS3Config
     {
         Unknown = -1,
         AccessKey,
+        CredentialChain,
     }
 
     public AuthTypes Auth { get; set; } = AuthTypes.Unknown;
@@ -45,14 +46,17 @@ public class AWSS3Config
             throw new ConfigurationException($"Authentication type '{this.Auth}' undefined or not supported");
         }
 
-        if (string.IsNullOrWhiteSpace(this.AccessKey))
+        if (this.Auth == AuthTypes.AccessKey)
         {
-            throw new ConfigurationException("S3 Access Key is undefined");
-        }
+            if (string.IsNullOrWhiteSpace(this.AccessKey))
+            {
+                throw new ConfigurationException("S3 Access Key is undefined");
+            }
 
-        if (string.IsNullOrWhiteSpace(this.SecretAccessKey))
-        {
-            throw new ConfigurationException("S3 Secret Key Access undefined");
+            if (string.IsNullOrWhiteSpace(this.SecretAccessKey))
+            {
+                throw new ConfigurationException("S3 Secret Key Access undefined");
+            }
         }
 
         if (string.IsNullOrWhiteSpace(this.BucketName))

--- a/extensions/AWS/S3/AWSS3Storage.cs
+++ b/extensions/AWS/S3/AWSS3Storage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.Collections.Generic;
@@ -41,6 +41,15 @@ public sealed class AWSS3Storage : IDocumentStorage, IDisposable
                         LogResponse = true
                     }
                 );
+                break;
+            }
+            case AWSS3Config.AuthTypes.CredentialChain:
+            {
+                this._client = new AmazonS3Client(new AmazonS3Config
+                {
+                    ServiceURL = config.Endpoint,
+                    LogResponse = true
+                });
                 break;
             }
 

--- a/service/Service/appsettings.json
+++ b/service/Service/appsettings.json
@@ -242,6 +242,7 @@
         "HttpClientName": ""
       },
       "AWSS3": {
+        // "AccessKey" or "CredentialChain". For other options see <AWSS3Config>.
         "Auth": "AccessKey",
         // AccessKey ID, required when using AccessKey auth
         // Note: you can use an env var 'KernelMemory__Services__AWSS3__AccessKey' to set this


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
Allow the use of [instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for authentication and the proper use of [credential chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html).

## High level description (Approach, Design)
Added AWS S3 Extension CredentialChain authentication method to use default credentials
