### PR TITLE
Limit GetSimilarRecordsList by index.

### DIFF
--- a/extensions/SQLServer/SQLServer/QueryProviders/VectorQueryProvider.cs
+++ b/extensions/SQLServer/SQLServer/QueryProviders/VectorQueryProvider.cs
@@ -139,6 +139,7 @@ internal sealed class VectorQueryProvider : ISqlServerQueryProvider
                        {this.GetFullTableName(this._config.MemoryTableName)}
                    WHERE
                        VECTOR_DISTANCE('cosine', CAST(@vector AS VECTOR({this._config.VectorSize})), Embedding) <= @max_distance
+                       AND {this.GetFullTableName(this._config.MemoryTableName)}.[collection] = @index
                        {generatedFilters}
                    ORDER BY [distance] ASC
                    """;


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)
For SQL Server 2025, the PrepareGetSimilarRecordsListQuery() method produces a query that does not account for the index that is being searched.  This only happens when NativeVectorSearch is true and the VectorQueryProvider is used.  The DefaultQueryProvider does not suffer from the same problem (though may benefit from the same fix performance-wise)  because it links to tables that are index-specific, like [{embeddingstable}_{index}] which naturally limits the memories via the inner join.

## High level description (Approach, Design)
Simply add in the [collection]=@index criteria.
