### PR TITLE
Normalize text new line to Unix-style

### DIFF
--- a/applications/evaluation/Evaluators/Faithfulness/FaithfulnessEvaluator.cs
+++ b/applications/evaluation/Evaluators/Faithfulness/FaithfulnessEvaluator.cs
@@ -59,7 +59,7 @@ internal sealed class FaithfulnessEvaluator : EvaluationEngine
         {
             var evaluation = await this.FaithfulnessEvaluation.InvokeAsync(this._kernel, new KernelArguments
             {
-                { "context", string.Join(Environment.NewLine, answer.RelevantSources.SelectMany(c => c.Partitions.Select(p => p.Text))) },
+                { "context", string.Join('\n', answer.RelevantSources.SelectMany(c => c.Partitions.Select(p => p.Text))) },
                 { "answer", answer.Result },
                 { "statements", JsonSerializer.Serialize(extraction) }
             }).ConfigureAwait(false);

--- a/applications/evaluation/Evaluators/Relevance/RelevanceEvaluator.cs
+++ b/applications/evaluation/Evaluators/Relevance/RelevanceEvaluator.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics.Tensors;
@@ -68,7 +67,7 @@ internal sealed class RelevanceEvaluator : EvaluationEngine
             {
                 var extraction = await this.ExtractQuestion.InvokeAsync(this._kernel, new KernelArguments
                 {
-                    { "context", string.Join(Environment.NewLine, answer.RelevantSources.SelectMany(c => c.Partitions.Select(p => p.Text))) },
+                    { "context", string.Join('\n', answer.RelevantSources.SelectMany(c => c.Partitions.Select(p => p.Text))) },
                     { "answer", answer.Result }
                 }).ConfigureAwait(false);
 

--- a/extensions/Chunkers/Chunkers/MarkDownChunker.cs
+++ b/extensions/Chunkers/Chunkers/MarkDownChunker.cs
@@ -12,6 +12,7 @@ using System.Text;
 using Microsoft.KernelMemory.AI;
 using Microsoft.KernelMemory.Chunkers.internals;
 using Microsoft.KernelMemory.DataFormats;
+using Microsoft.KernelMemory.Text;
 
 namespace Microsoft.KernelMemory.Chunkers;
 
@@ -152,10 +153,7 @@ public class MarkDownChunker
         ArgumentNullException.ThrowIfNull(options);
 
         // Clean up text. Note: LLMs don't use \r char
-        text = text
-            .Replace("\r\n", "\n", StringComparison.OrdinalIgnoreCase)
-            .Replace("\r", "\n", StringComparison.OrdinalIgnoreCase)
-            .Trim();
+        text = text.NormalizeNewlines(true);
 
         // Calculate chunk size leaving room for the optional chunk header
         int maxChunk1Size = options.MaxTokensPerChunk - this.TokenCount(options.ChunkHeader);

--- a/extensions/Chunkers/Chunkers/PlainTextChunker.cs
+++ b/extensions/Chunkers/Chunkers/PlainTextChunker.cs
@@ -12,6 +12,7 @@ using System.Text;
 using Microsoft.KernelMemory.AI;
 using Microsoft.KernelMemory.Chunkers.internals;
 using Microsoft.KernelMemory.DataFormats;
+using Microsoft.KernelMemory.Text;
 
 namespace Microsoft.KernelMemory.Chunkers;
 
@@ -127,10 +128,7 @@ public class PlainTextChunker
         ArgumentNullException.ThrowIfNull(options);
 
         // Clean up text. Note: LLMs don't use \r char
-        text = text
-            .Replace("\r\n", "\n", StringComparison.OrdinalIgnoreCase)
-            .Replace("\r", "\n", StringComparison.OrdinalIgnoreCase)
-            .Trim();
+        text = text.NormalizeNewlines(true);
 
         // Calculate chunk size leaving room for the optional chunk header
         int maxChunk1Size = options.MaxTokensPerChunk - this.TokenCount(options.ChunkHeader);

--- a/extensions/Postgres/Postgres/PostgresMemory.cs
+++ b/extensions/Postgres/Postgres/PostgresMemory.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.AI;
 using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.KernelMemory.MemoryStorage;
+using Microsoft.KernelMemory.Text;
 using Pgvector;
 
 namespace Microsoft.KernelMemory.Postgres;
@@ -272,7 +273,7 @@ public sealed class PostgresMemory : IMemoryDb, IDisposable, IAsyncDisposable
         foreach (MemoryFilter filter in filters.Where(f => !f.IsEmpty()))
         {
             var andSql = new StringBuilder();
-            andSql.AppendLine("(");
+            andSql.AppendLineNix("(");
 
             if (filter is PostgresMemoryFilter)
             {
@@ -298,10 +299,10 @@ public sealed class PostgresMemory : IMemoryDb, IDisposable, IAsyncDisposable
                 //  $"{PostgresSchema.PlaceholdersTags} @> " + safeSqlPlaceholder
                 //  $"{PostgresSchema.PlaceholdersTags} @> " + safeSqlPlaceholder + "::text[]"
                 //  $"{PostgresSchema.PlaceholdersTags} @> ARRAY[" + safeSqlPlaceholder + "]::text[]"
-                andSql.AppendLine($"{PostgresSchema.PlaceholdersTags} @> " + safeSqlPlaceholder);
+                andSql.AppendLineNix($"{PostgresSchema.PlaceholdersTags} @> " + safeSqlPlaceholder);
             }
 
-            andSql.AppendLine(")");
+            andSql.AppendLineNix(")");
             orConditions.Add(andSql.ToString());
         }
 

--- a/service/Abstractions/HTTP/SSE.cs
+++ b/service/Abstractions/HTTP/SSE.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
+using Microsoft.KernelMemory.Text;
 
 namespace Microsoft.KernelMemory.HTTP;
 
@@ -39,7 +40,7 @@ public static class SSE
             }
             else
             {
-                buffer.AppendLine(line);
+                buffer.AppendLineNix(line);
             }
         }
 

