### PR TITLE
Install ICU in Docker image to support SQL Server memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,16 @@ RUN \
     # Allow user to access the build
     chown -R $USER.$USER /app
 
+# Use of Microsoft.Data.SqlClient requires ICU to be installed
+# https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md
+ENV \
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
+RUN apk add --no-cache \
+    icu-data-full \
+    icu-libs
+
 COPY --from=build --chown=km:km --chmod=0550 /app/publish .
 
 #########################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,17 +38,12 @@ RUN \
     #Debian: useradd --create-home --user-group $USER --shell /bin/bash && \
     adduser -D -h /app -s /bin/sh $USER && \
     # Allow user to access the build
-    chown -R $USER.$USER /app
+    chown -R $USER:$USER /app
 
 # Use of Microsoft.Data.SqlClient requires ICU to be installed
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md
-ENV \
-    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8
-RUN apk add --no-cache \
-    icu-data-full \
-    icu-libs
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+RUN apk add --no-cache icu-libs
 
 COPY --from=build --chown=km:km --chmod=0550 /app/publish .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /app
 RUN \
     # Create user
     #Debian: useradd --create-home --user-group $USER --shell /bin/bash && \
-    adduser -D -h /app -s /bin/sh $USER && \
+    adduser --disabled-password --home /app --shell /bin/sh $USER && \
     # Allow user to access the build
     chown -R $USER:$USER /app && \
     # Install icu-libs for Microsoft.Data.SqlClient

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,9 @@ RUN \
     #Debian: useradd --create-home --user-group $USER --shell /bin/bash && \
     adduser -D -h /app -s /bin/sh $USER && \
     # Allow user to access the build
-    chown -R $USER:$USER /app
-
-# Use of Microsoft.Data.SqlClient requires ICU to be installed
-# https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
-RUN apk add --no-cache icu-libs
+    chown -R $USER:$USER /app && \
+    # Install icu-libs for Microsoft.Data.SqlClient
+    apk add --no-cache icu-libs
 
 COPY --from=build --chown=km:km --chmod=0550 /app/publish .
 
@@ -55,6 +52,9 @@ LABEL org.opencontainers.image.authors="Devis Lucato, https://github.com/dluc"
 
 # Define current user
 USER $USER
+
+# Disable globalization invariant mode for Microsoft.Data.SqlClient
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
 # Used by .NET and KM to load appsettings.Production.json
 ENV ASPNETCORE_ENVIRONMENT=Production


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

SQL Server memory cannot be configured when using the Docker image because it depends on ICU which is not installed in the `dotnet/aspnet:alpine` image. This results in a `System.NotSupportedException` being thrown at runtime when `SqlConnection` attempts to open a connection.

```
System.NotSupportedException: Globalization Invariant Mode is not supported.
    at Microsoft.Data.SqlClient.SqlConnection.TryOpen(TaskCompletionSource`1 retry, SqlConnectionOverrides overrides)
    at Microsoft.Data.SqlClient.SqlConnection.InternalOpenAsync(CancellationToken cancellationToken)
```

## High level description (Approach, Design)

Update the `Dockerfile` to install `icu-libs` and set the `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT` environment variable as outlined in the [Enabling (or disabling) globalization functionality](https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md) document.

This problem is discussed extensively in dotnet/SqlClient#220.

Building the Docker image was also failing in Docker Desktop on Windows because of the separator used in the `chown` command. This has been changed from `.` to `:` which should provide greater compatibility.

https://www.gnu.org/software/coreutils/manual/html_node/chown-invocation.html#chown-invocation

>  Some older scripts may still use `.` in place of the `:` separator. POSIX 1003.1-2001 (see [Standards conformance](https://www.gnu.org/software/coreutils/manual/html_node/Standards-conformance.html)) does not require support for that, but for backward compatibility GNU chown supports `.` so long as no ambiguity results, although it issues a warning and support may be removed in future versions. New scripts should avoid the use of `.` because it is not portable, and because it has undesirable results if the entire owner`.`group happens to identify a user whose name contains `.`.