### PR TITLE
Use Qdrant.Client for QdrantMemory internals

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,6 +34,7 @@
     <PackageVersion Include="OllamaSharp" Version="5.1.14" />
     <PackageVersion Include="PdfPig" Version="0.1.10" />
     <PackageVersion Include="Polly.Core" Version="8.5.2" />
+    <PackageVersion Include="Qdrant.Client" Version="1.14.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
     <PackageVersion Include="ReadLine" Version="2.0.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.1" />

--- a/extensions/Qdrant/Qdrant.FunctionalTests/appsettings.json
+++ b/extensions/Qdrant/Qdrant.FunctionalTests/appsettings.json
@@ -6,7 +6,7 @@
     },
     "Services": {
       "Qdrant": {
-        "Endpoint": "http://127.0.0.1:6333",
+        "Endpoint": "http://127.0.0.1:6334",
         "APIKey": ""
       },
       "OpenAI": {

--- a/extensions/Qdrant/Qdrant/Internals/QdrantFilter.cs
+++ b/extensions/Qdrant/Qdrant/Internals/QdrantFilter.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using Qdrant.Client.Grpc;
+
+namespace Microsoft.KernelMemory.MemoryDb.Qdrant.Client;
+
+internal static class QdrantFilter
+{
+    public static Filter? BuildFilter(IEnumerable<IEnumerable<string>?>? tagGroups)
+    {
+        if (tagGroups == null)
+        {
+            return null;
+        }
+
+        var list = tagGroups.ToList();
+        var filter = new Filter();
+
+        if (list.Count < 2)
+        {
+            var tags = list.FirstOrDefault();
+            if (tags == null)
+            {
+                return null;
+            }
+
+            filter.Must.AddRange(tags.Where(t => !string.IsNullOrEmpty(t)).Select(t => Conditions.MatchText("tags", t)));
+            return filter;
+        }
+
+        var orFilter = new Filter();
+        foreach (var tags in list)
+        {
+            if (tags == null)
+            {
+                continue;
+            }
+
+            var andFilter = new Filter();
+            andFilter.Must.AddRange(tags.Where(t => !string.IsNullOrEmpty(t)).Select(t => Conditions.MatchText("tags", t)));
+            orFilter.Should.Add(Conditions.Filter(andFilter));
+        }
+
+        filter.Must.Add(Conditions.Filter(orFilter));
+        return filter;
+    }
+}

--- a/extensions/Qdrant/Qdrant/Internals/QdrantPointStruct.cs
+++ b/extensions/Qdrant/Qdrant/Internals/QdrantPointStruct.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Google.Protobuf;
+using Microsoft.KernelMemory.MemoryStorage;
+using Qdrant.Client.Grpc;
+
+namespace Microsoft.KernelMemory.MemoryDb.Qdrant.Client;
+
+internal static class QdrantPointStruct
+{
+    private const string Id = "id";
+    private const string Tags = "tags";
+    private const string Payload = "payload";
+
+    public static PointStruct FromMemoryRecord(MemoryRecord record)
+    {
+        return new PointStruct
+        {
+            Vectors = new Vectors { Vector = new Vector { Data = { record.Vector.Data.ToArray() } } },
+            Payload =
+            {
+                [Id] = record.Id,
+                [Tags] = record.Tags.Pairs.Select(tag => $"{tag.Key}{Constants.ReservedEqualsChar}{tag.Value}").ToArray(),
+                [Payload] = Value.Parser.ParseJson(JsonSerializer.Serialize(record.Payload, QdrantConfig.JSONOptions)),
+            }
+        };
+    }
+
+    public static MemoryRecord ToMemoryRecord(ScoredPoint scoredPoint, bool withEmbedding = true)
+    {
+        MemoryRecord result = new()
+        {
+            Id = scoredPoint.Id.Uuid,
+            Payload = scoredPoint.Payload.TryGetValue(Payload, out var payload)
+                ? JsonSerializer.Deserialize<Dictionary<string, object>>(JsonFormatter.Default.Format(payload.StructValue), QdrantConfig.JSONOptions) ?? []
+                : []
+        };
+
+        if (withEmbedding)
+        {
+            result.Vector = new Embedding(scoredPoint.Vectors.Vector.Data.ToArray());
+        }
+
+        foreach (string[] keyValue in scoredPoint.Payload[Tags].ListValue.Values.Select(tag => tag.StringValue.Split(Constants.ReservedEqualsChar, 2)))
+        {
+            string key = keyValue[0];
+            string? value = keyValue.Length == 1 ? null : keyValue[1];
+            result.Tags.Add(key, value);
+        }
+
+        return result;
+    }
+
+    public static MemoryRecord ToMemoryRecord(RetrievedPoint retrievedPoint, bool withEmbedding = true)
+    {
+        MemoryRecord result = new()
+        {
+            Id = retrievedPoint.Id.Uuid,
+            Payload = retrievedPoint.Payload.TryGetValue(Payload, out var payload)
+                ? JsonSerializer.Deserialize<Dictionary<string, object>>(JsonFormatter.Default.Format(payload.StructValue), QdrantConfig.JSONOptions) ?? []
+                : []
+        };
+
+        if (withEmbedding)
+        {
+            result.Vector = new Embedding(retrievedPoint.Vectors.Vector.Data.ToArray());
+        }
+
+        foreach (string[] keyValue in retrievedPoint.Payload[Tags].ListValue.Values.Select(tag => tag.StringValue.Split(Constants.ReservedEqualsChar, 2)))
+        {
+            string key = keyValue[0];
+            string? value = keyValue.Length == 1 ? null : keyValue[1];
+            result.Tags.Add(key, value);
+        }
+
+        return result;
+    }
+}

--- a/extensions/Qdrant/Qdrant/Qdrant.csproj
+++ b/extensions/Qdrant/Qdrant/Qdrant.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="System.Linq.Async" />
+        <PackageReference Include="Qdrant.Client"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This commit updates QdrantMemory to use the official Qdrant client for QdrantMemory internals.

I wanted to open a PR at this stage to gauge interest in this change. Further work needed to remove the current client implementation and to test adapters between Kernel memory and Qdrant client is needed.

<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

- The official client uses gRPC rather than JSON over REST, with gRPC typically offering a significant overall performance improvement.
- Official client is maintained by Qdrant, reducing code needing to be maintained in this repository to interface with Qdrant

## High level description (Approach, Design)

- Replace the internal qdrant client implementation with the official Qdrant client, mapping the current client's implementation to methods of the official client.
- Adapt kernel memory types like `MemoryRecord` to Qdrant types. There may be opportunities to make this smoother.