--- a/service/Abstractions/Models/MemoryAnswer.cs
+++ b/service/Abstractions/Models/MemoryAnswer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.KernelMemory.Text;
 
 namespace Microsoft.KernelMemory;
 
@@ -92,7 +93,7 @@ public class MemoryAnswer
     public override string ToString()
     {
         var result = new StringBuilder();
-        result.AppendLine(this.Result);
+        result.AppendLineNix(this.Result);
 
         if (!this.NoResult && this.RelevantSources is { Count: > 0 })
         {
@@ -103,8 +104,8 @@ public class MemoryAnswer
                 sources[x.Index + x.Link] = $"  - {x.SourceName} [{date}]";
             }
 
-            result.AppendLine("- Sources:");
-            result.AppendLine(string.Join("\n", sources.Values));
+            result.AppendLineNix("- Sources:");
+            result.AppendLineNix(string.Join("\n", sources.Values));
         }
 
         return result.ToString();

--- a/service/Abstractions/Text/StringBuilderExtensions.cs
+++ b/service/Abstractions/Text/StringBuilderExtensions.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text;
+
+namespace Microsoft.KernelMemory.Text;
+
+public static class StringBuilderExtensions
+{
+    /// <summary>
+    /// Append line using Unix line ending "\n"
+    /// </summary>
+    public static void AppendLineNix(this StringBuilder sb)
+    {
+        sb.Append('\n');
+    }
+
+    /// <summary>
+    /// Append line using Unix line ending "\n"
+    /// </summary>
+    public static void AppendLineNix(this StringBuilder sb, string value)
+    {
+        sb.Append(value);
+        sb.Append('\n');
+    }
+
+    /// <summary>
+    /// Append line using Unix line ending "\n"
+    /// </summary>
+    public static void AppendLineNix(this StringBuilder sb, char value)
+    {
+        sb.Append(value);
+        sb.Append('\n');
+    }
+
+    /// <summary>
+    /// Append line using Unix line ending "\n"
+    /// </summary>
+    public static void AppendLineNix(this StringBuilder sb, StringBuilder value)
+    {
+        sb.Append(value);
+        sb.Append('\n');
+    }
+}

