### PR TITLE
Added await when calling async DecodeAsync method with disposable item.

### DIFF
--- a/examples/205-dotnet-extract-text-from-docs/Program.cs
+++ b/examples/205-dotnet-extract-text-from-docs/Program.cs
@@ -3,6 +3,7 @@
 using Microsoft.KernelMemory.DataFormats;
 using Microsoft.KernelMemory.DataFormats.Office;
 using Microsoft.KernelMemory.DataFormats.Pdf;
+using Microsoft.KernelMemory.DataFormats.Text;
 using Microsoft.KernelMemory.Pipeline;
 
 FileContent content = new(MimeTypes.PlainText);
@@ -94,6 +95,27 @@ Console.WriteLine("=== Text in file2.pdf ===");
 Console.WriteLine("=========================");
 
 content = await pdfDecoder.DecodeAsync("file2.pdf");
+
+foreach (Chunk section in content.Sections)
+{
+    Console.WriteLine($"Page: {section.Number}/{content.Sections.Count}");
+    Console.WriteLine(section.Content);
+    Console.WriteLine("-----");
+}
+
+Console.WriteLine("============================");
+Console.WriteLine("Press a Enter to continue...");
+Console.ReadLine();
+
+
+// ===================================================================================================================
+// Markdown
+Console.WriteLine("===========================");
+Console.WriteLine("=== Text in markdown.md ===");
+Console.WriteLine("===========================");
+
+var mdDecoder = new MarkDownDecoder();
+content = await mdDecoder.DecodeAsync("markdown.md");
 
 foreach (Chunk section in content.Sections)
 {

--- a/examples/205-dotnet-extract-text-from-docs/markdown.md
+++ b/examples/205-dotnet-extract-text-from-docs/markdown.md
@@ -1,0 +1,22 @@
+﻿Kernel Memory
+=============
+
+This repository presents best practices and a reference implementation for Memory in specific AI
+and LLMs application scenarios. Please note that **the code provided serves as a demonstration**
+and is **not an officially supported** Microsoft offering.
+
+**Kernel Memory** (KM) is a **multi-modal [AI Service](service/Service/README.md)** specialized
+in the efficient indexing of datasets through custom continuous data hybrid pipelines, with support
+for **[Retrieval Augmented Generation](https://en.wikipedia.org/wiki/Prompt_engineering#Retrieval-augmented_generation)**
+(RAG), synthetic memory, prompt engineering, and custom semantic memory processing.
+
+KM is available as a **Web Service**, as a **[Docker container](https://hub.docker.com/r/kernelmemory/service)**,
+a **[Plugin](https://learn.microsoft.com/copilot/plugins/overview)** for ChatGPT/Copilot/Semantic
+Kernel, and as a .NET library for embedded applications.
+
+Utilizing advanced embeddings and LLMs, the system enables Natural Language querying for obtaining
+answers from the indexed data, complete with citations and links to the original sources.
+
+Kernel Memory is designed for seamless integration as a Plugin with [Semantic Kernel](https://github.com/microsoft/semantic-kernel),
+Microsoft Copilot and ChatGPT.
+

--- a/service/Core/DataFormats/Text/MarkDownDecoder.cs
+++ b/service/Core/DataFormats/Text/MarkDownDecoder.cs
@@ -28,10 +28,10 @@ public sealed class MarkDownDecoder : IContentDecoder
     }
 
     /// <inheritdoc />
-    public Task<FileContent> DecodeAsync(string filename, CancellationToken cancellationToken = default)
+    public async Task<FileContent> DecodeAsync(string filename, CancellationToken cancellationToken = default)
     {
         using var stream = File.OpenRead(filename);
-        return this.DecodeAsync(stream, cancellationToken);
+        return await this.DecodeAsync(stream, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />

--- a/service/Core/DataFormats/Text/TextDecoder.cs
+++ b/service/Core/DataFormats/Text/TextDecoder.cs
@@ -31,10 +31,10 @@ public sealed class TextDecoder : IContentDecoder
     }
 
     /// <inheritdoc />
-    public Task<FileContent> DecodeAsync(string filename, CancellationToken cancellationToken = default)
+    public async Task<FileContent> DecodeAsync(string filename, CancellationToken cancellationToken = default)
     {
         using var stream = File.OpenRead(filename);
-        return this.DecodeAsync(stream, cancellationToken);
+        return await this.DecodeAsync(stream, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Motivation and Context (Why the change? What's the scenario?)

Fix for bug #1084  
Need to await the async DecodeAsync method calls so that the stream object isn't disposed of before it is used.

## High level description (Approach, Design)
Just need to await.
