### PR TITLE
Add ForcePathStyle support to AWSS3Config for MinIO compatibility

### DIFF
--- a/extensions/AWS/S3/AWSS3Config.cs
+++ b/extensions/AWS/S3/AWSS3Config.cs
@@ -39,6 +39,12 @@ public class AWSS3Config
     /// </summary>
     public string BucketName { get; set; } = string.Empty;
 
+    /// <summary>
+    /// When true, uses path-style addressing for S3 requests (e.g., https://s3.example.com/bucket-name/object).
+    /// This is required for S3-compatible services like MinIO that do not support virtual-hosted–style URLs.
+    /// </summary>
+    public bool ForcePathStyle { get; set; } = false;
+
     public void Validate()
     {
         if (this.Auth == AuthTypes.Unknown)

--- a/extensions/AWS/S3/AWSS3Storage.cs
+++ b/extensions/AWS/S3/AWSS3Storage.cs
@@ -37,6 +37,7 @@ public sealed class AWSS3Storage : IDocumentStorage, IDisposable
                     awsSecretAccessKey: config.SecretAccessKey,
                     clientConfig: new AmazonS3Config
                     {
+                        ForcePathStyle = config.ForcePathStyle,
                         ServiceURL = config.Endpoint,
                         LogResponse = true
                     }
@@ -47,6 +48,7 @@ public sealed class AWSS3Storage : IDocumentStorage, IDisposable
             {
                 this._client = new AmazonS3Client(new AmazonS3Config
                 {
+                    ForcePathStyle = config.ForcePathStyle,
                     ServiceURL = config.Endpoint,
                     LogResponse = true
                 });


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
This PR adds support for `ForcePathStyle` configuration in `AWSS3Config`

## High level description (Approach, Design)

- Added a `ForcePathStyle` boolean property to `AWSS3Config` (default: `false`)
- Updated `AWSS3Storage` to pass the value to the `AmazonS3Config.ForcePathStyle` property
- Maintains backward compatibility with AWS S3 by leaving the default behavior unchanged
- Improves compatibility with services like MinIO, LocalStack, and others that require path-style requests

This change is fully backward compatible and has no effect on current configurations unless explicitly enabled.