--- a/service/Abstractions/Text/StringExtensions.cs
+++ b/service/Abstractions/Text/StringExtensions.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.KernelMemory.Text;
+
+public static class StringExtensions
+{
+    public static string NormalizeNewlines(this string text, bool trim = false)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        // We won't need more than the original length
+        char[] buffer = new char[text.Length];
+        int bufferPos = 0;
+
+        // Skip leading whitespace if trimming
+        int i = 0;
+        if (trim)
+        {
+            while (i < text.Length && char.IsWhiteSpace(text[i])) { i++; }
+        }
+
+        // Tracks the last non-whitespace position written into buffer
+        int lastNonWhitespacePos = -1;
+
+        // Single pass: replace \r\n or \r with \n, record last non-whitespace
+        for (; i < text.Length; i++)
+        {
+            char c = text[i];
+
+            if (c == '\r')
+            {
+                // If \r\n then skip the \n
+                if (i + 1 < text.Length && text[i + 1] == '\n') { i++; }
+
+                // Write a single \n
+                buffer[bufferPos] = '\n';
+            }
+            else
+            {
+                buffer[bufferPos] = c;
+            }
+
+            // If trimming, update lastNonWhitespacePos only when char isn't whitespace
+            // If not trimming, always update because we keep everything
+            if (!trim || !char.IsWhiteSpace(buffer[bufferPos]))
+            {
+                lastNonWhitespacePos = bufferPos;
+            }
+
+            bufferPos++;
+        }
+
+        // Cut off trailing whitespace if trimming
+        // If every char was whitespace, lastNonWhitespacePos stays -1 and the result is an empty string
+        int finalLength = (trim && lastNonWhitespacePos >= 0)
+            ? lastNonWhitespacePos + 1
+            : bufferPos;
+
+        // Safety check if everything was trimmed away
+        if (finalLength < 0) { finalLength = 0; }
+
+        return new string(buffer, 0, finalLength);
+    }
+}

--- a/service/Core/DataFormats/Image/ImageDecoder.cs
+++ b/service/Core/DataFormats/Image/ImageDecoder.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.KernelMemory.Pipeline;
+using Microsoft.KernelMemory.Text;
 
 namespace Microsoft.KernelMemory.DataFormats.Image;
 
@@ -64,7 +65,7 @@ public sealed class ImageDecoder : IContentDecoder
 
         var result = new FileContent(MimeTypes.PlainText);
         var content = await this.ImageToTextAsync(data, cancellationToken).ConfigureAwait(false);
-        result.Sections.Add(new(content.Trim(), 1, Chunk.Meta(sentencesAreComplete: true)));
+        result.Sections.Add(new(content, 1, Chunk.Meta(sentencesAreComplete: true)));
 
         return result;
     }
@@ -87,10 +88,14 @@ public sealed class ImageDecoder : IContentDecoder
         }
     }
 
-    private Task<string> ImageToTextAsync(Stream data, CancellationToken cancellationToken = default)
+    private async Task<string> ImageToTextAsync(Stream data, CancellationToken cancellationToken = default)
     {
-        return this._ocrEngine is null
-            ? throw new NotSupportedException($"Image extraction not configured")
-            : this._ocrEngine.ExtractTextFromImageAsync(data, cancellationToken);
+        if (this._ocrEngine is null)
+        {
+            throw new NotSupportedException($"Image extraction not configured");
+        }
+
+        string text = await this._ocrEngine.ExtractTextFromImageAsync(data, cancellationToken).ConfigureAwait(false);
+        return text.NormalizeNewlines(true);
     }
 }

--- a/service/Core/DataFormats/Office/MsExcelDecoder.cs
+++ b/service/Core/DataFormats/Office/MsExcelDecoder.cs
@@ -11,6 +11,7 @@ using ClosedXML.Excel;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.KernelMemory.Pipeline;
+using Microsoft.KernelMemory.Text;
 
 namespace Microsoft.KernelMemory.DataFormats.Office;
 
@@ -61,7 +62,7 @@ public sealed class MsExcelDecoder : IContentDecoder
             worksheetNumber++;
             if (this._config.WithWorksheetNumber)
             {
-                sb.AppendLine(this._config.WorksheetNumberTemplate.Replace("{number}", $"{worksheetNumber}", StringComparison.OrdinalIgnoreCase));
+                sb.AppendLineNix(this._config.WorksheetNumberTemplate.Replace("{number}", $"{worksheetNumber}", StringComparison.OrdinalIgnoreCase));
             }
 
             var rowsUsed = worksheet.RangeUsed()?.RowsUsed();
@@ -142,12 +143,12 @@ public sealed class MsExcelDecoder : IContentDecoder
                     }
                 }
 
