### PR TITLE
Rename pipeline status methods for clarity and consistency

### DIFF
--- a/service/Abstractions/Pipeline/IPipelineOrchestrator.cs
+++ b/service/Abstractions/Pipeline/IPipelineOrchestrator.cs
@@ -61,22 +61,22 @@ public interface IPipelineOrchestrator
     Task RunPipelineAsync(DataPipeline pipeline, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Fetch the pipeline status from storage
+    /// Get pipeline from storage
     /// </summary>
     /// <param name="index">Index where memory is stored</param>
     /// <param name="documentId">Id of the document and pipeline execution instance</param>
     /// <param name="cancellationToken">Async task cancellation token</param>
-    /// <returns>Pipeline status if available</returns>
-    Task<DataPipeline?> ReadPipelineStatusAsync(string index, string documentId, CancellationToken cancellationToken = default);
+    /// <returns>Pipeline if available</returns>
+    Task<DataPipeline?> GetPipelineAsync(string index, string documentId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Fetch the pipeline status from storage
+    /// Get pipeline status from storage
     /// </summary>
     /// <param name="index">Index where memory is stored</param>
     /// <param name="documentId">Id of the document and pipeline execution instance</param>
     /// <param name="cancellationToken">Async task cancellation token</param>
     /// <returns>Pipeline status if available</returns>
-    Task<DataPipelineStatus?> ReadPipelineSummaryAsync(string index, string documentId, CancellationToken cancellationToken = default);
+    Task<DataPipelineStatus?> GetPipelineStatusAsync(string index, string documentId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Check if a document ID exists in a user memory and is ready for usage.

--- a/service/Core/MemoryServerless.cs
+++ b/service/Core/MemoryServerless.cs
@@ -208,8 +208,7 @@ public sealed class MemoryServerless : IKernelMemory
         index = IndexName.CleanName(index, this._defaultIndexName);
         try
         {
-            DataPipeline? pipeline = await this._orchestrator.ReadPipelineStatusAsync(index: index, documentId, cancellationToken).ConfigureAwait(false);
-            return pipeline?.ToDataPipelineStatus();
+            return await this._orchestrator.GetPipelineStatusAsync(index: index, documentId, cancellationToken).ConfigureAwait(false); ;
         }
         catch (PipelineNotFoundException)
         {

--- a/service/Core/MemoryService.cs
+++ b/service/Core/MemoryService.cs
@@ -181,7 +181,7 @@ public sealed class MemoryService : IKernelMemory
         CancellationToken cancellationToken = default)
     {
         index = IndexName.CleanName(index, this._defaultIndexName);
-        return this._orchestrator.ReadPipelineSummaryAsync(index: index, documentId, cancellationToken);
+        return this._orchestrator.GetPipelineStatusAsync(index: index, documentId, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/service/Core/Pipeline/BaseOrchestrator.cs
+++ b/service/Core/Pipeline/BaseOrchestrator.cs
@@ -155,7 +155,7 @@ public abstract class BaseOrchestrator : IPipelineOrchestrator, IDisposable
     }
 
     ///<inheritdoc />
-    public async Task<DataPipeline?> ReadPipelineStatusAsync(string index, string documentId, CancellationToken cancellationToken = default)
+    public async Task<DataPipeline?> GetPipelineAsync(string index, string documentId, CancellationToken cancellationToken = default)
     {
         index = IndexName.CleanName(index, this._defaultIndexName);
 
@@ -193,13 +193,13 @@ public abstract class BaseOrchestrator : IPipelineOrchestrator, IDisposable
     }
 
     ///<inheritdoc />
-    public async Task<DataPipelineStatus?> ReadPipelineSummaryAsync(string index, string documentId, CancellationToken cancellationToken = default)
+    public async Task<DataPipelineStatus?> GetPipelineStatusAsync(string index, string documentId, CancellationToken cancellationToken = default)
     {
         index = IndexName.CleanName(index, this._defaultIndexName);
 
         try
         {
-            DataPipeline? pipeline = await this.ReadPipelineStatusAsync(index: index, documentId: documentId, cancellationToken).ConfigureAwait(false);
+            DataPipeline? pipeline = await this.GetPipelineAsync(index: index, documentId: documentId, cancellationToken).ConfigureAwait(false);
             return pipeline?.ToDataPipelineStatus();
         }
         catch (PipelineNotFoundException)
@@ -216,7 +216,7 @@ public abstract class BaseOrchestrator : IPipelineOrchestrator, IDisposable
         try
         {
             this.Log.LogDebug("Checking if document {Id} on index {Index} is ready", documentId, index);
-            DataPipeline? pipeline = await this.ReadPipelineStatusAsync(index: index, documentId, cancellationToken).ConfigureAwait(false);
+            DataPipeline? pipeline = await this.GetPipelineAsync(index: index, documentId, cancellationToken).ConfigureAwait(false);
 
             if (pipeline == null)
             {
@@ -396,7 +396,7 @@ public abstract class BaseOrchestrator : IPipelineOrchestrator, IDisposable
         DataPipeline? previousPipeline;
         try
         {
-            previousPipeline = await this.ReadPipelineStatusAsync(currentPipeline.Index, currentPipeline.DocumentId, cancellationToken).ConfigureAwait(false);
+            previousPipeline = await this.GetPipelineAsync(currentPipeline.Index, currentPipeline.DocumentId, cancellationToken).ConfigureAwait(false);
         }
         catch (PipelineNotFoundException)
         {

--- a/service/Core/Pipeline/DistributedPipelineOrchestrator.cs
+++ b/service/Core/Pipeline/DistributedPipelineOrchestrator.cs
@@ -99,7 +99,7 @@ public sealed class DistributedPipelineOrchestrator : BaseOrchestrator
             DataPipeline? pipeline;
             try
             {
-                pipeline = await this.ReadPipelineStatusAsync(pipelinePointer.Index, pipelinePointer.DocumentId, cancellationToken).ConfigureAwait(false);
+                pipeline = await this.GetPipelineAsync(pipelinePointer.Index, pipelinePointer.DocumentId, cancellationToken).ConfigureAwait(false);
             }
             catch (PipelineNotFoundException)
             {


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

1. The ReadPipelineStatusAsync returns a DataPipeline instead of a DataPipelineStatus.
2. The ReadPipelineSummaryAsync returns a DataPipelineStatus instead of Summary (I guess Status was called Summary before).

## High level description (Approach, Design)

1. ReadPipelineStatusAsync renamed to GetPipelineAsync.
2. ReadPipelineSummaryAsync renamed to GetPipelineStatusAsync.

The references to those methods have been changed accordingly.
