### PR TITLE
Fix upload OpenAPI specs of “tags” and “steps” fields

### DIFF
--- a/service/Service.AspNetCore/WebAPIEndpoints.cs
+++ b/service/Service.AspNetCore/WebAPIEndpoints.cs
@@ -20,6 +20,7 @@ using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.KernelMemory.DocumentStorage;
 using Microsoft.KernelMemory.HTTP;
 using Microsoft.KernelMemory.Service.AspNetCore.Models;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.KernelMemory.Service.AspNetCore;
@@ -108,8 +109,7 @@ public static class WebAPIEndpoints
             })
             .WithName("UploadDocument")
             .WithDisplayName("UploadDocument")
-            .WithOpenApi(
-                operation =>
+            .WithOpenApi(operation =>
                 {
                     operation.Summary = "Upload a new document to the knowledge base";
                     operation.Description = "Upload a document consisting of one or more files to extract memories from. The extraction process happens asynchronously. If a document with the same ID already exists, it will be overwritten and the memories previously extracted will be updated.";
@@ -136,15 +136,27 @@ public static class WebAPIEndpoints
                                         },
                                         ["tags"] = new OpenApiSchema
                                         {
-                                            Type = "object",
-                                            AdditionalProperties = new OpenApiSchema { Type = "string" },
-                                            Description = "Tags to apply to the memories extracted from the files."
+                                            Type = "array",
+                                            Items = new OpenApiSchema { Type = "string" },
+                                            Description = "Tags to apply to the memories extracted from the files.",
+                                            Example = new OpenApiArray
+                                            {
+                                                new OpenApiString("group:abc123"),
+                                                new OpenApiString("user:xyz")
+                                            }
                                         },
                                         ["steps"] = new OpenApiSchema
                                         {
                                             Type = "array",
                                             Items = new OpenApiSchema { Type = "string" },
-                                            Description = "How to process the files, e.g. how to extract/chunk etc."
+                                            Description = "How to process the files, e.g. how to extract/chunk etc.",
+                                            Example = new OpenApiArray
+                                            {
+                                                new OpenApiString("extract"),
+                                                new OpenApiString("partition"),
+                                                new OpenApiString("gen_embeddings"),
+                                                new OpenApiString("save_records"),
+                                            }
                                         },
                                         ["files"] = new OpenApiSchema
                                         {
@@ -157,6 +169,11 @@ public static class WebAPIEndpoints
                                             Description = "Files to process and extract memories from."
                                         }
                                     }
+                                },
+                                Encoding =
+                                {
+                                    { "tags", new OpenApiEncoding { Explode = true } },
+                                    { "steps", new OpenApiEncoding { Explode = true } },
                                 }
                             }
                         },

--- a/swagger.json
+++ b/swagger.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Microsoft.KernelMemory.ServiceAssembly",
     "version": "1.0"
@@ -113,18 +113,28 @@
                     "description": "Unique ID used for import pipeline and document ID."
                   },
                   "tags": {
-                    "type": "object",
-                    "additionalProperties": {
+                    "type": "array",
+                    "items": {
                       "type": "string"
                     },
-                    "description": "Tags to apply to the memories extracted from the files."
+                    "description": "Tags to apply to the memories extracted from the files.",
+                    "example": [
+                      "group:abc123",
+                      "user:xyz"
+                    ]
                   },
                   "steps": {
                     "type": "array",
                     "items": {
                       "type": "string"
                     },
-                    "description": "How to process the files, e.g. how to extract/chunk etc."
+                    "description": "How to process the files, e.g. how to extract/chunk etc.",
+                    "example": [
+                      "extract",
+                      "partition",
+                      "gen_embeddings",
+                      "save_records"
+                    ]
                   },
                   "files": {
                     "type": "array",
@@ -134,6 +144,14 @@
                     },
                     "description": "Files to process and extract memories from."
                   }
+                }
+              },
+              "encoding": {
+                "tags": {
+                  "explode": true
+                },
+                "steps": {
+                  "explode": true
                 }
               }
             }

--- a/tools/km-cli/upload-file.sh
+++ b/tools/km-cli/upload-file.sh
@@ -56,7 +56,7 @@ readParameters() {
             ;;
             -t)
                 shift
-                TAGS="$TAGS $1"
+                TAGS+=("$1")
             ;;
             *)
                 help
@@ -102,7 +102,17 @@ readParameters "$@"
 validateParameters
 
 # Prepare curl command
-CMD="curl -v -F 'file1=@\"${FILENAME}\"' -F 'index=\"${INDEXNAME}\"' -F 'documentId=\"${DOCUMENT_ID}\"' -F 'tags=\"${TAGS}\"'"
+CMD="curl -v"
+CMD="$CMD -F file1=@\"${FILENAME}\""
+
+# Optianal params
+[ -n "$INDEXNAME" ] && CMD="$CMD -F index=\"${INDEXNAME}\""
+[ -n "$DOCUMENT_ID" ] && CMD="$CMD -F documentId=\"${DOCUMENT_ID}\""
+
+# Add tags
+for TAG in "${TAGS[@]}"; do
+    CMD="$CMD -F tags=\"$TAG\""
+done
 
 # Add URL
 CMD="$CMD $SERVICE_URL/upload"


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

OpenAPI specs incorrectly mapping "tags" to an object, and missing the "explode" encoding for "steps" and "tags". This was also making Swagger UI unusable for the upload endpoint.

## High level description (Approach, Design)

Fix specs, swagger.json in the root file, and update the same bash script under /tools/