-                sb.AppendLine(this._config.RowSuffix);
+                sb.AppendLineNix(this._config.RowSuffix);
             }
 
             if (this._config.WithEndOfWorksheetMarker)
             {
-                sb.AppendLine(this._config.EndOfWorksheetMarkerTemplate.Replace("{number}", $"{worksheetNumber}", StringComparison.OrdinalIgnoreCase));
+                sb.AppendLineNix(this._config.EndOfWorksheetMarkerTemplate.Replace("{number}", $"{worksheetNumber}", StringComparison.OrdinalIgnoreCase));
             }
 
             string worksheetContent = sb.ToString().Trim();

--- a/service/Core/DataFormats/Office/MsExcelDecoder.cs
+++ b/service/Core/DataFormats/Office/MsExcelDecoder.cs
@@ -151,7 +151,7 @@ public sealed class MsExcelDecoder : IContentDecoder
                 sb.AppendLineNix(this._config.EndOfWorksheetMarkerTemplate.Replace("{number}", $"{worksheetNumber}", StringComparison.OrdinalIgnoreCase));
             }
 
-            string worksheetContent = sb.ToString().Trim();
+            string worksheetContent = sb.ToString().NormalizeNewlines(true);
             sb.Clear();
             result.Sections.Add(new Chunk(worksheetContent, worksheetNumber, Chunk.Meta(sentencesAreComplete: true)));
         }

--- a/service/Core/DataFormats/Office/MsPowerPointDecoder.cs
+++ b/service/Core/DataFormats/Office/MsPowerPointDecoder.cs
@@ -13,6 +13,7 @@ using DocumentFormat.OpenXml.Presentation;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.KernelMemory.Pipeline;
+using Microsoft.KernelMemory.Text;
 
 namespace Microsoft.KernelMemory.DataFormats.Office;
 
@@ -99,16 +100,16 @@ public sealed class MsPowerPointDecoder : IContentDecoder
                     // Prepend slide number before the slide text
                     if (this._config.WithSlideNumber)
                     {
-                        sb.AppendLine(this._config.SlideNumberTemplate.Replace("{number}", $"{slideNumber}", StringComparison.OrdinalIgnoreCase));
+                        sb.AppendLineNix(this._config.SlideNumberTemplate.Replace("{number}", $"{slideNumber}", StringComparison.OrdinalIgnoreCase));
                     }
 
                     sb.Append(currentSlideContent);
-                    sb.AppendLine();
+                    sb.AppendLineNix();
 
                     // Append the end of slide marker
                     if (this._config.WithEndOfSlideMarker)
                     {
-                        sb.AppendLine(this._config.EndOfSlideMarkerTemplate.Replace("{number}", $"{slideNumber}", StringComparison.OrdinalIgnoreCase));
+                        sb.AppendLineNix(this._config.EndOfSlideMarkerTemplate.Replace("{number}", $"{slideNumber}", StringComparison.OrdinalIgnoreCase));
                     }
                 }
 

--- a/service/Core/DataFormats/Office/MsPowerPointDecoder.cs
+++ b/service/Core/DataFormats/Office/MsPowerPointDecoder.cs
@@ -113,7 +113,7 @@ public sealed class MsPowerPointDecoder : IContentDecoder
                     }
                 }
 
-                string slideContent = sb.ToString().Trim();
+                string slideContent = sb.ToString().NormalizeNewlines(true);
                 sb.Clear();
                 result.Sections.Add(new Chunk(slideContent, slideNumber, Chunk.Meta(sentencesAreComplete: true)));
             }

--- a/service/Core/DataFormats/Office/MsWordDecoder.cs
+++ b/service/Core/DataFormats/Office/MsWordDecoder.cs
@@ -12,6 +12,7 @@ using DocumentFormat.OpenXml.Wordprocessing;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.KernelMemory.Pipeline;
+using Microsoft.KernelMemory.Text;
 
 namespace Microsoft.KernelMemory.DataFormats.Office;
 
@@ -85,7 +86,7 @@ public sealed class MsWordDecoder : IContentDecoder
                         pageNumber++;
                     }
 
-                    sb.AppendLine(p.InnerText);
+                    sb.AppendLineNix(p.InnerText);
                 }
             }
 

--- a/service/Core/DataFormats/Office/MsWordDecoder.cs
+++ b/service/Core/DataFormats/Office/MsWordDecoder.cs
@@ -80,7 +80,8 @@ public sealed class MsWordDecoder : IContentDecoder
                     var lastRenderedPageBreak = p.GetFirstChild<Run>()?.GetFirstChild<LastRenderedPageBreak>();
                     if (lastRenderedPageBreak != null)
                     {
-                        string pageContent = sb.ToString().Trim();
+                        // Note: no trimming, use original spacing when working with pages
+                        string pageContent = sb.ToString().NormalizeNewlines(false);
                         sb.Clear();
                         result.Sections.Add(new Chunk(pageContent, pageNumber, Chunk.Meta(sentencesAreComplete: true)));
                         pageNumber++;
@@ -90,7 +91,8 @@ public sealed class MsWordDecoder : IContentDecoder
                 }
             }
 
-            var lastPageContent = sb.ToString().Trim();
+            // Note: no trimming, use original spacing when working with pages
+            string lastPageContent = sb.ToString().NormalizeNewlines(false);
             result.Sections.Add(new Chunk(lastPageContent, pageNumber, Chunk.Meta(sentencesAreComplete: true)));
 
             return Task.FromResult(result);

--- a/service/Core/DataFormats/Pdf/PdfDecoder.cs
+++ b/service/Core/DataFormats/Pdf/PdfDecoder.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.KernelMemory.Pipeline;
+using Microsoft.KernelMemory.Text;
 using UglyToad.PdfPig;
 using UglyToad.PdfPig.Content;
 using UglyToad.PdfPig.DocumentLayoutAnalysis.TextExtractor;
@@ -56,8 +57,9 @@ public sealed class PdfDecoder : IContentDecoder
 
         foreach (Page? page in pdfDocument.GetPages().Where(x => x != null))
         {
-            // Note: no trimming, use original spacing
-            string pageContent = ContentOrderTextExtractor.GetText(page) ?? string.Empty;
+            // Note: no trimming, use original spacing when working with pages
+            string pageContent = ContentOrderTextExtractor.GetText(page).NormalizeNewlines(false) ?? string.Empty;
+
             result.Sections.Add(new Chunk(pageContent, page.Number, Chunk.Meta(sentencesAreComplete: false)));
         }
 

--- a/service/Core/DataFormats/WebPages/HtmlDecoder.cs
+++ b/service/Core/DataFormats/WebPages/HtmlDecoder.cs
@@ -9,6 +9,7 @@ using HtmlAgilityPack;
 using Microsoft.Extensions.Logging;
 using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.KernelMemory.Pipeline;
+using Microsoft.KernelMemory.Text;
 
 namespace Microsoft.KernelMemory.DataFormats.WebPages;
 
@@ -51,7 +52,7 @@ public sealed class HtmlDecoder : IContentDecoder
         var doc = new HtmlDocument();
         doc.Load(data);
 
-        result.Sections.Add(new Chunk(doc.DocumentNode.InnerText.Trim(), 1, Chunk.Meta(sentencesAreComplete: true)));
+        result.Sections.Add(new Chunk(doc.DocumentNode.InnerText.NormalizeNewlines(true), 1, Chunk.Meta(sentencesAreComplete: true)));
 
         return Task.FromResult(result);
     }

--- a/service/Core/Handlers/SummarizationHandler.cs
+++ b/service/Core/Handlers/SummarizationHandler.cs
@@ -13,6 +13,7 @@ using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.KernelMemory.Extensions;
 using Microsoft.KernelMemory.Pipeline;
 using Microsoft.KernelMemory.Prompts;
+using Microsoft.KernelMemory.Text;
 
 namespace Microsoft.KernelMemory.Handlers;
 
@@ -214,7 +215,7 @@ public sealed class SummarizationHandler : IPipelineStepHandler
                     newContent.Append(token);
                 }
 
-                newContent.AppendLine();
+                newContent.AppendLineNix();
             }
 
             content = newContent.ToString();

--- a/service/Core/Handlers/SummarizationParallelHandler.cs
+++ b/service/Core/Handlers/SummarizationParallelHandler.cs
@@ -12,6 +12,7 @@ using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.KernelMemory.Extensions;
 using Microsoft.KernelMemory.Pipeline;
 using Microsoft.KernelMemory.Prompts;
+using Microsoft.KernelMemory.Text;
 
 namespace Microsoft.KernelMemory.Handlers;
 
@@ -188,7 +189,7 @@ public sealed class SummarizationParallelHandler : IPipelineStepHandler
                     newContent.Append(token);
                 }
 
-                newContent.AppendLine();
+                newContent.AppendLineNix();
             }
 
             content = newContent.ToString();

--- a/service/Core/Handlers/TextExtractionHandler.cs
+++ b/service/Core/Handlers/TextExtractionHandler.cs
@@ -12,6 +12,7 @@ using Microsoft.KernelMemory.DataFormats;
 using Microsoft.KernelMemory.DataFormats.WebPages;
 using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.KernelMemory.Pipeline;
+using Microsoft.KernelMemory.Text;
 
 namespace Microsoft.KernelMemory.Handlers;
 
@@ -224,8 +225,8 @@ public sealed class TextExtractionHandler : IPipelineStepHandler, IDisposable
             // Add a clean page separation
             if (section.SentencesAreComplete)
             {
-                textBuilder.AppendLine();
-                textBuilder.AppendLine();
+                textBuilder.AppendLineNix();
+                textBuilder.AppendLineNix();
             }
         }
 

--- a/service/tests/Abstractions.UnitTests/Text/StringExtensionsTest.cs
+++ b/service/tests/Abstractions.UnitTests/Text/StringExtensionsTest.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.KernelMemory.Text;
+
+namespace Microsoft.KM.Abstractions.UnitTests.Text;
+
+public class StringExtensionsTest
+{
+    [Theory]
+    [Trait("Category", "UnitTest")]
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    [InlineData(" ", " ")]
+    [InlineData("\n", "\n")]
+    [InlineData("\r", "\n")] // Old Mac
+    [InlineData("\r\n", "\n")] // Windows
+    [InlineData("\n\r", "\n\n")] // Not standard, that's 2 line endings
+    [InlineData("\n\n\n", "\n\n\n")]
+    [InlineData("\r\r\r", "\n\n\n")]
+    [InlineData("\r\r\n\r", "\n\n\n")]
+    [InlineData("\n\r\n\r", "\n\n\n")]
+    [InlineData("ciao", "ciao")]
+    [InlineData("ciao ", "ciao ")]
+    [InlineData(" ciao ", " ciao ")]
+    [InlineData("\r ciao ", "\n ciao ")]
+    [InlineData(" \rciao ", " \nciao ")]
+    [InlineData(" \r\nciao ", " \nciao ")]
+    [InlineData(" \r\nciao\n ", " \nciao\n ")]
+    [InlineData(" \r\nciao \n", " \nciao \n")]
+    [InlineData(" \r\nciao \r", " \nciao \n")]
+    [InlineData(" \r\nciao \rn", " \nciao \nn")]
+    public void ItNormalizesLineEndings(string? input, string? expected)
+    {
+        // Act
+#pragma warning disable CS8604 // it's an extension method, internally it handles the null scenario
+        string actual = input.NormalizeNewlines();
+#pragma warning restore CS8604
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [Trait("Category", "UnitTest")]
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    [InlineData(" ", "")]
+    [InlineData("\n", "")]
+    [InlineData("\r", "")]
+    [InlineData("\r\n", "")]
+    [InlineData("\n\r", "")]
+    [InlineData("\n\n\n", "")]
+    [InlineData("\r\r\r", "")]
+    [InlineData("\r\r\n\r", "")]
+    [InlineData("\n\r\n\r", "")]
+    [InlineData("ciao", "ciao")]
+    [InlineData("ciao ", "ciao")]
+    [InlineData(" ciao ", "ciao")]
+    [InlineData("\r ciao ", "ciao")]
+    [InlineData(" \rciao ", "ciao")]
+    [InlineData(" \r\nciao ", "ciao")]
+    [InlineData(" \r\nciao\n ", "ciao")]
+    [InlineData(" \r\nciao \n", "ciao")]
+    [InlineData(" \r\nciao \r", "ciao")]
+    [InlineData(" \r\nciao \rn", "ciao \nn")]
+    [InlineData(" \r\nc\ri\ra\no \r", "c\ni\na\no")]
+    [InlineData(" \r\nc\r\ni\n\na\r\ro \r", "c\ni\n\na\n\no")]
+    [InlineData(" \r\nccc\r\ni\n\naaa\r\ro \r", "ccc\ni\n\naaa\n\no")]
+    public void ItCanTrimWhileNormalizingLineEndings(string? input, string? expected)
+    {
+        // Act
+#pragma warning disable CS8604 // it's an extension method, internally it handles the null scenario
+        string actual = input.NormalizeNewlines(true);
+#pragma warning restore CS8604
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
Make text more consistent across Unix and Windows environments, avoiding the `\r` character in favor of the Unix new line ending.

See https://github.com/microsoft/kernel-memory/issues/975